### PR TITLE
Kjq/dexcom calibration

### DIFF
--- a/lib/drivers/dexcomDriver.js
+++ b/lib/drivers/dexcomDriver.js
@@ -199,7 +199,7 @@ module.exports = function (config) {
 
     for (var i = 0; i < header.nrecs; ++i) {
       var rec = struct.unpack(data, ctr, format, [
-        'systemSeconds', 'displaySeconds', 'meterValue', 'meterTime', 'crc'
+        'systemSeconds', 'displaySeconds', 'meterValue', 'meterTimeSeconds', 'crc'
       ]);
 
       rec.systemTimeMsec = BASE_DATE_DEVICE + 1000 * rec.systemSeconds;
@@ -535,9 +535,26 @@ module.exports = function (config) {
     return readings;
   };
 
-  var prepCBGData = function (progress, data) {
+  var processMeterPages = function (pagedata) {
+    var readings = [];
+    for (var i = 0; i < pagedata.length; ++i) {
+      var page = pagedata[i].parsed_payload;
+      for (var j = 0; j < page.data.length; ++j) {
+        var reading = _.pick(page.data[j], 'displaySeconds', 'displayTime',
+                             'displayUtc', 'systemSeconds', 'meterValue');
+        reading.pagenum = page.header.pagenum;
+        readings.push(reading);
+      }
+    }
+    return readings;
+  };
 
-    dexcomDeviceId = data.firmwareHeader.attrs.ProductName + ' ' + data.manufacturing_data.attrs.SerialNumber;
+  var getDeviceId = function (data) {
+    return data.firmwareHeader.attrs.ProductName + ' ' + data.manufacturing_data.attrs.SerialNumber;
+  };
+
+  var prepCBGData = function (data) {
+    dexcomDeviceId = getDeviceId(data);
 
     cfg.builder.setDefaults({
                               deviceId: dexcomDeviceId,
@@ -559,6 +576,29 @@ module.exports = function (config) {
         .set('trend', datum.trendText)
         .done();
       dataToPost.push(cbg);
+    }
+
+    return dataToPost;
+  };
+
+  var prepMeterData = function (data) {
+    dexcomDeviceId = getDeviceId(data);
+
+    cfg.builder.setDefaults({
+                              deviceId: dexcomDeviceId,
+                              source: 'device',
+                              units: 'mg/dL'      // everything the Dexcom receiver stores is in this unit
+                            });
+    var dataToPost = [];
+    for (var i = 0; i < data.calibration_data.length; ++i) {
+      var datum = data.calibration_data[i];
+      var cal = cfg.builder.makeDeviceMetaCalibration()
+        .with_value(datum.meterValue)
+        .with_time(datum.displayUtc)
+        .with_deviceTime(datum.displayTime)
+        .with_timezoneOffset(sundial.getOffsetFromZone(datum.displayUtc, cfg.timezone))
+        .done();
+      dataToPost.push(cal);
     }
 
     return dataToPost;
@@ -642,6 +682,7 @@ module.exports = function (config) {
     },
 
     fetchData: function (progress, data, cb) {
+      // a little helper to split up our progress bar segment
       var makeProgress = function (progfunc, start, end) {
         return function(x) {
           progfunc(start + (x/100.0)*(end-start));
@@ -650,13 +691,14 @@ module.exports = function (config) {
 
       debug('STEP: fetchData');
       progress(0);
+      // first half of the progress bar segment
       downloadEGVPages(makeProgress(progress, 0, 50), function (err, result) {
         data.egv_data = result;
         if (err == null) {
+          // second half of the progress bar segment
           downloadMeterPages(makeProgress(progress, 50, 100), function (err, result) {
             data.meter_data = result;
             progress(100);
-            console.log(data);
             cb(err, data);
           });
         } else {
@@ -670,7 +712,9 @@ module.exports = function (config) {
       debug('STEP: processData');
       progress(0);
       data.cbg_data = processEGVPages(data.egv_data);
-      data.post_records = prepCBGData(progress, data);
+      data.calibration_data = processMeterPages(data.meter_data);
+      data.post_records = prepCBGData(data);
+      data.post_records = data.post_records.concat(prepMeterData(data));
       var ids = {};
       for (var i = 0; i < data.post_records.length; ++i) {
         var id = data.post_records[i].time + '|' + data.post_records[i].deviceId;

--- a/lib/drivers/dexcomDriver.js
+++ b/lib/drivers/dexcomDriver.js
@@ -142,9 +142,8 @@ module.exports = function (config) {
     };
   };
 
-
-  var readEGVDataPages = function (rectype, startPage, numPages) {
-    var parser = function (result) {
+  var makeHeaderParser = function(recordParser) {
+    var headerParser = function (result) {
       var format = 'iibbiiiibb';
       var header = struct.unpack(result.payload, 0, format, [
         'index', 'nrecs', 'rectype', 'revision',
@@ -152,11 +151,28 @@ module.exports = function (config) {
       ]);
       return {
         header: header,
-        data: parse_records(header, result.payload.subarray(struct.structlen(format)))
+        data: recordParser(header, result.payload.subarray(struct.structlen(format)))
       };
     };
 
-    var parse_records = function (header, data) {
+    return headerParser;
+  };
+
+
+  var readEGVDataPages = function (rectype, startPage, numPages) {
+    // var parser = function (result) {
+    //   var format = 'iibbiiiibb';
+    //   var header = struct.unpack(result.payload, 0, format, [
+    //     'index', 'nrecs', 'rectype', 'revision',
+    //     'pagenum', 'r1', 'r2', 'r3', 'j1', 'j2'
+    //   ]);
+    //   return {
+    //     header: header,
+    //     data: parse_records(header, result.payload.subarray(struct.structlen(format)))
+    //   };
+    // };
+
+    var parse_egv_records = function (header, data) {
       var all = [];
       var ctr = 0;
       var format = 'iisbs';
@@ -197,7 +213,7 @@ module.exports = function (config) {
       packet: buildPacket(
         CMDS.READ_DATA_PAGES.value, len, payload
       ),
-      parser: parser
+      parser: makeHeaderParser(parse_egv_records)
     };
   };
 

--- a/lib/drivers/dexcomDriver.js
+++ b/lib/drivers/dexcomDriver.js
@@ -159,61 +159,79 @@ module.exports = function (config) {
   };
 
 
-  var readEGVDataPages = function (rectype, startPage, numPages) {
-    // var parser = function (result) {
-    //   var format = 'iibbiiiibb';
-    //   var header = struct.unpack(result.payload, 0, format, [
-    //     'index', 'nrecs', 'rectype', 'revision',
-    //     'pagenum', 'r1', 'r2', 'r3', 'j1', 'j2'
-    //   ]);
-    //   return {
-    //     header: header,
-    //     data: parse_records(header, result.payload.subarray(struct.structlen(format)))
-    //   };
-    // };
+  var parse_egv_records = function (header, data) {
+    var all = [];
+    var ctr = 0;
+    var format = 'iisbs';
+    var flen = struct.structlen(format);
 
-    var parse_egv_records = function (header, data) {
-      var all = [];
-      var ctr = 0;
-      var format = 'iisbs';
-      var flen = struct.structlen(format);
+    for (var i = 0; i < header.nrecs; ++i) {
+      var rec = struct.unpack(data, ctr, format, [
+        'systemSeconds', 'displaySeconds', 'glucose', 'reserved', 'crc'
+      ]);
 
-      for (var i = 0; i < header.nrecs; ++i) {
-        var rec = struct.unpack(data, ctr, format, [
-          'systemSeconds', 'displaySeconds', 'glucose', 'reserved', 'crc'
-        ]);
+      rec.reserved &= 0xF;
+      rec.systemTimeMsec = BASE_DATE_DEVICE + 1000 * rec.systemSeconds;
+      rec.displayTimeMsec = BASE_DATE_DEVICE + 1000 * rec.displaySeconds;
+      rec.displayTime = sundial.formatDeviceTime(new Date(rec.displayTimeMsec).toISOString());
+      rec.displayUtc = sundial.applyTimezone(rec.displayTime, cfg.timezone);
+      rec.data = data.subarray(ctr, ctr + flen);
+      ctr += flen;
 
-        rec.reserved &= 0xF;
-        rec.systemTimeMsec = BASE_DATE_DEVICE + 1000 * rec.systemSeconds;
-        rec.displayTimeMsec = BASE_DATE_DEVICE + 1000 * rec.displaySeconds;
-        rec.displayTime = sundial.formatDeviceTime(new Date(rec.displayTimeMsec).toISOString());
-        rec.displayUtc = sundial.applyTimezone(rec.displayTime, cfg.timezone);
-        rec.data = data.subarray(ctr, ctr + flen);
-        ctr += flen;
-
-        // dexcom specs say to ignore values outside these ranges
-        // some glucose records have a value with the high bit set;
-        // these seem to have a time identical to the next record,
-        // so we presume that they are superceded by
-        // the other record (probably a calibration)
-        // we ignore these as instructed.
-        if (rec.glucose >= 40 && rec.glucose <= 400) {
-          all.push(rec);
-        }
+      // dexcom specs say to ignore values outside these ranges
+      // some glucose records have a value with the high bit set;
+      // these seem to have a time identical to the next record,
+      // so we presume that they are superceded by
+      // the other record (probably a calibration)
+      // we ignore these as instructed.
+      if (rec.glucose >= 40 && rec.glucose <= 400) {
+        all.push(rec);
       }
-      return all;
-    };
+    }
+    return all;
+  };
 
+  var parse_meter_records = function (header, data) {
+    var all = [];
+    var ctr = 0;
+    var format = 'iisis';
+    var flen = struct.structlen(format);
+
+    for (var i = 0; i < header.nrecs; ++i) {
+      var rec = struct.unpack(data, ctr, format, [
+        'systemSeconds', 'displaySeconds', 'meterValue', 'meterTime', 'crc'
+      ]);
+
+      rec.systemTimeMsec = BASE_DATE_DEVICE + 1000 * rec.systemSeconds;
+      rec.displayTimeMsec = BASE_DATE_DEVICE + 1000 * rec.displaySeconds;
+      // not sure what to do with the meterTime -- it's very much not definitive.
+      rec.meterTimeMsec = BASE_DATE_DEVICE + 1000 * rec.meterTimeSeconds;
+
+      rec.displayTime = sundial.formatDeviceTime(new Date(rec.displayTimeMsec).toISOString());
+      rec.displayUtc = sundial.applyTimezone(rec.displayTime, cfg.timezone);
+      rec.data = data.subarray(ctr, ctr + flen);
+      ctr += flen;
+      all.push(rec);
+    }
+    return all;
+  };
+
+  var readDataPages = function (rectype, startPage, numPages) {
     var format = 'bib';
     var len = struct.structlen(format);
     var payload = new Uint8Array(len);
     struct.pack(payload, 0, format, rectype.value, startPage, numPages);
 
+    var parser = null;
+    if (rectype == RECORD_TYPES.EGV_DATA) {
+      parser = makeHeaderParser(parse_egv_records);
+    } else if (rectype == RECORD_TYPES.METER_DATA) {
+      parser = makeHeaderParser(parse_meter_records);
+    }
+
     return {
-      packet: buildPacket(
-        CMDS.READ_DATA_PAGES.value, len, payload
-      ),
-      parser: makeHeaderParser(parse_egv_records)
+      packet: buildPacket(CMDS.READ_DATA_PAGES.value, len, payload),
+      parser: parser
     };
   };
 
@@ -419,9 +437,8 @@ module.exports = function (config) {
     });
   };
 
-  var fetchOneEGVPage = function (pagenum, callback) {
-    var cmd = readEGVDataPages(
-      RECORD_TYPES.EGV_DATA, pagenum, 1);
+  var fetchOneDataPage = function (recordType, pagenum, callback) {
+    var cmd = readDataPages(recordType, pagenum, 1);
     dexcomCommandResponse(cmd, function (err, page) {
       // debug(page.parsed_payload);
       callback(err, page);
@@ -430,8 +447,6 @@ module.exports = function (config) {
 
   var fetchManufacturingData = function (pagenum, callback) {
     var cmd = readDataPageRange(RECORD_TYPES.MANUFACTURING_DATA);
-    // var cmd = readEGVDataPages(
-    //     RECORD_TYPES.MANUFACTURING_DATA, pagenum, 1);
     dexcomCommandResponse(cmd, function (err, page) {
       if (err) {
         callback(err, page);
@@ -466,8 +481,8 @@ module.exports = function (config) {
     });
   };
 
-  var downloadEGVPages = function (progress, callback) {
-    var cmd = readDataPageRange(RECORD_TYPES.EGV_DATA);
+  var downloadDataPages = function (recordType, progress, callback) {
+    var cmd = readDataPageRange(recordType);
     dexcomCommandResponse(cmd, function (err, pagerange) {
       if (err) {
         return callback(err, pagerange);
@@ -483,7 +498,7 @@ module.exports = function (config) {
       var npages = 0;
       var fetch_and_progress = function (data, callback) {
         progress(npages++ * 100.0 / pages.length);
-        return fetchOneEGVPage(data, callback);
+        return fetchOneDataPage(recordType, data, callback);
       };
       async.mapSeries(pages, fetch_and_progress, function (err, results) {
         if (err) {
@@ -495,6 +510,14 @@ module.exports = function (config) {
       });
 
     });
+  };
+
+  var downloadEGVPages = function (progress, callback) {
+    downloadDataPages(RECORD_TYPES.EGV_DATA, progress, callback);
+  };
+
+  var downloadMeterPages = function (progress, callback) {
+    downloadDataPages(RECORD_TYPES.METER_DATA, progress, callback);
   };
 
   var processEGVPages = function (pagedata) {
@@ -619,12 +642,27 @@ module.exports = function (config) {
     },
 
     fetchData: function (progress, data, cb) {
+      var makeProgress = function (progfunc, start, end) {
+        return function(x) {
+          progfunc(start + (x/100.0)*(end-start));
+        };
+      };
+
       debug('STEP: fetchData');
       progress(0);
-      downloadEGVPages(progress, function (err, result) {
+      downloadEGVPages(makeProgress(progress, 0, 50), function (err, result) {
         data.egv_data = result;
-        progress(100);
-        cb(err, data);
+        if (err == null) {
+          downloadMeterPages(makeProgress(progress, 50, 100), function (err, result) {
+            data.meter_data = result;
+            progress(100);
+            console.log(data);
+            cb(err, data);
+          });
+        } else {
+          progress(100);
+          cb(err, data);
+        }
       });
     },
 

--- a/lib/objectBuilder.js
+++ b/lib/objectBuilder.js
@@ -207,6 +207,16 @@ module.exports = function () {
     return rec;
   }
 
+  function makeDeviceMetaCalibration() {
+    var rec = _.assign(_createObject(), deviceInfo, {
+      type: 'deviceMeta',
+      subType: 'calibration',
+      value: REQUIRED,
+    });
+    rec._bindProps();
+    return rec;
+  }
+
   function makeScheduledBasal() {
     var rec = _.assign(_createObject(), deviceInfo, {
       type: 'basal',
@@ -273,6 +283,7 @@ module.exports = function () {
     makeCBG: makeCBG,
     makeDeviceMetaResume: makeDeviceMetaResume,
     makeDeviceMetaSuspend: makeDeviceMetaSuspend,
+    makeDeviceMetaCalibration: makeDeviceMetaCalibration,
     makeDualBolus: makeDualBolus,
     makeFood: makeFood,
     makeNormalBolus: makeNormalBolus,


### PR DESCRIPTION
@jebeck -- this adds the calibration records to dexcom.

They're a lot like the glucose records in that they use the same API to fetch them, so I generalized some of the functions to be reusable, then added a deviceMeta calibration to objectBuilder.

The records as fetched by octopus look like this:

      {
        "id" : "r3u1gr719ur00ldsrdbl8gfohleg66kp",
        "_active" : true,
        "createdTime" : "2015-01-23T03:53:12.028Z",
        "uploadId" : "7udfIBEpSQ2QEFsZ4u14MF7a3yQ=",
        "_version" : 0,
        "subType" : "calibration",
        "time" : "2014-08-20T15:09:30.000Z",
        "deviceId" : "Dexcom G4 Receiver SM33821888",
        "source" : "device",
        "timezoneOffset" : -420,
        "type" : "deviceMeta",
        "units" : "mg/dL",
        "value" : 9.713808984329683,
        "_groupId" : "d7a69a917c",
        "deviceTime" : "2014-08-20T08:09:30"
      },

 My big question is that there is a *third* time value on calibration records. The documentation says this:

 `public UInt32 MeterTime;` // System time that meter value was taken (as indicated by user during manual entry).

I think they're saying that the user has entered a time manually -- and I'm not at all sure what to do with that time. It doesn't seem to be a useful value. So far, i'm just ignoring it but would value your opinion.

