### PR TITLE
add support for floats to struct.js for Tandem support

### DIFF
--- a/lib/struct.js
+++ b/lib/struct.js
@@ -139,7 +139,7 @@ module.exports = function() {
       dataview.setUint8(2, b[st+2]);
       dataview.setUint8(3, b[st+3]);
       return dataview.getFloat32(0, true);
-    }
+    };
     var extractBEFloat = function(b, st){
       var buffer = new ArrayBuffer(4);
       var dataview = new DataView(buffer);
@@ -148,7 +148,7 @@ module.exports = function() {
       dataview.setUint8(2, b[st+2]);
       dataview.setUint8(3, b[st+3]);
       return dataview.getFloat32(0, false);
-    }
+    };
     var storeFloat = function(v, b, st) {
       var buffer = new ArrayBuffer(4);
       var dataview = new DataView(buffer);
@@ -157,7 +157,7 @@ module.exports = function() {
       b[st+1] = dataview.getUint8(1);
       b[st+2] = dataview.getUint8(2);
       b[st+3] = dataview.getUint8(3);
-    }
+    };
     var storeBEFloat = function(v, b, st) {
       var buffer = new ArrayBuffer(4);
       var dataview = new DataView(buffer);

--- a/lib/struct.js
+++ b/lib/struct.js
@@ -22,6 +22,8 @@
 // H -- a 2-byte signed integer in big-endian format
 // z -- a zero-terminated string of maximum length controlled by the size parameter.
 // Z -- a string of bytes with the length controlled by the size parameter.
+// f -- a 4-byte float in little-endian format
+// F -- a 4-byte float in big-endian format
 // . -- the appropriate number of bytes is ignored (used for padding)
 // Any other character is treated like '.' -- but don't depend on this, because we may
 // someday decide to use other characters.
@@ -129,6 +131,42 @@ module.exports = function() {
         }
         return s;
     };
+    var extractFloat = function(b, st){
+      var buffer = new ArrayBuffer(4);
+      var dataview = new DataView(buffer);
+      dataview.setUint8(0, b[st]);
+      dataview.setUint8(1, b[st+1]);
+      dataview.setUint8(2, b[st+2]);
+      dataview.setUint8(3, b[st+3]);
+      return dataview.getFloat32(0, true);
+    }
+    var extractBEFloat = function(b, st){
+      var buffer = new ArrayBuffer(4);
+      var dataview = new DataView(buffer);
+      dataview.setUint8(0, b[st]);
+      dataview.setUint8(1, b[st+1]);
+      dataview.setUint8(2, b[st+2]);
+      dataview.setUint8(3, b[st+3]);
+      return dataview.getFloat32(0, false);
+    }
+    var storeFloat = function(v, b, st) {
+      var buffer = new ArrayBuffer(4);
+      var dataview = new DataView(buffer);
+      dataview.setFloat32(0, v, true);
+      b[st] = dataview.getUint8(0);
+      b[st+1] = dataview.getUint8(1);
+      b[st+2] = dataview.getUint8(2);
+      b[st+3] = dataview.getUint8(3);
+    }
+    var storeBEFloat = function(v, b, st) {
+      var buffer = new ArrayBuffer(4);
+      var dataview = new DataView(buffer);
+      dataview.setFloat32(0,v, false);
+      b[st] = dataview.getUint8(0);
+      b[st+1] = dataview.getUint8(1);
+      b[st+2] = dataview.getUint8(2);
+      b[st+3] = dataview.getUint8(3);
+    };
     var extractNothing = function() {
         return 0;
     };
@@ -172,6 +210,8 @@ module.exports = function() {
         's': { len: 2, put: storeShort, get: extractShort },
         'h': { len: 2, put: storeShort, get: extractSignedShort },
         'b': { len: 1, put: storeByte, get: extractByte },
+        'f': { len: 4, put: storeFloat, get: extractFloat },
+        'F': { len: 4, put: storeBEFloat, get: extractBEFloat },
         'I': { len: 4, put: storeBEInt, get: extractBEInt },
         'N': { len: 4, put: storeBEInt, get: extractSignedBEInt },
         'S': { len: 2, put: storeBEShort, get: extractBEShort },
@@ -337,11 +377,15 @@ module.exports = function() {
         extractZString: extractZString,
         extractInt: extractInt,
         extractShort: extractShort,
+        extractFloat: extractFloat,
         extractByte: extractByte,
         extractBEInt: extractBEInt,
         extractBEShort: extractBEShort,
+        extractBEFloat: extractBEFloat,
         storeInt: storeInt,
         storeBEInt: storeBEInt,
+        storeFloat: storeFloat,
+        storeBEFloat: storeBEFloat,
         storeShort: storeShort,
         storeBEShort: storeBEShort,
         storeByte: storeByte,

--- a/test/testStruct.js
+++ b/test/testStruct.js
@@ -50,6 +50,16 @@ describe('struct.js', function(){
       expect(theStruct).itself.to.respondTo('extractShort');
     });
   });
+  describe('extractFloat', function(){
+    it('exists', function(){
+      expect(theStruct).itself.to.respondTo('extractFloat');
+    });
+  });
+  describe('extractBEFloat', function(){
+    it('exists', function(){
+      expect(theStruct).itself.to.respondTo('extractBEFloat');
+    });
+  });
   describe('extractByte', function(){
     it('exists', function(){
       expect(theStruct).itself.to.respondTo('extractByte');
@@ -68,6 +78,16 @@ describe('struct.js', function(){
   describe('storeBEShort', function(){
     it('exists', function(){
       expect(theStruct).itself.to.respondTo('storeBEShort');
+    });
+  });
+  describe('storeFloat', function(){
+    it('exists', function(){
+      expect(theStruct).itself.to.respondTo('storeFloat');
+    });
+  });
+  describe('storeBEFloat', function(){
+    it('exists', function(){
+      expect(theStruct).itself.to.respondTo('storeBEFloat');
     });
   });
   describe('storeByte', function(){
@@ -117,14 +137,16 @@ describe('struct.js', function(){
 // H -- a 2-byte signed integer in big-endian format
 // z -- a zero-terminated string of maximum length controlled by the size parameter.
 // Z -- a string of bytes with the length controlled by the size parameter.
+// f -- a 4-byte float in little-endian format
+// F -- a 4-byte float in big-endian format
 // . -- the appropriate number of bytes is ignored (used for padding)
   describe('structlen and format parsing', function(){
     it('work properly', function(){
       expect(theStruct.structlen('b6.Si')).to.equal(13);
-      expect(theStruct.structlen('bsSiInNhH.')).to.equal(26);
+      expect(theStruct.structlen('bsSiInNhHfF.')).to.equal(34);
       expect(theStruct.structlen('4b2s1I48.')).to.equal(60);
       expect(theStruct.structlen('4b 2s 1I 48.')).to.equal(60);
-      expect(theStruct.structlen('4bF')).to.equal(5); // F isn't currently used
+      expect(theStruct.structlen('4bK')).to.equal(5); // K isn't currently used
       expect(theStruct.structlen('8z')).to.equal(8);
       expect(theStruct.structlen('4Z')).to.equal(4);
       expect(theStruct.structlen('Z')).to.equal(1);
@@ -200,6 +222,20 @@ describe('struct.js', function(){
       expect(len).to.equal(4);
       var s = String.fromCharCode.apply(null, buf);
       expect(s).to.equal('\u00FE\u00FF\u00FF\u00FF');
+    });
+    it('works for f', function(){
+      var buf = new Uint8Array(4);
+      var len = theStruct.pack(buf, 0, 'f', -1.5);
+      expect(len).to.equal(4);
+      var s = String.fromCharCode.apply(null, buf);
+      expect(s).to.equal('\u0000\u0000\u00C0\u00BF');
+    });
+    it('works for F', function(){
+      var buf = new Uint8Array(4);
+      var len = theStruct.pack(buf, 0, 'F', -2.5);
+      expect(len).to.equal(4);
+      var s = String.fromCharCode.apply(null, buf);
+      expect(s).to.equal('\u00C0\u0020\u0000\u0000');
     });
   });
   describe('unpack', function(){
@@ -363,6 +399,34 @@ describe('struct.js', function(){
       buf[7] = 0x02;
       var result = theStruct.unpack(buf, 0, '8Z', ['s']);
       expect(result.s).to.equal('Hello\u0000\u0001\u0002');
+    });
+    it('works for f', function() {
+      var buf = new Uint8Array(8);
+      buf[0] = 0x00;
+      buf[1] = 0x00;
+      buf[2] = 0xD0;
+      buf[3] = 0x3F;
+      buf[4] = 0x00;
+      buf[5] = 0x00;
+      buf[6] = 0xA0;
+      buf[7] = 0x3F;
+      var result = theStruct.unpack(buf, 0, 'ff', ['a', 'b']);
+      expect(result.a).to.equal(1.625);
+      expect(result.b).to.equal(1.25);
+    });
+    it('works for F', function() {
+      var buf = new Uint8Array(8);
+      buf[0] = 0x3F;
+      buf[1] = 0xD0;
+      buf[2] = 0x00;
+      buf[3] = 0x00;
+      buf[4] = 0x3F;
+      buf[5] = 0xA0;
+      buf[6] = 0x00;
+      buf[7] = 0x00;
+      var result = theStruct.unpack(buf, 0, 'FF', ['a', 'b']);
+      expect(result.a).to.equal(1.625);
+      expect(result.b).to.equal(1.25);
     });
   });
   describe('general test of pack/unpack', function(){


### PR DESCRIPTION
This adds support for parsing single-precision floating-point numbers to struct.js