### PR TITLE
require units on cbg, smbg, wizard events

### DIFF
--- a/lib/drivers/abbottFreeStyle.js
+++ b/lib/drivers/abbottFreeStyle.js
@@ -397,8 +397,7 @@ module.exports = function (config) {
   var prepBGData = function (progress, data) {
     cfg.builder.setDefaults({
                               deviceId: data.id,
-                              source: 'device',
-                              units: 'mg/dL'      // everything the Precision XL meter stores is in this unit
+                              source: 'device'
                             });
     var dataToPost = [];
     for (var i = 0; i < data.logEntries.length; ++i) {
@@ -409,6 +408,7 @@ module.exports = function (config) {
           .with_deviceTime(datum.datetime.dev)
           .with_timezoneOffset(datum.datetime.offset)
           .with_time(datum.datetime.utc)
+          .with_units('mg/dL')
           .done();
         dataToPost.push(smbg);
       } else if (datum.readingType === 'ketone') {

--- a/lib/drivers/dexcomDriver.js
+++ b/lib/drivers/dexcomDriver.js
@@ -558,8 +558,7 @@ module.exports = function (config) {
 
     cfg.builder.setDefaults({
                               deviceId: dexcomDeviceId,
-                              source: 'device',
-                              units: 'mg/dL'      // everything the Dexcom receiver stores is in this unit
+                              source: 'device'
                             });
     var dataToPost = [];
     for (var i = 0; i < data.cbg_data.length; ++i) {
@@ -573,6 +572,7 @@ module.exports = function (config) {
         .with_time(datum.displayUtc)
         .with_deviceTime(datum.displayTime)
         .with_timezoneOffset(sundial.getOffsetFromZone(datum.displayUtc, cfg.timezone))
+        .with_units('mg/dL')      // everything the Dexcom receiver stores is in this unit
         .set('trend', datum.trendText)
         .done();
       dataToPost.push(cbg);
@@ -586,8 +586,7 @@ module.exports = function (config) {
 
     cfg.builder.setDefaults({
                               deviceId: dexcomDeviceId,
-                              source: 'device',
-                              units: 'mg/dL'      // everything the Dexcom receiver stores is in this unit
+                              source: 'device'
                             });
     var dataToPost = [];
     for (var i = 0; i < data.calibration_data.length; ++i) {
@@ -597,6 +596,7 @@ module.exports = function (config) {
         .with_time(datum.displayUtc)
         .with_deviceTime(datum.displayTime)
         .with_timezoneOffset(sundial.getOffsetFromZone(datum.displayUtc, cfg.timezone))
+        .with_units('mg/dL')      // everything the Dexcom receiver stores is in this unit
         .done();
       dataToPost.push(cal);
     }

--- a/lib/objectBuilder.js
+++ b/lib/objectBuilder.js
@@ -100,15 +100,6 @@ module.exports = function () {
     };
   }
 
-  function _makeWithValue(typename) {
-    var rec = _.assign(_createObject(), deviceInfo, {
-      type: typename,
-      value: REQUIRED
-    });
-    rec._bindProps();
-    return rec;
-  }
-
   function makeSMBG() {
     var rec = _.assign(_createObject(), deviceInfo, {
       type: 'smbg',
@@ -130,7 +121,12 @@ module.exports = function () {
   }
 
   function makeNote() {
-    return _makeWithValue('note');
+    var rec = _.assign(_createObject(), deviceInfo, {
+      type: 'note',
+      value: REQUIRED
+    });
+    rec._bindProps();
+    return rec;
   }
 
   function makeFood() {

--- a/lib/objectBuilder.js
+++ b/lib/objectBuilder.js
@@ -110,11 +110,23 @@ module.exports = function () {
   }
 
   function makeSMBG() {
-    return _makeWithValue('smbg');
+    var rec = _.assign(_createObject(), deviceInfo, {
+      type: 'smbg',
+      value: REQUIRED,
+      units: REQUIRED
+    });
+    rec._bindProps();
+    return rec;
   }
 
   function makeCBG() {
-    return _makeWithValue('cbg');
+    var rec = _.assign(_createObject(), deviceInfo, {
+      type: 'cbg',
+      value: REQUIRED,
+      units: REQUIRED
+    });
+    rec._bindProps();
+    return rec;
   }
 
   function makeNote() {
@@ -133,10 +145,7 @@ module.exports = function () {
   function makeWizard() {
     var rec = _.assign(_createObject(), deviceInfo, {
       type: 'wizard',
-      recommended: {
-        carb: 0,
-        correction: 0
-      },
+      recommended: OPTIONAL,
       bgInput: OPTIONAL,
       carbInput: OPTIONAL,
       insulinOnBoard: OPTIONAL,
@@ -144,7 +153,8 @@ module.exports = function () {
       insulinSensitivity: OPTIONAL,
       bgTarget: OPTIONAL,
       bolus: OPTIONAL,
-      payload: OPTIONAL
+      payload: OPTIONAL,
+      units: REQUIRED
     });
     rec._bindProps();
     return rec;

--- a/lib/objectBuilder.js
+++ b/lib/objectBuilder.js
@@ -55,7 +55,7 @@ module.exports = function () {
     timezoneOffset: REQUIRED
   };
   function setDefaults(info) {
-    deviceInfo = _.assign({}, deviceInfo, _.pick(info, 'deviceId', 'source', 'timezoneOffset', 'units'));
+    deviceInfo = _.assign({}, deviceInfo, _.pick(info, 'deviceId', 'source', 'timezoneOffset'));
   }
 
   function _createObject() {

--- a/test/carelink/testCarelinkSimulator.js
+++ b/test/carelink/testCarelinkSimulator.js
@@ -52,8 +52,9 @@ describe('carelinkSimulator.js', function(){
       var val = {
         time: '2014-09-25T01:00:00.000Z',
         deviceTime: '2014-09-25T01:00:00',
-        value: 123,
-        timezoneOffset: 0
+        value: 6.8274200289860065,
+        timezoneOffset: 0,
+        units: 'mg/dL'
       };
 
       simulator.cbg(val);
@@ -66,8 +67,9 @@ describe('carelinkSimulator.js', function(){
       var val = {
         time: '2014-09-25T01:00:00.000Z',
         deviceTime: '2014-09-25T01:00:00',
-        value: 1.3,
-        timezoneOffset: 0
+        value: 6.8274200289860065,
+        timezoneOffset: 0,
+        units: 'mg/dL'
       };
 
       simulator.smbg(val);

--- a/test/testObjectBuilder.js
+++ b/test/testObjectBuilder.js
@@ -306,7 +306,7 @@ describe('objectBuilder.js', function(){
       expect(wiz.carbInput).to.equal(OPTIONAL);
       expect(wiz.bolus).to.equal(OPTIONAL);
       expect(wiz.payload).to.equal(OPTIONAL);
-      expect(wiz.recommended).to.deep.equals({'carb':0,'correction':0});
+      expect(wiz.recommended).to.equal(OPTIONAL);
 
     });
   });


### PR DESCRIPTION
Here's the small builder change @kentquirk 

I made another small change because I happened to notice it - it was very bad that we were producing default `recommended` objects with values of 0 (because a 0 suggestion is a suggestion)! This change required a jellyfish change though: https://github.com/tidepool-org/jellyfish/pull/46