### PR TITLE
update CareLink deviceMeta status reasons to accord with revised data model

### DIFF
--- a/lib/carelink/carelinkSimulator.js
+++ b/lib/carelink/carelinkSimulator.js
@@ -312,7 +312,7 @@ exports.make = function(config){
        * during an LGS. We are already handling these in our basal clock, so we just
        * push the clock forward and exit early when we come across one.
        */
-      if (currStatus != null && currStatus.status === 'suspended' && currStatus.reason === 'low_glucose') {
+      if (currStatus != null && currStatus.status === 'suspended' && (currStatus.payload && currStatus.payload.cause === 'low_glucose')) {
         ensureTimestamp(event);
         pushBasalClockForward(event.time);
         return;
@@ -552,7 +552,8 @@ exports.make = function(config){
         .with_time(event.time)
         .with_timezoneOffset(event.timezoneOffset)
         .with_deviceTime(event.deviceTime)
-        .with_reason(event.reason);
+        .with_reason(event.reason)
+        .with_payload(event.payload);
 
       if (event.deviceId != null) {
         deviceMetaResumeBuilder.set('deviceId', event.deviceId);
@@ -636,7 +637,8 @@ exports.make = function(config){
         .with_time(event.time)
         .with_timezoneOffset(event.timezoneOffset)
         .with_deviceTime(event.deviceTime)
-        .with_reason('manual');
+        .with_reason(event.reason)
+        .with_payload(event.payload);
 
       if (event.deviceId != null) {
         deviceMetaResumeBuilder.set('deviceId', event.deviceId);
@@ -739,6 +741,10 @@ exports.make = function(config){
         .with_timezoneOffset(event.timezoneOffset)
         .with_deviceTime(event.deviceTime)
         .with_reason(event.reason);
+
+      if (event.payload != null) {
+        deviceMetaResumeBuilder.with_payload(event.payload);
+      }
 
       if (event.deviceId != null) {
         deviceMetaResumeBuilder.set('deviceId', event.deviceId);
@@ -861,7 +867,7 @@ exports.make = function(config){
       var event = ensureTimestamp(combineArguments(arguments));
       // threshold suspends involve several (usually 3-4) suspend events in succession
       // we only care about the first, so if the currStatus is already `suspended`, we return early
-      if (currStatus != null && currStatus.status === 'suspended' && event.reason === 'low_glucose') {
+      if (currStatus != null && currStatus.status === 'suspended' && (event.payload && event.payload.cause === 'low_glucose')) {
         return;
       }
       /** This `if` block is designed for a very specific case:
@@ -886,6 +892,10 @@ exports.make = function(config){
         .with_timezoneOffset(event.timezoneOffset)
         .with_deviceTime(event.deviceTime)
         .with_reason(event.reason);
+
+      if (event.payload != null) {
+        deviceMetaSuspendBuilder.with_payload(event.payload);
+      }
 
       if (event.deviceId != null) {
         deviceMetaSuspendBuilder.set('deviceId', event.deviceId);

--- a/lib/carelink/suspend.js
+++ b/lib/carelink/suspend.js
@@ -33,23 +33,68 @@ module.exports = function (timezone) {
               case 'null':
                 return null;
               case 'user_suspend':
-                return { status: 'suspended', reason: 'manual' };
+                return {
+                  status: 'suspended',
+                  reason: {
+                    suspended: 'manual'
+                  }
+                };
               case 'low_suspend_mode_1':
               case 'alarm_suspend':
               case 'low_suspend_no_response':
               case 'low_suspend_user_selected':
-                return { status: 'suspended', reason: 'low_glucose' };
-
+                return {
+                  status: 'suspended',
+                  reason: {
+                    suspended: 'automatic'
+                  },
+                  payload: {
+                    cause: 'low_glucose',
+                    code: reason
+                    // TODO: would be wonderful one day to include LGS threshold in payload
+                    // but looking that up from settings may have to be in simulator
+                  }
+                };
               // resume events
               case 'normal_pumping':
-                return { status: 'resumed', reason: 'manual' };
+                return {
+                  status: 'resumed',
+                  reason: {
+                    resumed: 'manual'
+                  }
+                };
               case 'user_restart_basal':
-                return { status: 'resumed', reason: 'user_restart_basal' };
+                return {
+                  status: 'resumed',
+                  reason: {
+                    resumed: 'manual'
+                  },
+                  payload: {
+                    cause: 'user_restart_basal'
+                  }
+                };
               case 'auto_resume_complete':
-                return { status: 'resumed', reason: 'user_automatic'};
+                return {
+                  status: 'resumed',
+                  reason: {
+                    resumed: 'automatic'
+                  },
+                  payload: {
+                    cause: 'auto_resume_complete',
+                    user_intervention: 'acknowledged'
+                  }
+                };
               case 'auto_resume_reduced':
-                return { status: 'resumed', reason: 'automatic' };
-
+                return {
+                  status: 'resumed',
+                  reason: {
+                    resumed: 'automatic'
+                  },
+                  payload: {
+                    cause: 'auto_resume_reduced',
+                    user_intervention: 'ignored'
+                  }
+                };
               default:
                 throw new Error(util.format('Unknown status[%s]', reason));
             }
@@ -65,13 +110,13 @@ module.exports = function (timezone) {
     // that isn't relevant to this processor
     // hence the lack of an `else` condition
     if (parsed != null && parsed.payload != null) {
-      var event = _.assign(_.omit(parsed, 'payload'), {reason: parsed.payload.reason});
+      var event = _.assign(_.omit(parsed, 'payload'), _.omit(parsed.payload, 'status'));
       switch (parsed.payload.status) {
         case 'suspended':
-          if (parsed.payload.reason === 'manual') {
+          if (event.payload && event.payload.cause === 'low_glucose') {
             simulator.suspend(event);
           }
-          else if (parsed.payload.reason === 'low_glucose') {
+          else if (event.reason.suspended === 'manual') {
             simulator.suspend(event);
           }
           else {
@@ -79,18 +124,17 @@ module.exports = function (timezone) {
           }
           break;
         case 'resumed':
-          if (parsed.payload.reason === 'manual') {
+          if (event.payload && event.payload.cause === 'auto_resume_complete') {
             simulator.resume(event);
           }
-          else if (parsed.payload.reason === 'user_automatic') {
-            event.reason = 'automatic';
-            simulator.resume(event);
+          else if (event.payload && event.payload.cause === 'auto_resume_reduced') {
+            simulator.lgsAutoResume(event);
           }
-          else if (parsed.payload.reason === 'user_restart_basal') {
+          else if (event.payload && event.payload.cause === 'user_restart_basal') {
             simulator.lgsResume(event);
           }
-          else if (parsed.payload.reason === 'automatic') {
-            simulator.lgsAutoResume(event);
+          else if (event.reason.resumed === 'manual') {
+            simulator.resume(event);
           }
           else {
             throw new Error(util.format('Unknown resume reason[%s]', parsed.payload.reason));

--- a/lib/objectBuilder.js
+++ b/lib/objectBuilder.js
@@ -208,7 +208,8 @@ module.exports = function () {
       subType: 'status',
       status: 'suspended',
       reason: REQUIRED,
-      previous: OPTIONAL
+      previous: OPTIONAL,
+      payload: OPTIONAL
     });
     rec._bindProps();
     return rec;
@@ -220,7 +221,8 @@ module.exports = function () {
       subType: 'status',
       status: 'resumed',
       reason: REQUIRED,
-      previous: OPTIONAL
+      previous: OPTIONAL,
+      payload: OPTIONAL
     });
     rec._bindProps();
     return rec;

--- a/test/carelink/bolus/dual/withWizardInterruptedWithOverride/output.json
+++ b/test/carelink/bolus/dual/withWizardInterruptedWithOverride/output.json
@@ -57,7 +57,9 @@
         "time": "2014-11-15T21:31:40.000Z",
         "timezoneOffset": -600,
         "deviceId": "Paradigm Revel - 723-=-53602018",
-        "reason": "manual"
+        "reason": {
+            "suspended": "manual"
+        }
     },
     {
         "type": "basal-scheduled",
@@ -78,7 +80,9 @@
         "time": "2014-11-15T21:41:37.000Z",
         "timezoneOffset": -600,
         "deviceId": "Paradigm Revel - 723-=-53602018",
-        "reason": "manual"
+        "reason": {
+            "resumed": "manual"
+        }
     },
     {
         "type": "basal-scheduled",

--- a/test/carelink/bolus/square/noWizardInterrupted/output.json
+++ b/test/carelink/bolus/square/noWizardInterrupted/output.json
@@ -31,7 +31,9 @@
         "time": "2014-11-17T02:17:50.000Z",
         "timezoneOffset": -600,
         "deviceId": "Paradigm Revel - 723-=-53602018",
-        "reason": "manual"
+        "reason": {
+            "suspended": "manual"
+        }
     },
     {
         "type": "resume",
@@ -40,6 +42,8 @@
         "time": "2014-11-17T02:28:43.000Z",
         "timezoneOffset": -600,
         "deviceId": "Paradigm Revel - 723-=-53602018",
-        "reason": "manual"
+        "reason": {
+            "resumed": "manual"
+        }
     }
 ]

--- a/test/carelink/suspend/output.json
+++ b/test/carelink/suspend/output.json
@@ -1,65 +1,79 @@
 [
-  {
-    "time": "2014-03-14T15:48:38.000Z",
-    "deviceTime": "2014-03-14T05:48:38",
-    "timezoneOffset": -600,
-    "source": "carelink",
-    "type": "suspend",
-    "reason": "manual",
-    "deviceId": "Paradigm Revel - 723-=-52825853"
-  },
-  {
-    "time": "2014-03-14T20:08:19.000Z",
-    "deviceTime": "2014-03-14T10:08:19",
-    "timezoneOffset": -600,
-    "source": "carelink",
-    "type": "suspend",
-    "reason": "manual",
-    "deviceId": "Paradigm Revel - 723-=-52850875"
-  },
-  {
-    "time": "2014-03-14T20:11:06.000Z",
-    "deviceTime": "2014-03-14T10:11:06",
-    "timezoneOffset": -600,
-    "source": "carelink",
-    "type": "resume",
-    "reason": "manual",
-    "deviceId": "Paradigm Revel - 723-=-52861049"
-  },
-  {
-    "time": "2014-03-15T01:40:47.000Z",
-    "deviceTime": "2014-03-14T15:40:47",
-    "timezoneOffset": -600,
-    "source": "carelink",
-    "type": "suspend",
-    "reason": "manual",
-    "deviceId": "Paradigm Revel - 723-=-53118738"
-  },
-  {
-    "time": "2014-03-15T01:42:38.000Z",
-    "deviceTime": "2014-03-14T15:42:38",
-    "timezoneOffset": -600,
-    "source": "carelink",
-    "type": "suspend",
-    "reason": "manual",
-    "deviceId": "Paradigm Revel - 723-=-53021863"
-  },
-  {
-    "time": "2014-03-15T01:42:52.000Z",
-    "deviceTime": "2014-03-14T15:42:52",
-    "timezoneOffset": -600,
-    "source": "carelink",
-    "type": "resume",
-    "reason": "manual",
-    "deviceId": "Paradigm Revel - 723-=-53021863"
-  },
-  {
-    "time": "2014-03-15T01:51:39.000Z",
-    "deviceTime": "2014-03-14T15:51:39",
-    "timezoneOffset": -600,
-    "source": "carelink",
-    "type": "resume",
-    "reason": "manual",
-    "deviceId": "Paradigm Revel - 723-=-53136995"
-  }
+    {
+        "time": "2014-03-14T15:48:38.000Z",
+        "deviceTime": "2014-03-14T05:48:38",
+        "timezoneOffset": -600,
+        "source": "carelink",
+        "type": "suspend",
+        "reason": {
+            "suspended": "manual"
+        },
+        "deviceId": "Paradigm Revel - 723-=-52825853"
+    },
+    {
+        "time": "2014-03-14T20:08:19.000Z",
+        "deviceTime": "2014-03-14T10:08:19",
+        "timezoneOffset": -600,
+        "source": "carelink",
+        "type": "suspend",
+        "reason": {
+            "suspended": "manual"
+        },
+        "deviceId": "Paradigm Revel - 723-=-52850875"
+    },
+    {
+        "time": "2014-03-14T20:11:06.000Z",
+        "deviceTime": "2014-03-14T10:11:06",
+        "timezoneOffset": -600,
+        "source": "carelink",
+        "type": "resume",
+        "reason": {
+            "resumed": "manual"
+        },
+        "deviceId": "Paradigm Revel - 723-=-52861049"
+    },
+    {
+        "time": "2014-03-15T01:40:47.000Z",
+        "deviceTime": "2014-03-14T15:40:47",
+        "timezoneOffset": -600,
+        "source": "carelink",
+        "type": "suspend",
+        "reason": {
+            "suspended": "manual"
+        },
+        "deviceId": "Paradigm Revel - 723-=-53118738"
+    },
+    {
+        "time": "2014-03-15T01:42:38.000Z",
+        "deviceTime": "2014-03-14T15:42:38",
+        "timezoneOffset": -600,
+        "source": "carelink",
+        "type": "suspend",
+        "reason": {
+            "suspended": "manual"
+        },
+        "deviceId": "Paradigm Revel - 723-=-53021863"
+    },
+    {
+        "time": "2014-03-15T01:42:52.000Z",
+        "deviceTime": "2014-03-14T15:42:52",
+        "timezoneOffset": -600,
+        "source": "carelink",
+        "type": "resume",
+        "reason": {
+            "resumed": "manual"
+        },
+        "deviceId": "Paradigm Revel - 723-=-53021863"
+    },
+    {
+        "time": "2014-03-15T01:51:39.000Z",
+        "deviceTime": "2014-03-14T15:51:39",
+        "timezoneOffset": -600,
+        "source": "carelink",
+        "type": "resume",
+        "reason": {
+            "resumed": "manual"
+        },
+        "deviceId": "Paradigm Revel - 723-=-53136995"
+    }
 ]

--- a/test/carelink/testCarelinkSimulator.js
+++ b/test/carelink/testCarelinkSimulator.js
@@ -765,8 +765,8 @@ describe('carelinkSimulator.js', function(){
   });
 
   describe('deviceMeta', function() {
-    var suspend = { time: '2014-09-25T00:40:00.000Z', deviceTime: '2014-09-25T00:40:00', reason: 'manual', timezoneOffset: 0 };
-    var resume = { time: '2014-09-25T01:10:00.000Z', deviceTime: '2014-09-25T01:10:00', reason: 'manual', timezoneOffset: 0 };
+    var suspend = { time: '2014-09-25T00:40:00.000Z', deviceTime: '2014-09-25T00:40:00', reason: {'suspended': 'manual'}, timezoneOffset: 0 };
+    var resume = { time: '2014-09-25T01:10:00.000Z', deviceTime: '2014-09-25T01:10:00', reason: {'suspended': 'manual'}, timezoneOffset: 0 };
 
     it('sets up the previous', function(){
       simulator.suspend(suspend);
@@ -891,7 +891,7 @@ describe('carelinkSimulator.js', function(){
            simulator.basalScheduled(basal);
            simulator.basalTemp(_.assign({}, temp, { duration: 900000 })); // 15 minutes
 
-           simulator.suspend({ time: '2014-09-25T00:40:00.000Z', deviceTime: '2014-09-25T00:40:00', reason: 'manual', timezoneOffset: 0 });
+           simulator.suspend({ time: '2014-09-25T00:40:00.000Z', deviceTime: '2014-09-25T00:40:00', reason: {'suspended': 'manual'}, timezoneOffset: 0 });
            expect(getBasals()).deep.equals(
              attachPrev(
                [
@@ -920,7 +920,7 @@ describe('carelinkSimulator.js', function(){
                ])
            );
 
-           simulator.resume({ time: '2014-09-25T01:10:00.000Z', deviceTime: '2014-09-25T01:10:00', reason: 'manual', timezoneOffset: 0 });
+           simulator.resume({ time: '2014-09-25T01:10:00.000Z', deviceTime: '2014-09-25T01:10:00', reason: {'suspended': 'manual'}, timezoneOffset: 0 });
 
            expect(getBasals()).deep.equals(
              attachPrev(
@@ -1102,13 +1102,13 @@ describe('carelinkSimulator.js', function(){
         timezoneOffset: 0
       };
       var suspend = {
-        reason: 'manual',
+        reason: {'suspended': 'manual'},
         timezoneOffset: 0,
         time: '2014-09-25T00:05:00.000Z',
         deviceTime: '2014-09-25T00:05:00'
       };
       var resume = {
-        reason: 'manual',
+        reason: {'suspended': 'manual'},
         timezoneOffset: 0,
         time: '2014-09-25T00:12:00.000Z',
         deviceTime: '2014-09-25T00:12:00'
@@ -1212,13 +1212,13 @@ describe('carelinkSimulator.js', function(){
         duration: 1800000
       };
       var suspend = {
-        reason: 'manual',
+        reason: {'suspended': 'manual'},
         timezoneOffset: 0,
         time: '2014-09-25T00:05:00.000Z',
         deviceTime: '2014-09-25T00:05:00'
       };
       var resume = {
-        reason: 'manual',
+        reason: {'resumed': 'manual'},
         timezoneOffset: 0,
         time: '2014-09-25T00:12:00.000Z',
         deviceTime: '2014-09-25T00:12:00'
@@ -1476,7 +1476,7 @@ describe('carelinkSimulator.js', function(){
         scheduleName: 'standard'
       };
       var suspend = {
-        reason: 'manual',
+        reason: {'suspended': 'manual'},
         timezoneOffset: -600,
         time: '2014-03-16T02:23:19.000Z',
         deviceTime: '2014-03-15T16:23:19'
@@ -1489,7 +1489,7 @@ describe('carelinkSimulator.js', function(){
         scheduleName: 'standard'
       };
       var resume = {
-        reason: 'manual',
+        reason: {'resumed': 'manual'},
         timezoneOffset: -600,
         time: '2014-03-16T03:18:35.000Z',
         deviceTime: '2014-03-15T17:18:35'
@@ -1634,7 +1634,7 @@ describe('carelinkSimulator.js', function(){
            simulator.basalTemp(_.assign({}, temp, { duration: 900000 })); // 15 minutes
 
            simulator.suspend({ time: '2014-09-25T04:40:00.000Z', deviceTime: '2014-09-25T00:40:00',
-              reason: 'manual', timezoneOffset: -240 });
+              reason: {'suspended': 'manual'}, timezoneOffset: -240 });
            expect(getBasals()).deep.equals(
              attachPrev(
                [
@@ -1668,7 +1668,7 @@ describe('carelinkSimulator.js', function(){
            );
 
            simulator.resume({ time: '2014-09-25T05:10:00.000Z', deviceTime: '2014-09-25T01:10:00',
-            reason: 'manual', timezoneOffset: -240 });
+            reason: {'resumed': 'manual'}, timezoneOffset: -240 });
 
            expect(getBasals()).deep.equals(
              attachPrev(
@@ -1867,28 +1867,32 @@ describe('carelinkSimulator.js', function(){
         };
         // alarm_suspend
         var suspend1 = {
-          reason: 'low_glucose',
+          reason: {suspended: 'automatic'},
+          payload: {cause: 'low_glucose'},
           timezoneOffset: 0,
           time: '2014-09-25T00:05:00.000Z',
           deviceTime: '2014-09-25T00:05:00'
         };
         // low_suspend_mode_1
         var suspend2 = {
-          reason: 'low_glucose',
+          reason: {suspended: 'automatic'},
+          payload: {cause: 'low_glucose'},
           timezoneOffset: 0,
           time: '2014-09-25T00:05:05.000Z',
           deviceTime: '2014-09-25T00:05:05'
         };
         // low_suspend_no_response
         var suspend3 = {
-          reason: 'low_glucose',
+          reason: {suspended: 'automatic'},
+          payload: {cause: 'low_glucose'},
           timezoneOffset: 0,
           time: '2014-09-25T00:05:10.000Z',
           deviceTime: '2014-09-25T00:05:10'
         };
         // low_suspend_user_selected
         var suspend4 = {
-          reason: 'low_glucose',
+          reason: {suspended: 'automatic'},
+          payload: {cause: 'low_glucose'},
           timezoneOffset: 0,
           time: '2014-09-25T00:05:15.000Z',
           deviceTime: '2014-09-25T00:05:15'
@@ -1904,13 +1908,14 @@ describe('carelinkSimulator.js', function(){
         var resume1 = {
           time: '2014-09-25T00:05:20.000Z',
           deviceTime: '2014-09-25T00:05:20',
-          reason: 'user_restart_basal',
+          reason: {resumed: 'manual'},
+          payload: {cause: 'user_restart_basal'},
           timezoneOffset: 0
         };
         var resume2 = {
           time: '2014-09-25T00:05:30.000Z',
           deviceTime: '2014-09-25T00:05:30',
-          reason: 'manual',
+          reason: {resumed: 'manual'},
           timezoneOffset: 0
         };
         var basal3 = {
@@ -1955,7 +1960,7 @@ describe('carelinkSimulator.js', function(){
                 suspendBasal,
                 _.assign({}, resume1, {
                   type: 'deviceMeta', subType: 'status',
-                  status: 'resumed', previous: expectedSuspend, reason: 'manual'
+                  status: 'resumed', previous: expectedSuspend, reason: {'resumed': 'manual'}
                 }),
                 fillInBasal,
                 _.assign({}, basal3, {type: 'basal', deliveryType: 'scheduled'})
@@ -1997,7 +2002,7 @@ describe('carelinkSimulator.js', function(){
                 _.assign({}, suspendBasal, {suppressed: tempBasal}),
                 _.assign({}, resume1, {
                   type: 'deviceMeta', subType: 'status',
-                  status: 'resumed', previous: expectedSuspend, reason: 'manual'
+                  status: 'resumed', previous: expectedSuspend, reason: {'resumed': 'manual'}
                 }),
                 fillInBasal,
                 _.assign({}, backToScheduled, {type: 'basal', deliveryType: 'scheduled', duration: 1680000}),
@@ -2043,7 +2048,7 @@ describe('carelinkSimulator.js', function(){
                 secondSuspendBasal,
                 _.assign({}, resume1, {
                   type: 'deviceMeta', subType: 'status',
-                  status: 'resumed', previous: expectedSuspend, reason: 'manual'
+                  status: 'resumed', previous: expectedSuspend, reason: {'resumed': 'manual'}
                 }),
                 fillInBasal,
                 _.assign({}, basal3, {type: 'basal', deliveryType: 'scheduled'})
@@ -2094,14 +2099,16 @@ describe('carelinkSimulator.js', function(){
         };
         // alarm_suspend
         var suspend1 = {
-          reason: 'low_glucose',
+          reason: {suspended: 'automatic'},
+          payload: {cause: 'low_glucose'},
           timezoneOffset: 0,
           time: '2014-09-25T00:05:00.000Z',
           deviceTime: '2014-09-25T00:05:00'
         };
         // low_suspend_no_response
         var suspend2 = {
-          reason: 'low_glucose',
+          reason: {suspended: 'automatic'},
+          payload: {cause: 'low_glucose'},
           timezoneOffset: 0,
           time: '2014-09-25T00:05:10.000Z',
           deviceTime: '2014-09-25T00:05:10'
@@ -2110,7 +2117,8 @@ describe('carelinkSimulator.js', function(){
         var resume = {
           time: '2014-09-25T02:05:00.000Z',
           deviceTime: '2014-09-25T02:05:00',
-          reason: 'automatic',
+          reason: {resumed: 'automatic'},
+          payload: {cause: 'auto_resume_reduced', user_intervention: 'ignored'},
           timezoneOffset: 0
         };
         var basal2 = {


### PR DESCRIPTION
Dependency hell: required jellyfish v0.8.0 for Insulet demo broke CareLink. This fixes (although it also required additional tweaks to jellyfish: https://github.com/tidepool-org/jellyfish/pull/54)

This is already merged into the branch I'll be building for the devel Chrome store, and there will be a few small branches like that this weekend. I will be creating a list (incl. order in which I think they should be reviewed) by end of weekend.