### PR TITLE
fix localStorage for cli tools running in node

### DIFF
--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -25,6 +25,11 @@ var bows = require('../bows');
 var builder = require('../objectBuilder')();
 var localStore = require('./localStore');
 
+// for cli tools running in node
+if (typeof localStore === 'function') {
+  localStore = localStore({});
+}
+
 // Wrapper around the Tidepool client library
 var createTidepoolClient = require('tidepool-platform-client');
 var tidepool;


### PR DESCRIPTION
I accidentally broke the cli tools for CareLink and Insulet in #74. This fixes.

PR for tracking purposes, merging immediately.