### PR TITLE
add sequencing info for Jaeb

### DIFF
--- a/lib/carelink/bolusNWizard.js
+++ b/lib/carelink/bolusNWizard.js
@@ -473,6 +473,7 @@ module.exports = function(timezone, opts) {
       else {
         // TODO: delete after conclusion of Jaeb study
         common.mergeJaebPayloads(normal, square);
+        // TODO: end deletion
         return _.assign({}, cleanEvent(square), cleanEvent(normal), {subType: 'dual/square'});
       }
     }

--- a/lib/carelink/bolusNWizard.js
+++ b/lib/carelink/bolusNWizard.js
@@ -471,6 +471,8 @@ module.exports = function(timezone, opts) {
         return _.clone(cleanEvent(normal));
       }
       else {
+        // TODO: delete after conclusion of Jaeb study
+        common.mergeJaebPayloads(normal, square);
         return _.assign({}, cleanEvent(square), cleanEvent(normal), {subType: 'dual/square'});
       }
     }

--- a/lib/carelink/carelinkSimulator.js
+++ b/lib/carelink/carelinkSimulator.js
@@ -533,6 +533,31 @@ exports.make = function(config){
     },
 
     /**
+     * Report a change to the device's date and time settings.
+     *
+     * @param argument... Variable number of arguments, each should be an object.  The field:value pairs passed in
+     *                    are smooshed together into a deviceMeta event recorded by the simulator
+     */
+    changeDeviceTime: function() {
+      var event = ensureTimestamp(combineArguments(arguments));
+      var timeChange = bob.makeDeviceMetaTimeChange()
+        .with_change({
+          from: event.deviceTime,
+          to: new Date(event.timestamp).toISOString().slice(0,-5),
+          agent: 'manual'
+        })
+        .with_deviceTime(event.deviceTime)
+        .with_time(event.time)
+        .with_timezoneOffset(event.timezoneOffset)
+        .with_payload({
+          NEW_TIME: event.timestamp
+        })
+        .set('deviceId', event.deviceId)
+        .done();
+      events.push(timeChange);
+    },
+
+    /**
      * Resumes basal and bolus delivery from a previous LGS suspend.
      * This is the case that will *not* resume a temp basal that would still have been in effect
      * (Cf. MiniMed 530G manual, p. 125: http://www.accessdata.fda.gov/cdrh_docs/pdf12/P120010c.pdf)

--- a/lib/carelink/carelinkSimulator.js
+++ b/lib/carelink/carelinkSimulator.js
@@ -553,6 +553,8 @@ exports.make = function(config){
           NEW_TIME: event.timestamp
         })
         .set('deviceId', event.deviceId)
+        // TODO: delete after conclusion of Jaeb study
+        .set('jaebPayload', event.jaebPayload)
         .done();
       events.push(timeChange);
     },
@@ -578,7 +580,9 @@ exports.make = function(config){
         .with_timezoneOffset(event.timezoneOffset)
         .with_deviceTime(event.deviceTime)
         .with_reason(event.reason)
-        .with_payload(event.payload);
+        .with_payload(event.payload)
+        // TODO: delete after conclusion of Jaeb study
+        .set('jaebPayload', event.jaebPayload);
 
       if (event.deviceId != null) {
         deviceMetaResumeBuilder.set('deviceId', event.deviceId);
@@ -663,7 +667,9 @@ exports.make = function(config){
         .with_timezoneOffset(event.timezoneOffset)
         .with_deviceTime(event.deviceTime)
         .with_reason(event.reason)
-        .with_payload(event.payload);
+        .with_payload(event.payload)
+        // TODO: delete after conclusion of Jaeb study
+        .set('jaebPayload', event.jaebPayload);
 
       if (event.deviceId != null) {
         deviceMetaResumeBuilder.set('deviceId', event.deviceId);
@@ -686,7 +692,9 @@ exports.make = function(config){
       events.push(deviceMetaResume);
 
       // fabricate a nextBasal from the basal that was suppressed by the suspend
-      var nextBasal = _.cloneDeep(currBasal.suppressed);
+      // TODO: omitting the payload is because of the jaebPayload and can likely
+      // be safely deleted after the conclusion of the Jaeb study
+      var nextBasal = _.cloneDeep(_.omit(currBasal.suppressed, 'payload'));
       if (nextBasal == null) {
         return;
       }
@@ -765,7 +773,9 @@ exports.make = function(config){
         .with_time(event.time)
         .with_timezoneOffset(event.timezoneOffset)
         .with_deviceTime(event.deviceTime)
-        .with_reason(event.reason);
+        .with_reason(event.reason)
+        // TODO: delete after conclusion of Jaeb study
+        .set('jaebPayload', event.jaebPayload);
 
       if (event.payload != null) {
         deviceMetaResumeBuilder.with_payload(event.payload);
@@ -803,7 +813,9 @@ exports.make = function(config){
        * basal we come across and add it then (after pushing the basal clock forward to force
        * emission of any other necessary segments due to schedule changes).
        */
-      var nextBasal = _.cloneDeep(currBasal.suppressed);
+      // TODO: omitting the payload is because of the jaebPayload and can likely
+      // be safely deleted after the conclusion of the Jaeb study
+      var nextBasal = _.cloneDeep(_.omit(currBasal.suppressed, 'payload'));
       if (nextBasal == null) {
         return;
       }
@@ -916,7 +928,9 @@ exports.make = function(config){
         .with_time(event.time)
         .with_timezoneOffset(event.timezoneOffset)
         .with_deviceTime(event.deviceTime)
-        .with_reason(event.reason);
+        .with_reason(event.reason)
+        // TODO: delete after conclusion of Jaeb study
+        .set('jaebPayload', event.jaebPayload);
 
       if (event.payload != null) {
         deviceMetaSuspendBuilder.with_payload(event.payload);

--- a/lib/carelink/carelinkSimulator.js
+++ b/lib/carelink/carelinkSimulator.js
@@ -555,6 +555,7 @@ exports.make = function(config){
         .set('deviceId', event.deviceId)
         // TODO: delete after conclusion of Jaeb study
         .set('jaebPayload', event.jaebPayload)
+        // TODO: end deletion
         .done();
       events.push(timeChange);
     },
@@ -583,6 +584,7 @@ exports.make = function(config){
         .with_payload(event.payload)
         // TODO: delete after conclusion of Jaeb study
         .set('jaebPayload', event.jaebPayload);
+        // TODO: end deletion
 
       if (event.deviceId != null) {
         deviceMetaResumeBuilder.set('deviceId', event.deviceId);
@@ -670,6 +672,7 @@ exports.make = function(config){
         .with_payload(event.payload)
         // TODO: delete after conclusion of Jaeb study
         .set('jaebPayload', event.jaebPayload);
+        // TODO: end deletion
 
       if (event.deviceId != null) {
         deviceMetaResumeBuilder.set('deviceId', event.deviceId);
@@ -776,6 +779,7 @@ exports.make = function(config){
         .with_reason(event.reason)
         // TODO: delete after conclusion of Jaeb study
         .set('jaebPayload', event.jaebPayload);
+        // TODO: end deletion
 
       if (event.payload != null) {
         deviceMetaResumeBuilder.with_payload(event.payload);
@@ -931,6 +935,7 @@ exports.make = function(config){
         .with_reason(event.reason)
         // TODO: delete after conclusion of Jaeb study
         .set('jaebPayload', event.jaebPayload);
+        // TODO: end deletion
 
       if (event.payload != null) {
         deviceMetaSuspendBuilder.with_payload(event.payload);

--- a/lib/carelink/common.js
+++ b/lib/carelink/common.js
@@ -35,7 +35,12 @@ exports.makeCommonVals = function(timezone){
       deviceTime: deviceTime,
       time: time,
       timezoneOffset: sundial.getOffsetFromZone(time, timezone),
-      deviceId: line['Raw-Device Type'] + '-=-' + line['Raw-Upload ID']
+      deviceId: line['Raw-Device Type'] + '-=-' + line['Raw-Upload ID'],
+      // TODO: delete after conclusion of Jaeb study
+      jaebPayload: {
+        rawSeqNums: [line['Raw-Seq Num']],
+        rawUploadId: line['Raw-Upload ID']
+      }
     };
   };
 };
@@ -123,4 +128,13 @@ exports.convertBackToMmol = function(n) {
   // return a value with a single significant digit
   // matching other mmol/L values found in CareLink data
   return Math.floor(inMmol * 10 + 0.5) / 10;
+};
+
+// TODO: delete after conclusion of Jaeb study
+exports.mergeJaebPayloads = function(obj1, obj2) {
+  if (!_.isEmpty(obj1.jaebPayload) && !_.isEmpty(obj2.jaebPayload)) {
+    if (!_.isEmpty(obj1.jaebPayload.rawSeqNums) && !_.isEmpty(obj2.jaebPayload.rawSeqNums)) {
+      obj1.jaebPayload.rawSeqNums = obj1.jaebPayload.rawSeqNums.concat(obj2.jaebPayload.rawSeqNums);
+    }
+  }
 };

--- a/lib/carelink/common.js
+++ b/lib/carelink/common.js
@@ -41,6 +41,7 @@ exports.makeCommonVals = function(timezone){
         rawSeqNums: [line['Raw-Seq Num']],
         rawUploadId: line['Raw-Upload ID']
       }
+      // TODO: end deletion
     };
   };
 };
@@ -138,3 +139,4 @@ exports.mergeJaebPayloads = function(obj1, obj2) {
     }
   }
 };
+// TODO: end deletion

--- a/lib/carelink/getDeviceInfo.js
+++ b/lib/carelink/getDeviceInfo.js
@@ -22,6 +22,7 @@ var parsing = require('./parsing.js');
 
 module.exports = function(rows, type) {
   var serials = [], multiple = false;
+  var timeChanges = [];
   for (var i = 0; i < rows.length; ++i) {
     if (rows[i][0].search(type) != -1) {
       var model = rows[i][1].replace(' -', '');
@@ -30,8 +31,16 @@ module.exports = function(rows, type) {
         deviceModel: model,
         deviceSerialNumber: serial
       });
+      var match = rows[i][3].match(/Time Changes: (\d+)/);
+      if (match !== null) {
+        timeChanges.push({
+          deviceSerialNumber: serial,
+          numTimeChanges: parseInt(match[1], 10)
+        });
+      }
     } 
   }
+
   if (serials.length > 1) {
     multiple = true;
   }
@@ -59,6 +68,12 @@ module.exports = function(rows, type) {
       }
     },
     hasMultiple: function() { return multiple; },
-    getPayload: function() { return {devices: serials}; }
+    getPayload: function() { return {devices: serials}; },
+    getNumTimeChangesPerSN: function() {
+      return timeChanges;
+    },
+    hasTimeChanges: function() {
+      return !_.isEmpty(timeChanges);
+    }
   };
 };

--- a/lib/carelink/settings.js
+++ b/lib/carelink/settings.js
@@ -437,7 +437,11 @@ module.exports = function (timezone, opts) {
     });
 
     cachedObjects = _.sortBy(
-      _.map(Object.keys(unique), function(key) { return unique[key]; }),
+      _.map(Object.keys(unique), function(key) {
+        // TODO: delete after conclusion of Jaeb study
+        delete unique[key].jaebPayload;
+        return unique[key];
+      }),
       function(obj) { return obj.time; }
     );
   }

--- a/lib/carelink/settings.js
+++ b/lib/carelink/settings.js
@@ -440,6 +440,7 @@ module.exports = function (timezone, opts) {
       _.map(Object.keys(unique), function(key) {
         // TODO: delete after conclusion of Jaeb study
         delete unique[key].jaebPayload;
+        // TODO: end deletion
         return unique[key];
       }),
       function(obj) { return obj.time; }

--- a/lib/carelink/suspend.js
+++ b/lib/carelink/suspend.js
@@ -61,6 +61,9 @@ module.exports = function (timezone) {
                   status: 'resumed',
                   reason: {
                     resumed: 'manual'
+                  },
+                  payload: {
+                    code: reason
                   }
                 };
               case 'user_restart_basal':
@@ -70,7 +73,7 @@ module.exports = function (timezone) {
                     resumed: 'manual'
                   },
                   payload: {
-                    cause: 'user_restart_basal'
+                    code: reason
                   }
                 };
               case 'auto_resume_complete':
@@ -80,7 +83,7 @@ module.exports = function (timezone) {
                     resumed: 'automatic'
                   },
                   payload: {
-                    cause: 'auto_resume_complete',
+                    code: reason,
                     user_intervention: 'acknowledged'
                   }
                 };
@@ -91,7 +94,7 @@ module.exports = function (timezone) {
                     resumed: 'automatic'
                   },
                   payload: {
-                    cause: 'auto_resume_reduced',
+                    code: reason,
                     user_intervention: 'ignored'
                   }
                 };
@@ -124,13 +127,13 @@ module.exports = function (timezone) {
           }
           break;
         case 'resumed':
-          if (event.payload && event.payload.cause === 'auto_resume_complete') {
+          if (event.payload && event.payload.code === 'auto_resume_complete') {
             simulator.resume(event);
           }
-          else if (event.payload && event.payload.cause === 'auto_resume_reduced') {
+          else if (event.payload && event.payload.code === 'auto_resume_reduced') {
             simulator.lgsAutoResume(event);
           }
-          else if (event.payload && event.payload.cause === 'user_restart_basal') {
+          else if (event.payload && event.payload.code === 'user_restart_basal') {
             simulator.lgsResume(event);
           }
           else if (event.reason.resumed === 'manual') {

--- a/lib/carelink/timeChange.js
+++ b/lib/carelink/timeChange.js
@@ -1,0 +1,42 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2014, Tidepool Project
+ * 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ * 
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+var common = require('./common.js');
+var parsing = require('./parsing.js');
+
+module.exports = function (timezone) {
+  var parser = common.makeParser(
+    {
+      ChangeTime: [
+        common.makeCommonVals(timezone),
+        {
+          timestamp: parsing.asNumber(['Raw-Values', 'NEW_TIME'])
+        }
+      ]
+    }
+  );
+
+  return function (simulator, data) {
+    var parsed = parser(data);
+    // if parsed *is* null, we're just in a row of the CSV
+    // that isn't relevant to this processor
+    // hence the lack of an `else` condition
+    if (parsed != null) {
+      simulator.changeDeviceTime(parsed);
+    }
+  };
+};

--- a/lib/drivers/carelinkDriver.js
+++ b/lib/drivers/carelinkDriver.js
@@ -59,7 +59,8 @@ function initializeProcessors(timezone, opts) {
     require('../carelink/cbg.js')(timezone, opts),
     require('../carelink/basal.js')(timezone),
     require('../carelink/suspend.js')(timezone),
-    require('../carelink/bolusNWizard')(timezone, opts)
+    require('../carelink/bolusNWizard')(timezone, opts),
+    require('../carelink/timeChange')(timezone, opts)
   ];
 }
 
@@ -70,6 +71,7 @@ module.exports = function(simulatorMaker, api){
     'BasalProfileStart': true,
     'ChangeTempBasalPercent': true,
     'ChangeTempBasal': true,
+    'ChangeTime': true,
     // bolus and wizard
     'BolusNormal': true,
     'BolusSquare': true,

--- a/lib/objectBuilder.js
+++ b/lib/objectBuilder.js
@@ -104,6 +104,7 @@ module.exports = function () {
           self.payload = _.assign({}, payload, self.jaebPayload);
           delete self.jaebPayload;
         }
+        // TODO: end deletion
 
         return _.pick(this, function (value) {
           return !(_.isFunction(value) || value === OPTIONAL);

--- a/lib/objectBuilder.js
+++ b/lib/objectBuilder.js
@@ -86,6 +86,8 @@ module.exports = function () {
       // checks the object, removes unused optional fields,
       // and returns a copy of the object with all functions removed.
       done: function () {
+        var self = this;
+
         var valid = _.reduce(this, function (result, value, key) {
           if (value === REQUIRED) {
             result.push(key);
@@ -96,7 +98,14 @@ module.exports = function () {
           throw new Error(util.format('Some arguments to %s(%j) were not specified!', this.type, valid.join(',')));
         }
 
-        return _.pick(this, function (value, key) {
+        // TODO: delete after conclusion of Jaeb study
+        if (!_.isEmpty(self.jaebPayload)) {
+          var payload = self.payload === OPTIONAL ? {} : _.clone(self.payload);
+          self.payload = _.assign({}, payload, self.jaebPayload);
+          delete self.jaebPayload;
+        }
+
+        return _.pick(this, function (value) {
           return !(_.isFunction(value) || value === OPTIONAL);
         });
       },
@@ -117,7 +126,8 @@ module.exports = function () {
       type: 'smbg',
       value: REQUIRED,
       units: REQUIRED,
-      subType: OPTIONAL
+      subType: OPTIONAL,
+      payload: OPTIONAL
     });
     rec._bindProps();
     return rec;
@@ -127,7 +137,8 @@ module.exports = function () {
     var rec = _.assign(_createObject(), deviceInfo, {
       type: 'cbg',
       value: REQUIRED,
-      units: REQUIRED
+      units: REQUIRED,
+      payload: OPTIONAL
     });
     rec._bindProps();
     return rec;
@@ -136,7 +147,8 @@ module.exports = function () {
   function makeNote() {
     var rec = _.assign(_createObject(), deviceInfo, {
       type: 'note',
-      value: REQUIRED
+      value: REQUIRED,
+      payload: OPTIONAL
     });
     rec._bindProps();
     return rec;
@@ -146,7 +158,8 @@ module.exports = function () {
     var rec = _.assign(_createObject(), deviceInfo, {
       type: 'bloodKetone',
       units: 'mmol/L',
-      value: REQUIRED
+      value: REQUIRED,
+      payload: OPTIONAL
     });
     rec._bindProps();
     return rec;
@@ -155,7 +168,8 @@ module.exports = function () {
   function makeFood() {
     var rec = _.assign(_createObject(), deviceInfo, {
       type: 'food',
-      carbs: REQUIRED
+      carbs: REQUIRED,
+      payload: OPTIONAL
     });
     rec._bindProps();
     return rec;
@@ -172,8 +186,8 @@ module.exports = function () {
       insulinSensitivity: OPTIONAL,
       bgTarget: OPTIONAL,
       bolus: OPTIONAL,
-      payload: OPTIONAL,
-      units: REQUIRED
+      units: REQUIRED,
+      payload: OPTIONAL
     });
     rec._bindProps();
     return rec;
@@ -183,7 +197,8 @@ module.exports = function () {
     var rec = _.assign(_createObject(), deviceInfo, {
       type: 'bolus',
       subType: 'normal',
-      normal: REQUIRED
+      normal: REQUIRED,
+      payload: OPTIONAL
     });
     rec._bindProps();
     return rec;
@@ -194,7 +209,8 @@ module.exports = function () {
       type: 'bolus',
       subType: 'square',
       extended: REQUIRED,
-      duration: REQUIRED
+      duration: REQUIRED,
+      payload: OPTIONAL
     });
     rec._bindProps();
     return rec;
@@ -206,7 +222,8 @@ module.exports = function () {
       subType: 'dual/square',
       normal: REQUIRED,
       extended: REQUIRED,
-      duration: REQUIRED
+      duration: REQUIRED,
+      payload: OPTIONAL
     });
     rec._bindProps();
     return rec;
@@ -217,8 +234,8 @@ module.exports = function () {
       type: 'deviceMeta',
       subType: 'alarm',
       alarmType: REQUIRED,
-      payload: OPTIONAL,
-      status: OPTIONAL
+      status: OPTIONAL,
+      payload: OPTIONAL
     });
     rec._bindProps();
     return rec;
@@ -255,7 +272,8 @@ module.exports = function () {
       type: 'deviceMeta',
       subType: 'calibration',
       value: REQUIRED,
-      units: REQUIRED
+      units: REQUIRED,
+      payload: OPTIONAL
     });
     rec._bindProps();
     return rec;
@@ -265,8 +283,8 @@ module.exports = function () {
     var rec = _.assign(_createObject(), deviceInfo, {
       type: 'deviceMeta',
       subType: 'reservoirChange',
-      payload: OPTIONAL,
-      status: OPTIONAL
+      status: OPTIONAL,
+      payload: OPTIONAL
     });
     rec._bindProps();
     return rec;
@@ -290,7 +308,8 @@ module.exports = function () {
       scheduleName: REQUIRED,
       rate: REQUIRED,
       duration: REQUIRED,
-      previous: OPTIONAL
+      previous: OPTIONAL,
+      payload: OPTIONAL
     });
     rec._bindProps();
     return rec;
@@ -302,7 +321,8 @@ module.exports = function () {
       deliveryType: 'suspend',
       duration: OPTIONAL,
       previous: OPTIONAL,
-      suppressed: OPTIONAL
+      suppressed: OPTIONAL,
+      payload: OPTIONAL
     });
     rec._bindProps();
     return rec;
@@ -316,7 +336,8 @@ module.exports = function () {
       percent: OPTIONAL,
       duration: REQUIRED,
       previous: OPTIONAL,
-      suppressed: OPTIONAL
+      suppressed: OPTIONAL,
+      payload: OPTIONAL
     });
     rec._bindProps();
     return rec;
@@ -330,7 +351,8 @@ module.exports = function () {
       basalSchedules: {},
       carbRatio: [],
       insulinSensitivity: [],
-      bgTarget: []
+      bgTarget: [],
+      payload: OPTIONAL
     });
     rec._bindProps();
     rec.add_basalScheduleItem = function (key, item) {

--- a/test/carelink/bolus/dual/withWizardInterruptedWithOverride/output.json
+++ b/test/carelink/bolus/dual/withWizardInterruptedWithOverride/output.json
@@ -80,6 +80,9 @@
         "time": "2014-11-15T21:41:37.000Z",
         "timezoneOffset": -600,
         "deviceId": "Paradigm Revel - 723-=-53602018",
+        "payload": {
+            "code": "normal_pumping"
+        },
         "reason": {
             "resumed": "manual"
         }

--- a/test/carelink/bolus/square/noWizardInterrupted/output.json
+++ b/test/carelink/bolus/square/noWizardInterrupted/output.json
@@ -42,6 +42,9 @@
         "time": "2014-11-17T02:28:43.000Z",
         "timezoneOffset": -600,
         "deviceId": "Paradigm Revel - 723-=-53602018",
+        "payload": {
+            "code": "normal_pumping"
+        },
         "reason": {
             "resumed": "manual"
         }

--- a/test/carelink/mockSimulator.js
+++ b/test/carelink/mockSimulator.js
@@ -45,7 +45,12 @@ exports.make = function(config) {
     smbg: appendToEvents('smbg'),
     wizard: appendToEvents('wizard'),
     getEvents: function(){
-      return events;
+      return _.map(events, function(event) {
+        if (event.type === 'wizard') {
+          event.bolus = _.omit(event.bolus, 'jaebPayload');
+        }
+        return _.omit(event, 'jaebPayload');
+      });
     }
   };
 };

--- a/test/carelink/suspend/output.json
+++ b/test/carelink/suspend/output.json
@@ -27,6 +27,9 @@
         "timezoneOffset": -600,
         "source": "carelink",
         "type": "resume",
+        "payload": {
+            "code": "normal_pumping"
+        },
         "reason": {
             "resumed": "manual"
         },
@@ -60,6 +63,9 @@
         "timezoneOffset": -600,
         "source": "carelink",
         "type": "resume",
+        "payload": {
+            "code": "normal_pumping"
+        },
         "reason": {
             "resumed": "manual"
         },
@@ -71,6 +77,9 @@
         "timezoneOffset": -600,
         "source": "carelink",
         "type": "resume",
+        "payload": {
+            "code": "normal_pumping"
+        },
         "reason": {
             "resumed": "manual"
         },

--- a/test/carelink/testSerial.js
+++ b/test/carelink/testSerial.js
@@ -26,13 +26,13 @@ describe('getDeviceInfo', function() {
   var fakeRows = [
     ['The cure for anything is salt water:', 'sweat', 'tears', 'or the sea'],
     ['Isak', 'Dinesen'],
-    ['Meter:', 'OneTouch Mini', '#12345'],
-    ['Pump:', 'MiniMed 530G - 551', '#6789A'],
+    ['Meter:', 'OneTouch Mini', '#12345', ''],
+    ['Pump:', 'MiniMed 530G - 551', '#6789A', 'Time Changes: 2'],
     ['Baroness', 'Karen', 'von', 'Blixen-Finecke']
   ];
 
   var multiplePumps = _.cloneDeep(fakeRows);
-  multiplePumps.splice(4, 0, ['Pump:', 'Paradigm Revel - 523', 'foobar']);
+  multiplePumps.splice(4, 0, ['Pump:', 'Paradigm Revel - 523', 'foobar', '']);
 
   it('should return an object', function() {
     expect(getDeviceInfo([], /foo/)).to.be.an('object');
@@ -91,6 +91,35 @@ describe('getDeviceInfo', function() {
     it('should return true when multiple devices of a particular type present', function() {
       var pumps = getDeviceInfo(multiplePumps, /Pump/);
       expect(pumps.hasMultiple()).to.be.true;
+    });
+  });
+
+  describe('getNumTimeChangesPerSN', function() {
+    it('should return an array giving number of time changes per SN', function() {
+      var pumps = getDeviceInfo(fakeRows, /Pump/);
+      expect(pumps.getNumTimeChangesPerSN()).to.be.an('array');
+      expect(pumps.getNumTimeChangesPerSN()).deep.equals([{
+        deviceSerialNumber: '6789A',
+        numTimeChanges: 2
+      }]);
+    });
+
+    it('should return an empty array if no time changes', function() {
+      var meters = getDeviceInfo(fakeRows, /Meter/);
+      expect(meters.getNumTimeChangesPerSN()).to.be.an('array');
+      expect(meters.getNumTimeChangesPerSN()).deep.equals([]);
+    });
+  });
+
+  describe('hasTimeChanges', function() {
+    it('should return true if there are time changes in one or more devices within a category (pumps or meters)', function() {
+      var pumps = getDeviceInfo(fakeRows, /Pump/);
+      expect(pumps.hasTimeChanges()).to.be.true;
+    });
+
+    it('should return false if there are time changes in one or more devices within a category (pumps or meters)', function() {
+      var meters = getDeviceInfo(fakeRows, /Meter/);
+      expect(meters.hasTimeChanges()).to.be.false;
     });
   });
 });


### PR DESCRIPTION
This is a start on reading time change events in CareLink (i.e., it adds parsing and simulation of deviceMeta subType `timeChange` events, but does not do any "bootstrapping" from them).

It also preserves the `Raw-Seq Num` and `Raw-Upload ID` in the payload for most objects, as requested by Jaeb.