### PR TITLE
add internalTime to the payload for Dexcom EGVs and calibrations

### DIFF
--- a/lib/drivers/dexcomDriver.js
+++ b/lib/drivers/dexcomDriver.js
@@ -196,8 +196,9 @@ module.exports = function (config) {
       rec.trendText = getTrendName(rec.trendArrow);
       rec.systemTimeMsec = BASE_DATE_DEVICE + 1000 * rec.systemSeconds;
       rec.displayTimeMsec = BASE_DATE_DEVICE + 1000 * rec.displaySeconds;
+      rec.internalTime = sundial.formatDeviceTime(new Date(rec.systemTimeMsec).toISOString());
       rec.displayTime = sundial.formatDeviceTime(new Date(rec.displayTimeMsec).toISOString());
-      rec.displayUtc = sundial.applyTimezone(rec.displayTime, cfg.timezone);
+      rec.displayUtc = sundial.applyTimezone(rec.displayTime, cfg.timezone).toISOString();
       rec.data = data.subarray(ctr, ctr + flen);
       ctr += flen;
 
@@ -253,9 +254,9 @@ module.exports = function (config) {
       rec.displayTimeMsec = BASE_DATE_DEVICE + 1000 * rec.displaySeconds;
       // not sure what to do with the meterTime -- it's very much not definitive.
       rec.meterTimeMsec = BASE_DATE_DEVICE + 1000 * rec.meterTimeSeconds;
-
+      rec.internalTime = sundial.formatDeviceTime(new Date(rec.systemTimeMsec).toISOString());
       rec.displayTime = sundial.formatDeviceTime(new Date(rec.displayTimeMsec).toISOString());
-      rec.displayUtc = sundial.applyTimezone(rec.displayTime, cfg.timezone);
+      rec.displayUtc = sundial.applyTimezone(rec.displayTime, cfg.timezone).toISOString();
       rec.data = data.subarray(ctr, ctr + flen);
       ctr += flen;
       all.push(rec);
@@ -573,7 +574,7 @@ module.exports = function (config) {
       var page = pagedata[i].parsed_payload;
       for (var j = 0; j < page.data.length; ++j) {
         var reading = _.pick(page.data[j],
-                             'displaySeconds', 'displayTime', 'displayUtc', 'systemSeconds',
+                             'displaySeconds', 'displayTime', 'displayUtc', 'internalTime', 'systemSeconds',
                              'glucose', 'trendArrow', 'trendText');
         reading.pagenum = page.header.pagenum;
         readings.push(reading);
@@ -588,7 +589,7 @@ module.exports = function (config) {
       var page = pagedata[i].parsed_payload;
       for (var j = 0; j < page.data.length; ++j) {
         var reading = _.pick(page.data[j], 'displaySeconds', 'displayTime',
-                             'displayUtc', 'systemSeconds', 'meterValue');
+                             'displayUtc', 'internalTime', 'systemSeconds', 'meterValue');
         reading.pagenum = page.header.pagenum;
         readings.push(reading);
       }
@@ -624,7 +625,7 @@ module.exports = function (config) {
           threshold: 400
         };
       }
-      var payload = { trend: datum.trendText };
+      var payload = { trend: datum.trendText, internalTime: datum.internalTime };
       var cbg = cfg.builder.makeCBG()
         .with_value(datum.glucose)
         .with_time(datum.displayUtc)
@@ -655,6 +656,9 @@ module.exports = function (config) {
         .with_deviceTime(datum.displayTime)
         .with_timezoneOffset(sundial.getOffsetFromZone(datum.displayUtc, cfg.timezone))
         .with_units('mg/dL')      // everything the Dexcom receiver stores is in this unit
+        .set('payload', {
+          internalTime: datum.internalTime
+        })
         .done();
       dataToPost.push(cal);
     }


### PR DESCRIPTION
Add the Dexcom internal time to the payload. Cleaner than for the pumps, since there's no much less object-building going on.

I also made sure we're handling the UTC time translation into a string - happened to catch that that was happening in the transformation to JSON on the way to the server, which I think only by chance matched what we wanted!