### PR TITLE
Jhbate/nice errors

### DIFF
--- a/lib/components/Upload.jsx
+++ b/lib/components/Upload.jsx
@@ -204,16 +204,7 @@ var Upload = React.createClass({
     }
     if (this.isUploadFailed()) {
       var uploadError = this.getUploadError();
-
-      if (getIn(uploadError, ['error', 'code']) && getIn(uploadError, ['error', 'message'])) {
-          return <div className="Upload-status Upload-status--error">{uploadError.error.message}</div>;
-      }
-
-      if (uploadError.code && uploadError.code === 404) {
-        return <div className="Upload-status Upload-status--error">{uploadError.message}</div>;
-      }
-
-      return <div className="Upload-status Upload-status--error">{'The upload didn\'t work.'}</div>;
+      return <div className="Upload-status Upload-status--error">{uploadError.message}</div>;
     }
     if (this.isBlockModeFileChosen()) {
       return <div className="Upload-status Upload-status--uploading"><p>{this.props.upload.file.name}</p></div>;

--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -329,17 +329,11 @@ function stringifyData(data) {
   if(_.isEmpty(data)){
     return '';
   }
-  if (_.isPlainObject(data)) {
-    return JSON.stringify(data);
-  }
-  else {
-    return data.toString();
-  }
+  return JSON.stringify(data);
 }
 
 api.errors.log = function(error, message, properties) {
-  api.log('POST /errors');
-
+  api.log('GET /errors');
   return tidepool.logAppError(stringifyData(error), message, stringifyData(properties));
 };
 

--- a/lib/core/device.js
+++ b/lib/core/device.js
@@ -70,6 +70,7 @@ device.init = function(options, cb) {
   self._version = options.version;
   self._groupId = options.targetId;
   chrome.runtime.getPlatformInfo(function (platformInfo) {
+    self._os = platformInfo.os;
     if (platformInfo.os == 'win') {
       self._portpattern = 'COM[0-9]+';
     } else {
@@ -175,6 +176,15 @@ device.detectUsb = function(driverId, cb) {
         portPattern: self._portpattern,
         usbDevice: result.device
       };
+      if (self._os == 'win') {
+        if (driverManifest.winPortPattern) {
+          retval.portPattern = driverManifest.winPortPattern;
+        }
+      } else {
+        if (driverManifest.macPortPattern) {
+          retval.portPattern = driverManifest.macPortPattern;
+        }
+      }
       if (!!driverManifest.bitrate) {
         retval.bitrate = driverManifest.bitrate;
       }

--- a/lib/core/uploadError.js
+++ b/lib/core/uploadError.js
@@ -1,0 +1,26 @@
+// == BSD2 LICENSE ==
+// Copyright (c) 2014, Tidepool Project
+//
+// This program is free software; you can redistribute it and/or modify it under
+// the terms of the associated License, which is identical to the BSD 2-Clause
+// License as published by the Open Source Initiative at opensource.org.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the License for more details.
+//
+// You should have received a copy of the License along with this program; if
+// not, you can obtain one from Tidepool Project at tidepool.org.
+// == BSD2 LICENSE ==
+
+'use strict';
+
+// Create a new object, that prototypally inherits from the Error constructor.
+function UploaderError(message, debugDetails) {
+  this.name = 'UploaderError';
+  this.message = message || 'no message provided';
+  this.detail = debugDetails || {'no details provided'};
+}
+
+UploaderError.prototype = Object.create(Error.prototype);
+UploaderError.prototype.constructor = UploaderError;

--- a/lib/core/uploadError.js
+++ b/lib/core/uploadError.js
@@ -19,7 +19,7 @@
 function UploaderError(message, debugDetails) {
   this.name = 'UploaderError';
   this.message = message || 'no message provided';
-  this.detail = debugDetails || {'no details provided'};
+  this.detail = debugDetails || {};
 }
 
 UploaderError.prototype = Object.create(Error.prototype);

--- a/lib/core/uploaderError.js
+++ b/lib/core/uploaderError.js
@@ -21,16 +21,26 @@ var sundial = require('sundial');
 function UploaderError(message, stage, error) {
 
   this.name = this.constructor.name;
-  this.message = [ message, UploaderError.UTC_TIME, sundial.utcDateString(),UploaderError.STAGE, stage.Message].join(' ');
-  //the short code for this stage
-  this.code = stage.Code;
-  //which step of the current stage are we at
-  this.step = stage.Step;
-  this.originalError = error || {};
+  this.message = message;
+
+  var theStep = stage.Step || '';
+  if(error && error.step){
+    theStep = error.step;
+  }
+
+  this.debug = [
+    message || stage.Message,'|',
+    UploaderError.UTC_TIME, sundial.utcDateString(),'|',
+    UploaderError.CODE, stage.Code,'|',
+    UploaderError.STEP, theStep
+  ].join(' ');
+
+  this.originalError = { 'originalError' : error || {}};
 }
 
 UploaderError.UTC_TIME = 'UTC Time:';
-UploaderError.STAGE = 'Stage:';
+UploaderError.CODE = 'Code:';
+UploaderError.STEP = 'Step:';
 
 UploaderError.prototype = Object.create(Error.prototype);
 UploaderError.prototype.constructor = UploaderError;

--- a/lib/core/uploaderError.js
+++ b/lib/core/uploaderError.js
@@ -15,12 +15,22 @@
 
 'use strict';
 
+var sundial = require('sundial');
+
 // Create a new object, that prototypally inherits from the Error constructor.
-function UploaderError(message, debugDetails) {
-  this.name = 'UploaderError';
-  this.message = message || 'no message provided';
-  this.detail = debugDetails || {};
+function UploaderError(message, stage) {
+
+  this.name = this.constructor.name;
+  this.message = [ message,
+                   UploaderError.UTC_TIME, sundial.utcDateString(),
+                   'Stage: ', stage.Message].join(' ');
+  //the short code for this stage
+  this.code = stage.Code;
+  //which step of the current stage are we at
+  this.step = stage.Step;
 }
+
+UploaderError.UTC_TIME = 'UTC Time: ';
 
 UploaderError.prototype = Object.create(Error.prototype);
 UploaderError.prototype.constructor = UploaderError;

--- a/lib/core/uploaderError.js
+++ b/lib/core/uploaderError.js
@@ -24,3 +24,5 @@ function UploaderError(message, debugDetails) {
 
 UploaderError.prototype = Object.create(Error.prototype);
 UploaderError.prototype.constructor = UploaderError;
+
+exports = module.exports = UploaderError;

--- a/lib/core/uploaderError.js
+++ b/lib/core/uploaderError.js
@@ -18,19 +18,19 @@
 var sundial = require('sundial');
 
 // Create a new object, that prototypally inherits from the Error constructor.
-function UploaderError(message, stage) {
+function UploaderError(message, stage, error) {
 
   this.name = this.constructor.name;
-  this.message = [ message,
-                   UploaderError.UTC_TIME, sundial.utcDateString(),
-                   'Stage: ', stage.Message].join(' ');
+  this.message = [ message, UploaderError.UTC_TIME, sundial.utcDateString(),UploaderError.STAGE, stage.Message].join(' ');
   //the short code for this stage
   this.code = stage.Code;
   //which step of the current stage are we at
   this.step = stage.Step;
+  this.originalError = error || {};
 }
 
-UploaderError.UTC_TIME = 'UTC Time: ';
+UploaderError.UTC_TIME = 'UTC Time:';
+UploaderError.STAGE = 'Stage:';
 
 UploaderError.prototype = Object.create(Error.prototype);
 UploaderError.prototype.constructor = UploaderError;

--- a/lib/driverManager.js
+++ b/lib/driverManager.js
@@ -129,7 +129,6 @@ module.exports = function (driverObjects, configs) {
         try{
           drvr.uploadData(stat.progressForStep(5), data, next);
         } catch (uploadDataError) {
-          uploadDataError.step = uploadDataError.step || 'what_what';
           return next(uploadDataError);
         }
       }

--- a/lib/driverManager.js
+++ b/lib/driverManager.js
@@ -95,14 +95,60 @@ module.exports = function (driverObjects, configs) {
       var deviceInfo = configs[driver].deviceInfo;
       var drvr = drivers[driver];
       var stat = createStat(driver);
+
+
+      function connect(data, next){
+        try{
+          drvr.connect(stat.progressForStep(1), data, next);
+        } catch (connectError) {
+          return next(connectError);
+        }
+      }
+      function getConfigInfo(data, next){
+        try{
+          drvr.getConfigInfo(stat.progressForStep(2), data, next);
+        } catch (configError) {
+          return next(configError);
+        }
+      }
+      function fetchData(data, next){
+        try{
+          drvr.fetchData(stat.progressForStep(3), data, next);
+        } catch (fetchDataError) {
+          return next(fetchDataError);
+        }
+      }
+      function processData(data, next){
+        try{
+          drvr.processData(stat.progressForStep(4), data, next);
+        } catch (processDataError) {
+          return next(processDataError);
+        }
+      }
+      function uploadData(data, next){
+        try{
+          drvr.uploadData(stat.progressForStep(5), data, next);
+        } catch (uploadDataError) {
+          uploadDataError.step = uploadDataError.step || 'what_what';
+          return next(uploadDataError);
+        }
+      }
+      function disconnect(data, next){
+        try{
+          drvr.disconnect(stat.progressForStep(6), data, next);
+        } catch (disconnectError) {
+          return next(disconnectError);
+        }
+      }
+
       async.waterfall([
         drvr.setup.bind(drvr, deviceInfo, stat.progressForStep(0)),
-        drvr.connect.bind(drvr, stat.progressForStep(1)),
-        drvr.getConfigInfo.bind(drvr, stat.progressForStep(2)),
-        drvr.fetchData.bind(drvr, stat.progressForStep(3)),
-        drvr.processData.bind(drvr, stat.progressForStep(4)),
-        drvr.uploadData.bind(drvr, stat.progressForStep(5)),
-        drvr.disconnect.bind(drvr, stat.progressForStep(6))
+        connect,
+        getConfigInfo,
+        fetchData,
+        processData,
+        uploadData,
+        disconnect
       ], function(err, result) {
         result = result || {};
         drvr.cleanup(stat.progressForStep(7), result, function() {

--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -42,6 +42,15 @@ appActions.trackedState = {
   SEE_IN_BLIP : 'Clicked See Data in Blip'
 };
 
+appActions.errorText = {
+  E_READING_FILE : 'Error reading file: ',
+  E_WRONG_FILE_EXT : 'Please choose a file ending in: ',
+  E_UPLOAD_IN_PROGRESS : 'Cannot start upload while an upload is in progress',
+  E_UNSUPPORTED_TYPE : 'Unsupported upload source type: ',
+  E_INVAILD_UPLOAD_INDEX : 'Invalid upload index: ',
+  E_DEVICE_NOT_CONNECTED : 'The device doesn\'t appear to be connected'
+};
+
 appActions.bindApp = function(app) {
   this.app = app;
   return this;
@@ -380,7 +389,7 @@ appActions.readFile = function(uploadIndex, targetId, file, extension) {
     var reader = new FileReader();
 
     reader.onerror = function(e) {
-      var error = new Error('Error reading ' + file.name);
+      var error = new Error(self.errorText.E_READING_FILE + file.name);
       inputError(error);
     };
 
@@ -401,7 +410,7 @@ appActions.readFile = function(uploadIndex, targetId, file, extension) {
     return true;
   }
   else {
-    var error = new Error('Please choose a file ending in ' + extension);
+    var error = new Error(self.errorText.E_WRONG_FILE_EXT + extension);
     error.code = 404;
     inputError(error);
     // the return is just for ease of testing
@@ -416,7 +425,7 @@ appActions.upload = function(uploadIndex, options, cb) {
   this._assertValidUploadIndex(uploadIndex);
 
   if (appState.hasUploadInProgress()) {
-    throw new Error('Cannot start upload while an upload is in progress');
+    throw new Error(self.errorText.E_UPLOAD_IN_PROGRESS);
   }
 
   var upload = this.app.state.uploads[uploadIndex];
@@ -454,13 +463,13 @@ appActions.upload = function(uploadIndex, options, cb) {
     return this._uploadCarelink(credentials, options, onUploadFinish);
   }
   else {
-    throw new Error('Unsupported upload source type ' + upload.source.type);
+    throw new Error(self.errorText.E_UNSUPPORTED_TYPE + upload.source.type);
   }
 };
 
 appActions._assertValidUploadIndex = function(uploadIndex) {
   if (uploadIndex > this.app.state.uploads.length - 1) {
-    throw new Error('Invalid upload index ' + uploadIndex);
+    throw new Error(self.errorText.E_INVAILD_UPLOAD_INDEX + uploadIndex);
   }
 };
 
@@ -577,7 +586,7 @@ appActions._uploadDevice = function(driverId, options, cb) {
     }
 
     if (!d && options.filename == null) {
-      err = new Error('The device doesn\'t appear to be connected');
+      err = new Error(self.errorText.E_DEVICE_NOT_CONNECTED);
       err.code = 404;
       return cb(err);
     }

--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -22,6 +22,7 @@ var sundial = require('sundial');
 var localStore = require('../core/localStore');
 var api = require('../core/api');
 var device = require('../core/device');
+var UploaderError = require('../core/uploaderError');
 var carelink = require('../core/carelink');
 var appState = require('./appState');
 
@@ -49,6 +50,16 @@ appActions.errorText = {
   E_UNSUPPORTED_TYPE : 'Unsupported upload source type: ',
   E_INVAILD_UPLOAD_INDEX : 'Invalid upload index: ',
   E_DEVICE_NOT_CONNECTED : 'The device doesn\'t appear to be connected'
+};
+
+appActions.errorStage = {
+  STAGE_DETECT_DEVICES : 'Detect Devices',
+  STAGE_READ_FILE : 'Read File',
+  STAGE_UPLOAD : 'Uploading Data',
+  STAGE_DEVICE_UPLOAD : 'Upload Device',
+  STAGE_DEVICE_DETECT : 'Detect Device',
+  STAGE_CARELINK_UPLOAD : 'CareLink Upload',
+  STAGE_CARELINK_FETCH : 'CareLink Fetch'
 };
 
 appActions.bindApp = function(app) {
@@ -226,7 +237,15 @@ appActions.detectDevices = function(cb) {
   var self = this;
   device.detectAll(function(err, devices) {
     if (err) {
-      return cb(err);
+      var msg = err.message || err;
+      error = new UploaderError(
+        msg,
+        {
+          utcTime: appActions._now(),
+          stage: appActions.errorStage.STAGE_DETECT_DEVICES
+        }
+      );
+      return cb(error);
     }
 
     var uploads = self._mergeDevicesWithUploads(
@@ -257,7 +276,6 @@ appActions.addOrRemoveTargetDevice = function(e) {
       return device === e.target.value;
     });
   }
-  
   this.app.setState({
     targetDevices: targetDevices
   });
@@ -389,7 +407,14 @@ appActions.readFile = function(uploadIndex, targetId, file, extension) {
     var reader = new FileReader();
 
     reader.onerror = function() {
-      var error = new Error(self.errorText.E_READING_FILE + file.name);
+      var error = new UploaderError(
+        self.errorText.E_READING_FILE + file.name,
+        {
+          utcTime: appActions._now(),
+          stage: appActions.errorStage.STAGE_READ_FILE
+        }
+      );
+
       inputError(error);
     };
 
@@ -410,8 +435,14 @@ appActions.readFile = function(uploadIndex, targetId, file, extension) {
     return true;
   }
   else {
-    var error = new Error(self.errorText.E_WRONG_FILE_EXT + extension);
-    error.code = 404;
+    var error = new UploaderError(
+      self.errorText.E_WRONG_FILE_EXT + extension,
+      {
+        utcTime: appActions._now(),
+        stage: appActions.errorStage.STAGE_READ_FILE,
+        code: 404
+      }
+    );
     inputError(error);
     // the return is just for ease of testing
     return error;
@@ -437,7 +468,18 @@ appActions.upload = function(uploadIndex, options, cb) {
   });
   var onUploadFinish = function(err, records) {
     if (err) {
-      self._handleUploadError(uploadIndex, err);
+
+      var msg = err.message || err;
+      var error = new UploaderError(
+        msg,
+        {
+          utcTime: appActions._now(),
+          stage: appActions.errorStage.STAGE_UPLOAD
+        }
+      );
+
+
+      self._handleUploadError(uploadIndex, error);
       return cb(err);
     }
     self._handleUploadSuccess(uploadIndex, records);
@@ -584,18 +626,40 @@ appActions._uploadDevice = function(driverId, options, cb) {
 
   device.detect(driverId, options, function(err, d) {
     if (err) {
-      return cb(err);
+      var msg = err.message || err;
+      var error = new UploaderError(
+        msg,
+        {
+          utcTime: appActions._now(),
+          stage: appActions.errorStage.STAGE_DEVICE_DETECT
+        }
+      );
+      return cb(error);
     }
 
     if (!d && options.filename == null) {
-      err = new Error(self.errorText.E_DEVICE_NOT_CONNECTED);
-      err.code = 404;
-      return cb(err);
+      var error = new UploaderError(
+        self.errorText.E_DEVICE_NOT_CONNECTED,
+        {
+          utcTime: appActions._now(),
+          stage: appActions.errorStage.STAGE_DEVICE_DETECT,
+          code: 404
+        }
+      );
+      return cb(error);
     }
 
     device.upload(driverId, options, function(err, records) {
       if (err) {
-        return cb(err);
+        var msg = err.message || err;
+        var error = new UploaderError(
+          msg,
+          {
+            utcTime: appActions._now(),
+            stage: appActions.errorStage.STAGE_DEVICE_UPLOAD
+          }
+        );
+        return cb(error);
       }
 
       records = records || [];
@@ -627,16 +691,32 @@ appActions._uploadCarelink = function(credentials, options, cb) {
         loggedMessage = loggedMessage +' '+err.error.error;
       }
 
+      var error = new UploaderError(
+        loggedMessage,
+        {
+          utcTime: appActions._now(),
+          stage: appActions.errorStage.STAGE_CARELINK_UPLOAD
+        }
+      );
+
       self._logMetric(loggedMessage);
-      self._logError(err, loggedMessage);
-      return cb(err);
+      self._logError(error, loggedMessage);
+      return cb(error);
     }
 
     self._logMetric(self.trackedState.CARELINK_FETCH_SUCCESS);
 
     carelink.upload(data, options, function(err, records) {
       if (err) {
-        return cb(err);
+        var msg = err.message || err;
+        var error = new UploaderError(
+          msg,
+          {
+            utcTime: appActions._now(),
+            stage: appActions.errorStage.STAGE_CARELINK_UPLOAD
+          }
+        );
+        return cb(error);
       }
 
       records = records || [];

--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -388,7 +388,7 @@ appActions.readFile = function(uploadIndex, targetId, file, extension) {
   if (file.name.slice(-extension.length) === extension) {
     var reader = new FileReader();
 
-    reader.onerror = function(e) {
+    reader.onerror = function() {
       var error = new Error(self.errorText.E_READING_FILE + file.name);
       inputError(error);
     };
@@ -469,7 +469,7 @@ appActions.upload = function(uploadIndex, options, cb) {
 
 appActions._assertValidUploadIndex = function(uploadIndex) {
   if (uploadIndex > this.app.state.uploads.length - 1) {
-    throw new Error(self.errorText.E_INVAILD_UPLOAD_INDEX + uploadIndex);
+    throw new Error(this.errorText.E_INVAILD_UPLOAD_INDEX + uploadIndex);
   }
 };
 
@@ -579,6 +579,8 @@ appActions._updateUpload = function(uploadIndex, updateFn) {
 };
 
 appActions._uploadDevice = function(driverId, options, cb) {
+
+  var self = this;
 
   device.detect(driverId, options, function(err, d) {
     if (err) {

--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -48,7 +48,7 @@ appActions.errorText = {
   E_WRONG_FILE_EXT : 'Please choose a file ending in: ',
   E_UPLOAD_IN_PROGRESS : 'Cannot start upload while an upload is in progress',
   E_UNSUPPORTED_TYPE : 'Unsupported upload source type: ',
-  E_INVAILD_UPLOAD_INDEX : 'Invalid upload index: ',
+  E_INVALID_UPLOAD_INDEX : 'Invalid upload index: ',
   E_DEVICE_NOT_CONNECTED : 'The device doesn\'t appear to be connected'
 };
 
@@ -489,7 +489,7 @@ appActions.upload = function(uploadIndex, options, cb) {
 
 appActions._assertValidUploadIndex = function(uploadIndex) {
   if (uploadIndex > this.app.state.uploads.length - 1) {
-    throw new UploaderError(this.errorText.E_INVAILD_UPLOAD_INDEX + uploadIndex, appActions.errorStage.STAGE_UPLOAD);
+    throw new UploaderError(this.errorText.E_INVALID_UPLOAD_INDEX + uploadIndex, appActions.errorStage.STAGE_UPLOAD);
   }
 };
 
@@ -560,7 +560,7 @@ appActions._handleUploadError = function(uploadIndex, error) {
       self.trackedState.UPLOAD_FAILED +' '+self._getUploadId(upload),
       {type: upload.source.type ,source:upload.source.driverId, error: error }
     );
-    
+
     self._logError(
       error,
       self.trackedState.UPLOAD_FAILED +' '+self._getUploadId(upload),

--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -53,6 +53,9 @@ appActions.errorText = {
 };
 
 appActions.errorStage = {
+  STAGE_SETUP : { Code: 'E_SETUP' , Message: 'Setup', Step: '' },
+  STAGE_LOGIN : { Code: 'E_LOGIN' , Message: 'Login', Step: '' },
+  STAGE_LOGOUT : { Code: 'E_LOGOUT' , Message: 'Logout', Step: '' },
   STAGE_DETECT_DEVICES : { Code: 'E_DETECTING_DEVICES' , Message: 'Detect Devices', Step: '' },
   STAGE_READ_FILE : { Code: 'E_READING_FILE' , Message: 'Read File' , Step: '' },
   STAGE_UPLOAD : { Code: 'E_UPLOADING' , Message: 'Uploading Data' , Step: ''},
@@ -124,7 +127,8 @@ appActions.load = function(cb) {
     setHostsWithCallback,
   ], function(err, results) {
     if (err) {
-      return cb(err);
+      var error = new UploaderError('', appActions.errorStage.STAGE_SETUP, err);
+      return cb(error);
     }
 
     var session = results[3];
@@ -166,7 +170,8 @@ appActions.login = function(credentials, options, cb) {
     api.user.getUploadGroups.bind(null)
   ], function(err, results) {
     if (err) {
-      return cb(err);
+      var error = new UploaderError('', appActions.errorStage.STAGE_LOGIN, err);
+      return cb(error);
     }
     self._logMetric(self.trackedState.LOGIN_SUCCESS);
     // once we've logged in, we don't want the right-click menus around, so
@@ -218,7 +223,8 @@ appActions.logout = function(cb) {
   self._logMetric(this.trackedState.LOGOUT_CLICKED);
   api.user.logout(function(err) {
     if (err) {
-      return cb(err);
+      var error = new UploaderError('', appActions.errorStage.STAGE_LOGOUT, err);
+      return cb(error);
     }
 
     self.app.setState(_.assign(appState.getInitial(), {
@@ -238,8 +244,7 @@ appActions.detectDevices = function(cb) {
   var self = this;
   device.detectAll(function(err, devices) {
     if (err) {
-      var msg = err.message || err;
-      var error = new UploaderError(msg, appActions.errorStage.STAGE_DETECT_DEVICES);
+      var error = new UploaderError('', appActions.errorStage.STAGE_DETECT_DEVICES, err);
       return cb(error);
     }
 
@@ -451,8 +456,7 @@ appActions.upload = function(uploadIndex, options, cb) {
   });
   var onUploadFinish = function(err, records) {
     if (err) {
-      var msg = err.message || err;
-      var error = new UploaderError(msg, appActions.errorStage.STAGE_UPLOAD);
+      var error = new UploaderError('', appActions.errorStage.STAGE_UPLOAD, err);
       self._handleUploadError(uploadIndex, error);
       return cb(error);
     }
@@ -602,20 +606,18 @@ appActions._uploadDevice = function(driverId, options, cb) {
 
   device.detect(driverId, options, function(err, d) {
     if (err) {
-      var msg = err.message || err;
-      var error = new UploaderError(msg, appActions.errorStage.STAGE_DEVICE_DETECT);
+      var error = new UploaderError(appActions.errorStage.STAGE_DEVICE_DETECT, err);
       return cb(error);
     }
 
     if (!d && options.filename == null) {
-      var error = new UploaderError( self.errorText.E_DEVICE_NOT_CONNECTED,  appActions.errorStage.STAGE_DEVICE_DETECT );
+      var error = new UploaderError( self.errorText.E_DEVICE_NOT_CONNECTED, appActions.errorStage.STAGE_DEVICE_DETECT );
       return cb(error);
     }
 
     device.upload(driverId, options, function(err, records) {
       if (err) {
-        var msg = err.message || err;
-        var error = new UploaderError( msg, appActions.errorStage.STAGE_DEVICE_UPLOAD );
+        var error = new UploaderError('', appActions.errorStage.STAGE_DEVICE_UPLOAD, err );
         return cb(error);
       }
 
@@ -648,7 +650,7 @@ appActions._uploadCarelink = function(credentials, options, cb) {
         loggedMessage = loggedMessage +' '+err.error.error;
       }
 
-      var error = new UploaderError(loggedMessage, appActions.errorStage.STAGE_CARELINK_FETCH);
+      var error = new UploaderError(loggedMessage, appActions.errorStage.STAGE_CARELINK_FETCH, err);
 
       self._logMetric(loggedMessage);
       self._logError(error, loggedMessage);
@@ -659,8 +661,7 @@ appActions._uploadCarelink = function(credentials, options, cb) {
 
     carelink.upload(data, options, function(err, records) {
       if (err) {
-        var msg = err.message || err;
-        var error = new UploaderError(msg, appActions.errorStage.STAGE_CARELINK_UPLOAD);
+        var error = new UploaderError('', appActions.errorStage.STAGE_CARELINK_UPLOAD, err);
         return cb(error);
       }
 

--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -53,16 +53,16 @@ appActions.errorText = {
 };
 
 appActions.errorStage = {
-  STAGE_SETUP : { Code: 'E_SETUP' , Message: 'Setup', Step: '' },
-  STAGE_LOGIN : { Code: 'E_LOGIN' , Message: 'Login', Step: '' },
-  STAGE_LOGOUT : { Code: 'E_LOGOUT' , Message: 'Logout', Step: '' },
-  STAGE_DETECT_DEVICES : { Code: 'E_DETECTING_DEVICES' , Message: 'Detect Devices', Step: '' },
-  STAGE_READ_FILE : { Code: 'E_READING_FILE' , Message: 'Read File' , Step: '' },
-  STAGE_UPLOAD : { Code: 'E_UPLOADING' , Message: 'Uploading Data' , Step: ''},
-  STAGE_DEVICE_UPLOAD : { Code: 'E_DEVICE_UPLOAD' , Message: 'Uploading Data', Step: '' },
-  STAGE_DEVICE_DETECT : { Code: 'E_DEVICE_DETECT' , Message: 'Detect Device' , Step: '' },
-  STAGE_CARELINK_UPLOAD : { Code: 'E_CARELINK_UPLOAD' , Message: 'CareLink Upload' , Step: ''},
-  STAGE_CARELINK_FETCH : { Code: 'E_CARELINK_FETCH' , Message: 'CareLink Fetch' , Step: '' }
+  STAGE_SETUP : { Code: 'E_SETUP' , Message: 'Error during setup', Step: '' },
+  STAGE_LOGIN : { Code: 'E_LOGIN' , Message: 'Error during login', Step: '' },
+  STAGE_LOGOUT : { Code: 'E_LOGOUT' , Message: 'Error during logout', Step: '' },
+  STAGE_DETECT_DEVICES : { Code: 'E_DETECTING_DEVICES' , Message: 'Error detecting devices', Step: '' },
+  STAGE_READ_FILE : { Code: 'E_READING_FILE' , Message: 'Error trying to read file' , Step: '' },
+  STAGE_UPLOAD : { Code: 'E_UPLOADING' , Message: 'Error uploading data' , Step: ''},
+  STAGE_DEVICE_UPLOAD : { Code: 'E_DEVICE_UPLOAD' , Message: 'Error uploading device data', Step: '' },
+  STAGE_DEVICE_DETECT : { Code: 'E_DEVICE_DETECT' , Message: 'Error trying to detect a device' , Step: '' },
+  STAGE_CARELINK_UPLOAD : { Code: 'E_CARELINK_UPLOAD' , Message: 'Error uploading CareLink data' , Step: ''},
+  STAGE_CARELINK_FETCH : { Code: 'E_CARELINK_FETCH' , Message: 'Error fetching CareLink data' , Step: '' }
 };
 
 
@@ -127,7 +127,7 @@ appActions.load = function(cb) {
     setHostsWithCallback,
   ], function(err, results) {
     if (err) {
-      var error = new UploaderError('', appActions.errorStage.STAGE_SETUP, err);
+      var error = new UploaderError(err.message, appActions.errorStage.STAGE_SETUP, err);
       return cb(error);
     }
 
@@ -170,7 +170,7 @@ appActions.login = function(credentials, options, cb) {
     api.user.getUploadGroups.bind(null)
   ], function(err, results) {
     if (err) {
-      var error = new UploaderError('', appActions.errorStage.STAGE_LOGIN, err);
+      var error = new UploaderError(err.message, appActions.errorStage.STAGE_LOGIN, err);
       return cb(error);
     }
     self._logMetric(self.trackedState.LOGIN_SUCCESS);
@@ -223,7 +223,7 @@ appActions.logout = function(cb) {
   self._logMetric(this.trackedState.LOGOUT_CLICKED);
   api.user.logout(function(err) {
     if (err) {
-      var error = new UploaderError('', appActions.errorStage.STAGE_LOGOUT, err);
+      var error = new UploaderError(err.message, appActions.errorStage.STAGE_LOGOUT, err);
       return cb(error);
     }
 
@@ -244,7 +244,7 @@ appActions.detectDevices = function(cb) {
   var self = this;
   device.detectAll(function(err, devices) {
     if (err) {
-      var error = new UploaderError('', appActions.errorStage.STAGE_DETECT_DEVICES, err);
+      var error = new UploaderError(err.message, appActions.errorStage.STAGE_DETECT_DEVICES, err);
       return cb(error);
     }
 
@@ -456,7 +456,7 @@ appActions.upload = function(uploadIndex, options, cb) {
   });
   var onUploadFinish = function(err, records) {
     if (err) {
-      var error = new UploaderError('', appActions.errorStage.STAGE_UPLOAD, err);
+      var error = new UploaderError(err.message, appActions.errorStage.STAGE_UPLOAD, err);
       self._handleUploadError(uploadIndex, error);
       return cb(error);
     }
@@ -555,11 +555,6 @@ appActions._handleUploadError = function(uploadIndex, error) {
   var self = this;
   this._updateUpload(uploadIndex, function(upload) {
 
-    //always attach the UTC time for tracking down errors
-    if ( error.message.indexOf(UploaderError.UTC_TIME) === -1 ){
-      error.message = error.message +' ('+ UploaderError.UTC_TIME + self._now() + ')';
-    }
-
     //log the errors
     self._logMetric(
       self.trackedState.UPLOAD_FAILED +' '+self._getUploadId(upload),
@@ -606,18 +601,18 @@ appActions._uploadDevice = function(driverId, options, cb) {
 
   device.detect(driverId, options, function(err, d) {
     if (err) {
-      var error = new UploaderError(appActions.errorStage.STAGE_DEVICE_DETECT, err);
+      var error = new UploaderError(err.message, appActions.errorStage.STAGE_DEVICE_DETECT, err);
       return cb(error);
     }
 
     if (!d && options.filename == null) {
-      var error = new UploaderError( self.errorText.E_DEVICE_NOT_CONNECTED, appActions.errorStage.STAGE_DEVICE_DETECT );
-      return cb(error);
+      var noDevice = new UploaderError( self.errorText.E_DEVICE_NOT_CONNECTED, appActions.errorStage.STAGE_DEVICE_DETECT );
+      return cb(noDevice);
     }
 
     device.upload(driverId, options, function(err, records) {
       if (err) {
-        var error = new UploaderError('', appActions.errorStage.STAGE_DEVICE_UPLOAD, err );
+        var error = new UploaderError(err.message, appActions.errorStage.STAGE_DEVICE_UPLOAD, err );
         return cb(error);
       }
 
@@ -643,17 +638,16 @@ appActions._uploadCarelink = function(credentials, options, cb) {
   api.upload.fetchCarelinkData(payload, function(err, data) {
 
     if (err) {
-      var loggedMessage = self.trackedState.CARELINK_FETCH_FAILED;
-
-      if (err.error && err.error.error){
-        //add detail to name as we have it.
-        loggedMessage = loggedMessage +' '+err.error.error;
+      var msg = self.trackedState.CARELINK_FETCH_FAILED;
+      if (err.error && err.error.message){
+        //add detail if we have it
+        msg = err.error.message;
       }
 
-      var error = new UploaderError(loggedMessage, appActions.errorStage.STAGE_CARELINK_FETCH, err);
+      var error = new UploaderError(msg, appActions.errorStage.STAGE_CARELINK_FETCH, err);
 
-      self._logMetric(loggedMessage);
-      self._logError(error, loggedMessage);
+      self._logMetric(self.trackedState.CARELINK_FETCH_FAILED);
+      self._logError(error, self.trackedState.CARELINK_FETCH_FAILED);
       return cb(error);
     }
 
@@ -661,7 +655,7 @@ appActions._uploadCarelink = function(credentials, options, cb) {
 
     carelink.upload(data, options, function(err, records) {
       if (err) {
-        var error = new UploaderError('', appActions.errorStage.STAGE_CARELINK_UPLOAD, err);
+        var error = new UploaderError(err.message, appActions.errorStage.STAGE_CARELINK_UPLOAD, err);
         return cb(error);
       }
 

--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -53,14 +53,15 @@ appActions.errorText = {
 };
 
 appActions.errorStage = {
-  STAGE_DETECT_DEVICES : 'Detect Devices',
-  STAGE_READ_FILE : 'Read File',
-  STAGE_UPLOAD : 'Uploading Data',
-  STAGE_DEVICE_UPLOAD : 'Upload Device',
-  STAGE_DEVICE_DETECT : 'Detect Device',
-  STAGE_CARELINK_UPLOAD : 'CareLink Upload',
-  STAGE_CARELINK_FETCH : 'CareLink Fetch'
+  STAGE_DETECT_DEVICES : { Code: 'E_DETECTING_DEVICES' , Message: 'Detect Devices', Step: '' },
+  STAGE_READ_FILE : { Code: 'E_READING_FILE' , Message: 'Read File' , Step: '' },
+  STAGE_UPLOAD : { Code: 'E_UPLOADING' , Message: 'Uploading Data' , Step: ''},
+  STAGE_DEVICE_UPLOAD : { Code: 'E_DEVICE_UPLOAD' , Message: 'Uploading Data', Step: '' },
+  STAGE_DEVICE_DETECT : { Code: 'E_DEVICE_DETECT' , Message: 'Detect Device' , Step: '' },
+  STAGE_CARELINK_UPLOAD : { Code: 'E_CARELINK_UPLOAD' , Message: 'CareLink Upload' , Step: ''},
+  STAGE_CARELINK_FETCH : { Code: 'E_CARELINK_FETCH' , Message: 'CareLink Fetch' , Step: '' }
 };
+
 
 appActions.bindApp = function(app) {
   this.app = app;
@@ -238,13 +239,7 @@ appActions.detectDevices = function(cb) {
   device.detectAll(function(err, devices) {
     if (err) {
       var msg = err.message || err;
-      error = new UploaderError(
-        msg,
-        {
-          utcTime: appActions._now(),
-          stage: appActions.errorStage.STAGE_DETECT_DEVICES
-        }
-      );
+      var error = new UploaderError(msg, appActions.errorStage.STAGE_DETECT_DEVICES);
       return cb(error);
     }
 
@@ -407,15 +402,10 @@ appActions.readFile = function(uploadIndex, targetId, file, extension) {
     var reader = new FileReader();
 
     reader.onerror = function() {
-      var error = new UploaderError(
-        self.errorText.E_READING_FILE + file.name,
-        {
-          utcTime: appActions._now(),
-          stage: appActions.errorStage.STAGE_READ_FILE
-        }
-      );
-
+      var error = new UploaderError(self.errorText.E_READING_FILE + file.name, appActions.errorStage.STAGE_READ_FILE);
       inputError(error);
+      // the return is just for ease of testing
+      return error;
     };
 
     reader.onloadend = (function(theFile) {
@@ -435,14 +425,7 @@ appActions.readFile = function(uploadIndex, targetId, file, extension) {
     return true;
   }
   else {
-    var error = new UploaderError(
-      self.errorText.E_WRONG_FILE_EXT + extension,
-      {
-        utcTime: appActions._now(),
-        stage: appActions.errorStage.STAGE_READ_FILE,
-        code: 404
-      }
-    );
+    var error = new UploaderError(self.errorText.E_WRONG_FILE_EXT + extension, appActions.errorStage.STAGE_READ_FILE);
     inputError(error);
     // the return is just for ease of testing
     return error;
@@ -456,7 +439,7 @@ appActions.upload = function(uploadIndex, options, cb) {
   this._assertValidUploadIndex(uploadIndex);
 
   if (appState.hasUploadInProgress()) {
-    throw new Error(self.errorText.E_UPLOAD_IN_PROGRESS);
+    throw new UploaderError(self.errorText.E_UPLOAD_IN_PROGRESS, appActions.errorStage.STAGE_UPLOAD);
   }
 
   var upload = this.app.state.uploads[uploadIndex];
@@ -468,19 +451,10 @@ appActions.upload = function(uploadIndex, options, cb) {
   });
   var onUploadFinish = function(err, records) {
     if (err) {
-
       var msg = err.message || err;
-      var error = new UploaderError(
-        msg,
-        {
-          utcTime: appActions._now(),
-          stage: appActions.errorStage.STAGE_UPLOAD
-        }
-      );
-
-
+      var error = new UploaderError(msg, appActions.errorStage.STAGE_UPLOAD);
       self._handleUploadError(uploadIndex, error);
-      return cb(err);
+      return cb(error);
     }
     self._handleUploadSuccess(uploadIndex, records);
     return cb(null, records);
@@ -505,13 +479,13 @@ appActions.upload = function(uploadIndex, options, cb) {
     return this._uploadCarelink(credentials, options, onUploadFinish);
   }
   else {
-    throw new Error(self.errorText.E_UNSUPPORTED_TYPE + upload.source.type);
+    throw new UploaderError(self.errorText.E_UNSUPPORTED_TYPE + upload.source.type, appActions.errorStage.STAGE_UPLOAD);
   }
 };
 
 appActions._assertValidUploadIndex = function(uploadIndex) {
   if (uploadIndex > this.app.state.uploads.length - 1) {
-    throw new Error(this.errorText.E_INVAILD_UPLOAD_INDEX + uploadIndex);
+    throw new UploaderError(this.errorText.E_INVAILD_UPLOAD_INDEX + uploadIndex, appActions.errorStage.STAGE_UPLOAD);
   }
 };
 
@@ -578,7 +552,9 @@ appActions._handleUploadError = function(uploadIndex, error) {
   this._updateUpload(uploadIndex, function(upload) {
 
     //always attach the UTC time for tracking down errors
-    error.message = error.message +' (UTC time: ' + self._now() + ')';
+    if ( error.message.indexOf(UploaderError.UTC_TIME) === -1 ){
+      error.message = error.message +' ('+ UploaderError.UTC_TIME + self._now() + ')';
+    }
 
     //log the errors
     self._logMetric(
@@ -627,38 +603,19 @@ appActions._uploadDevice = function(driverId, options, cb) {
   device.detect(driverId, options, function(err, d) {
     if (err) {
       var msg = err.message || err;
-      var error = new UploaderError(
-        msg,
-        {
-          utcTime: appActions._now(),
-          stage: appActions.errorStage.STAGE_DEVICE_DETECT
-        }
-      );
+      var error = new UploaderError(msg, appActions.errorStage.STAGE_DEVICE_DETECT);
       return cb(error);
     }
 
     if (!d && options.filename == null) {
-      var error = new UploaderError(
-        self.errorText.E_DEVICE_NOT_CONNECTED,
-        {
-          utcTime: appActions._now(),
-          stage: appActions.errorStage.STAGE_DEVICE_DETECT,
-          code: 404
-        }
-      );
+      var error = new UploaderError( self.errorText.E_DEVICE_NOT_CONNECTED,  appActions.errorStage.STAGE_DEVICE_DETECT );
       return cb(error);
     }
 
     device.upload(driverId, options, function(err, records) {
       if (err) {
         var msg = err.message || err;
-        var error = new UploaderError(
-          msg,
-          {
-            utcTime: appActions._now(),
-            stage: appActions.errorStage.STAGE_DEVICE_UPLOAD
-          }
-        );
+        var error = new UploaderError( msg, appActions.errorStage.STAGE_DEVICE_UPLOAD );
         return cb(error);
       }
 
@@ -691,13 +648,7 @@ appActions._uploadCarelink = function(credentials, options, cb) {
         loggedMessage = loggedMessage +' '+err.error.error;
       }
 
-      var error = new UploaderError(
-        loggedMessage,
-        {
-          utcTime: appActions._now(),
-          stage: appActions.errorStage.STAGE_CARELINK_UPLOAD
-        }
-      );
+      var error = new UploaderError(loggedMessage, appActions.errorStage.STAGE_CARELINK_FETCH);
 
       self._logMetric(loggedMessage);
       self._logError(error, loggedMessage);
@@ -709,13 +660,7 @@ appActions._uploadCarelink = function(credentials, options, cb) {
     carelink.upload(data, options, function(err, records) {
       if (err) {
         var msg = err.message || err;
-        var error = new UploaderError(
-          msg,
-          {
-            utcTime: appActions._now(),
-            stage: appActions.errorStage.STAGE_CARELINK_UPLOAD
-          }
-        );
+        var error = new UploaderError(msg, appActions.errorStage.STAGE_CARELINK_UPLOAD);
         return cb(error);
       }
 

--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -456,7 +456,7 @@ appActions.upload = function(uploadIndex, options, cb) {
   });
   var onUploadFinish = function(err, records) {
     if (err) {
-      var error = new UploaderError(err.message, appActions.errorStage.STAGE_UPLOAD, err);
+      var error = new UploaderError(appActions.errorStage.STAGE_UPLOAD.Message, appActions.errorStage.STAGE_UPLOAD, err);
       self._handleUploadError(uploadIndex, error);
       return cb(error);
     }
@@ -560,7 +560,7 @@ appActions._handleUploadError = function(uploadIndex, error) {
       self.trackedState.UPLOAD_FAILED +' '+self._getUploadId(upload),
       {type: upload.source.type ,source:upload.source.driverId, error: error }
     );
-
+    
     self._logError(
       error,
       self.trackedState.UPLOAD_FAILED +' '+self._getUploadId(upload),

--- a/manifest.json
+++ b/manifest.json
@@ -35,6 +35,7 @@
         {
           "deviceName": "Dexcom G4 CGM",
           "driverId": "DexcomG4",
+          "macPortPattern": "/dev/cu\\.(usb|dex).+",
           "mode": "serial",
           "vendorId": 8867,
           "productId": 71

--- a/styles/components/Upload.less
+++ b/styles/components/Upload.less
@@ -64,6 +64,10 @@
   color: @red;
 }
 
+.Upload-status--error--debug {
+  font-size: 10px;
+}
+
 .Upload-reset > a  {
   &:extend(.btn all);
 

--- a/test/core/testUploaderError.js
+++ b/test/core/testUploaderError.js
@@ -1,0 +1,50 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2014, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+/* global beforeEach, describe, it */
+
+var expect = require('salinity').expect;
+
+var UploaderError = require('../../lib/core/uploaderError.js');
+
+describe('UploaderError', function(){
+
+  var errToTest = new UploaderError('Yay',{ Code: 'E_TEST' , Message: 'Test', Step: 'Loading' });
+
+  it('message', function(){
+    expect(errToTest.message).to.include(UploaderError.STAGE);
+    expect(errToTest.message).to.include(UploaderError.UTC_TIME);
+    expect(errToTest.message).to.include('Yay');
+  });
+  it('name', function(){
+    expect(errToTest.name).to.equal('UploaderError');
+  });
+  it('code', function(){
+    expect(errToTest.code).to.equal('E_TEST');
+  });
+  it('step', function(){
+    expect(errToTest.step).to.equal('Loading');
+  });
+  it('originalError when none passed', function(){
+    expect(errToTest.originalError).to.be.empty;
+  });
+  it('originalError when none passed', function(){
+    var errorToWarp = new Error('error to wrap');
+    var err = new UploaderError('Yay',{ Code: 'E_TEST' , Message: 'Test', Step: 'Loading' },errorToWarp);
+    expect(err.originalError).to.deep.equal(errorToWarp);
+  });
+});

--- a/test/core/testUploaderError.js
+++ b/test/core/testUploaderError.js
@@ -23,28 +23,34 @@ var UploaderError = require('../../lib/core/uploaderError.js');
 
 describe('UploaderError', function(){
 
-  var errToTest = new UploaderError('Yay',{ Code: 'E_TEST' , Message: 'Test', Step: 'Loading' });
+  var errToTest = new UploaderError('Oh noes',{ Code: 'E_TEST' , Message: 'Test', Step: 'Loading' });
 
   it('message', function(){
-    expect(errToTest.message).to.include(UploaderError.STAGE);
-    expect(errToTest.message).to.include(UploaderError.UTC_TIME);
-    expect(errToTest.message).to.include('Yay');
+    expect(errToTest.message).to.equal('Oh noes');
+  });
+  it('debug', function(){
+    expect(errToTest.debug).to.include(UploaderError.CODE);
+    expect(errToTest.debug).to.include('E_TEST');
+    expect(errToTest.debug).to.include(UploaderError.UTC_TIME);
+    expect(errToTest.debug).to.include('Oh noes');
+    expect(errToTest.debug).to.include(UploaderError.STEP);
+    expect(errToTest.debug).to.include('Loading');
   });
   it('name', function(){
     expect(errToTest.name).to.equal('UploaderError');
   });
-  it('code', function(){
-    expect(errToTest.code).to.equal('E_TEST');
-  });
-  it('step', function(){
-    expect(errToTest.step).to.equal('Loading');
-  });
   it('originalError when none passed', function(){
-    expect(errToTest.originalError).to.be.empty;
+    expect(errToTest.originalError).to.deep.equal({ 'originalError' : {}});
   });
-  it('originalError when none passed', function(){
+  it('originalError when passed', function(){
     var errorToWarp = new Error('error to wrap');
-    var err = new UploaderError('Yay',{ Code: 'E_TEST' , Message: 'Test', Step: 'Loading' },errorToWarp);
-    expect(err.originalError).to.deep.equal(errorToWarp);
+    var err = new UploaderError('Something bad happened',{ Code: 'E_TEST_OTHER' , Message: 'Test', Step: 'Loading' },errorToWarp);
+    expect(err.originalError).to.deep.equal({'originalError':errorToWarp});
+  });
+  it('step is set from originalError', function(){
+    var errorToWarp = new Error('error to wrap w step');
+    errorToWarp.step = 'carelink_parsefile';
+    var err = new UploaderError('Something bad happened',{ Code: 'E_TEST_OTHER' , Message: 'Test' },errorToWarp);
+    expect(err.debug).to.include(errorToWarp.step);
   });
 });

--- a/test/ui/testAppActions.js
+++ b/test/ui/testAppActions.js
@@ -681,7 +681,7 @@ describe('appActions', function() {
         }
       }];
 
-      appActions.upload(0, {}, function(err) {
+      appActions.upload(0, {}, function() {
 
         function checkInstance(actual, expected){
           expect(actual.targetId).to.equal(expected.targetId);
@@ -702,8 +702,8 @@ describe('appActions', function() {
         };
 
         expect(app.state.uploads[0].history).to.have.length(1);
-        checkInstance(app.state.uploads[0].progress,instance)
-        checkInstance(app.state.uploads[0].history[0],instance)
+        checkInstance(app.state.uploads[0].progress,instance);
+        checkInstance(app.state.uploads[0].history[0],instance);
         expect(uploadErrorCall).to.not.be.empty;
         expect(uploadDeviceMetricsCall).to.not.be.empty;
         expect(uploadErrorCall.two).to.equal(appActions.trackedState.UPLOAD_FAILED+' DexcomG4');

--- a/test/ui/testAppActions.js
+++ b/test/ui/testAppActions.js
@@ -570,7 +570,7 @@ describe('appActions', function() {
       app.state.uploads = [];
 
       expect(appActions.upload.bind(appActions, 0))
-        .to.throw(/index/);
+        .to.throw(appActions.errorText.E_INVAILD_UPLOAD_INDEX);
     });
 
     it('throws an error if an upload is already in progress', function() {
@@ -579,7 +579,7 @@ describe('appActions', function() {
       }];
 
       expect(appActions.upload.bind(appActions, 0))
-        .to.throw(/progress/);
+        .to.throw(appActions.errorText.E_UPLOAD_IN_PROGRESS);
     });
 
     it('starts upload with correct progress data', function() {
@@ -729,7 +729,7 @@ describe('appActions', function() {
       app.state.uploads = [];
 
       expect(appActions.reset.bind(appActions, 0))
-        .to.throw(/index/);
+        .to.throw(appActions.errorText.E_INVAILD_UPLOAD_INDEX);
     });
 
     it('clears upload progress', function() {

--- a/test/ui/testAppActions.js
+++ b/test/ui/testAppActions.js
@@ -552,7 +552,7 @@ describe('appActions', function() {
 
     it('should return an error if the filename doesn\'t end in the specified extension', function() {
       var err = appActions.readFile(0, '11', {name: 'foo.bar'}, '.txt');
-      expect(err.message).to.equal('Please choose a file ending in .txt');
+      expect(err.message).to.equal(appActions.errorText.E_WRONG_FILE_EXT+'.txt');
       expect(err.code).to.equal(404);
     });
   });

--- a/test/ui/testAppActions.js
+++ b/test/ui/testAppActions.js
@@ -688,7 +688,6 @@ describe('appActions', function() {
           expect(actual.start).to.equal(expected.start);
           expect(actual.percentage).to.equal(expected.percentage);
           expect(actual.error.name).to.equal('UploaderError');
-          expect(actual.error.message).to.equal(uploadError.message);
           expect(actual.error.originalError).to.not.be.empty;
         }
 


### PR DESCRIPTION
WIP @jebeck @kentquirk feel free to have a look.

really just need to get to to display the debug details also (we already log it) so we can get the more detailed user errors we want. 

* Create a common error type that all other errors are wrapped in
* Move app error messages into common location
* Build a "debug" message within the common error that contains utc time, error code, current step
  * so we can get better detail from errors created during parsing data (for instance) you can add a `step` to the error that will then be attached to the error in the appActions  
* Retain original error message so we don't loose any details
* Ensure wrapped error is also logged to server for consistency

I have asked the question about how we want to display these errors so its not overwhelming. I was thinking the message was the friendly part and then there was the debug with all the details we might want if the use sends in a screen shot. I was thinking of a modal but open to other suggestions.  
