### PR TITLE
invalid local timestamps as a separate upload

### DIFF
--- a/lib/carelink/basal.js
+++ b/lib/carelink/basal.js
@@ -18,11 +18,11 @@
 var common = require('./common.js');
 var parsing = require('./parsing.js');
 
-module.exports = function (timezone) {
+module.exports = function () {
   var parser = common.makeParser(
     {
       BasalProfileStart: [
-        common.makeCommonVals(timezone),
+        common.makeCommonVals(),
         {
           uploadSeqNum: parsing.asNumber('Raw-Seq Num'),
           deliveryType: 'scheduled',
@@ -31,7 +31,7 @@ module.exports = function (timezone) {
         }
       ],
       ChangeTempBasalPercent: [
-        common.makeCommonVals(timezone),
+        common.makeCommonVals(),
         {
           deliveryType: 'temp',
           percent: parsing.map(['Raw-Values', 'PERCENT_OF_RATE'], function(e){ return parseFloat(e) / 100.0; }),
@@ -39,7 +39,7 @@ module.exports = function (timezone) {
         }
       ],
       ChangeTempBasal: [
-        common.makeCommonVals(timezone),
+        common.makeCommonVals(),
         {
           deliveryType: 'temp',
           rate: parsing.asNumber(['Raw-Values', 'RATE']),

--- a/lib/carelink/bolusNWizard.js
+++ b/lib/carelink/bolusNWizard.js
@@ -21,18 +21,18 @@ var annotate = require('../eventAnnotations');
 var common = require('./common.js');
 var parsing = require('./parsing.js');
 
-module.exports = function(timezone, opts) {
+module.exports = function(opts) {
   var deliveredField = 'Bolus Volume Delivered (U)',
     selectedField = 'Bolus Volume Selected (U)',
     uploadIdField = 'Raw-Upload ID',
     seqNumField = 'Raw-Seq Num';
 
-  var commonParser = common.makeCommonVals(timezone);
+  var commonParser = common.makeCommonVals();
 
   var parser = common.makeParser(
     {
       'BolusNormal': [
-        common.makeCommonVals(timezone),
+        common.makeCommonVals(),
         {
           type: 'bolusNormal',
           subType: 'normal',
@@ -44,7 +44,7 @@ module.exports = function(timezone, opts) {
         }
       ],
       'BolusSquare': [
-        common.makeCommonVals(timezone),
+        common.makeCommonVals(),
         {
           type: 'bolusSquare',
           subType: 'square',
@@ -66,7 +66,7 @@ module.exports = function(timezone, opts) {
         }
       ],
       'BolusWizardBolusEstimate': [
-        common.makeCommonVals(timezone),
+        common.makeCommonVals(),
         {
           type: 'wizard',
           uploadId: parsing.extract(uploadIdField),

--- a/lib/carelink/carelinkSimulator.js
+++ b/lib/carelink/carelinkSimulator.js
@@ -370,11 +370,21 @@ exports.make = function(config){
       if (currSchedule == null || currSchedule.length === 0) {
         if (event.duration == null) {
           event.duration = 0;
-          annotateEvent(event, 'basal/unknown-duration');
+          var nullDurationBasal = bob.makeScheduledBasal()
+            .set('deviceId', event.deviceId)
+            .with_time(event.time)
+            .with_timezoneOffset(event.timezoneOffset)
+            .with_deviceTime(event.deviceTime)
+            .with_rate(event.rate)
+            .with_scheduleName(event.scheduleName)
+            .with_payload(event.payload)
+            .with_duration(event.duration);
+          annotateEvent(nullDurationBasal, 'basal/unknown-duration');
           if (currBasal != null) {
-            event.previous = _.omit(currBasal, 'previous');
+            nullDurationBasal.with_previous(_.omit(currBasal, 'previous'));
           }
-          currBasal = addEvent(bob.makeScheduledBasal(), _.omit(event, 'uploadSeqNum'));
+          currBasal = nullDurationBasal.done();
+          events.push(currBasal);
           return;
         }
       } else {

--- a/lib/carelink/cbg.js
+++ b/lib/carelink/cbg.js
@@ -18,9 +18,9 @@
 var common = require('./common.js');
 var parsing = require('./parsing.js');
 
-module.exports = function (timezone, opts) {
+module.exports = function (opts) {
   var cbgSpec = [
-    common.makeCommonVals(timezone),
+    common.makeCommonVals(),
     {
       value: parsing.asNumber(opts.colNames.sensorGlucose),
       units: opts.units

--- a/lib/carelink/common.js
+++ b/lib/carelink/common.js
@@ -129,6 +129,22 @@ exports.convertBackToMmol = function(n) {
   return Math.floor(inMmol * 10 + 0.5) / 10;
 };
 
+// a timestamp between e.g., 2-3 a.m. on March 8th, 2015 in any U.S. timezone
+// is invalid (because of the change to Daylight Time at 2 a.m., when the clock jumps
+// straight to 3 a.m.)
+// this function identifies such timestamps
+// it doesn't really belong in sundial because the long-term solution to this kind of
+// problem is to "bootstrap" properly into UTC
+exports.isValidLocalTimestamp = function(deviceTime, utcTime, prescribedOffset) {
+  var conversionOffset = -(Date.parse(utcTime) - Date.parse(deviceTime + '.000Z'))/sundial.MIN_TO_MSEC;
+  if (prescribedOffset !== conversionOffset) {
+    return false;
+  }
+  else {
+    return true;
+  }
+};
+
 // TODO: delete after conclusion of Jaeb study
 exports.mergeJaebPayloads = function(obj1, obj2) {
   if (!_.isEmpty(obj1.jaebPayload) && !_.isEmpty(obj2.jaebPayload)) {

--- a/lib/carelink/common.js
+++ b/lib/carelink/common.js
@@ -26,15 +26,13 @@ exports.autoGenModels = {
   'Paradigm 722': true
 };
 
-exports.makeCommonVals = function(timezone){
+exports.makeCommonVals = function(){
   return function (line) {
-    var deviceTime = sundial.formatDeviceTime(line.deviceTime);
-    var time = sundial.applyTimezone(deviceTime, timezone).toISOString();
 
     return {
-      deviceTime: deviceTime,
-      time: time,
-      timezoneOffset: sundial.getOffsetFromZone(time, timezone),
+      deviceTime: line.deviceTime,
+      time: line.time,
+      timezoneOffset: line.timezoneOffset,
       deviceId: line['Raw-Device Type'] + '-=-' + line['Raw-Upload ID'],
       // TODO: delete after conclusion of Jaeb study
       jaebPayload: {

--- a/lib/carelink/settings.js
+++ b/lib/carelink/settings.js
@@ -192,13 +192,13 @@ function buildWizardChange(data, range, id){
   return retVal;
 }
 
-module.exports = function (timezone, opts) {
+module.exports = function (opts) {
   if (opts.units === 'mmol/L') {
     bgConversionFn = common.convertBackToMmol;
   }
   entryParser = makeEntryParser();
 
-  var commonParser = common.makeCommonVals(timezone);
+  var commonParser = common.makeCommonVals();
 
   var cachedObjects = null;
   var pointer = 0;

--- a/lib/carelink/smbg.js
+++ b/lib/carelink/smbg.js
@@ -18,12 +18,12 @@
 var common = require('./common.js');
 var parsing = require('./parsing.js');
 
-module.exports = function (timezone, opts) {
+module.exports = function (opts) {
 
   var parser = common.makeParser(
     {
       CalBGForPH: [
-        common.makeCommonVals(timezone),
+        common.makeCommonVals(),
         {
           units: opts.units,
           value: parsing.asNumber(opts.colNames.CalBGForPH)

--- a/lib/carelink/suspend.js
+++ b/lib/carelink/suspend.js
@@ -21,11 +21,11 @@ var util = require('util');
 var common = require('./common.js');
 var parsing = require('./parsing.js');
 
-module.exports = function (timezone) {
+module.exports = function () {
   var parser = common.makeParser(
     {
       ChangeSuspendEnable: [
-        common.makeCommonVals(timezone),
+        common.makeCommonVals(),
         {
           payload: parsing.map(['Raw-Values', 'ENABLE'], function(reason){
             switch(reason) {

--- a/lib/carelink/timeChange.js
+++ b/lib/carelink/timeChange.js
@@ -18,11 +18,11 @@
 var common = require('./common.js');
 var parsing = require('./parsing.js');
 
-module.exports = function (timezone) {
+module.exports = function () {
   var parser = common.makeParser(
     {
       ChangeTime: [
-        common.makeCommonVals(timezone),
+        common.makeCommonVals(),
         {
           timestamp: parsing.asNumber(['Raw-Values', 'NEW_TIME'])
         }

--- a/lib/drivers/carelinkDriver.js
+++ b/lib/drivers/carelinkDriver.js
@@ -290,7 +290,7 @@ module.exports = function(simulatorMaker, api){
               autoGenScheduleds: common.autoGenModels[thisKey] ? true : false,
               defaults: {
                 source: 'carelink',
-                annotations: [{code: 'spring-forward'}]
+                annotations: [{code: 'spring-forward'}, {code: 'possible-duplicate'}]
               }
             }),
             processors: initializeProcessors({model: thisKey, units: units, colNames: colNames}),

--- a/lib/drivers/carelinkDriver.js
+++ b/lib/drivers/carelinkDriver.js
@@ -174,6 +174,7 @@ module.exports = function(simulatorMaker, api){
         });
         payload.colLabels = parsed.meta;
         payload.theData = [];
+        payload.invalidTimestampData = [];
 
         for (var i = 0; i < parsed.data.length; ++i) {
           convertRawValues(parsed.data[i]);
@@ -186,7 +187,7 @@ module.exports = function(simulatorMaker, api){
             payload.theData.push(parsed.data[i]);
           }
           else {
-            console.warn('Removed invalid local timestamp for selected timezone:', parsed.data[i].deviceTime);
+            payload.invalidTimestampData.push(parsed.data[i]);
           }
         }
         delete parsed.data;
@@ -276,7 +277,22 @@ module.exports = function(simulatorMaker, api){
             device.data.push(payload.theData[k]);
           }
         }
+        if (!_.isEmpty(payload.invalidTimestampData)) {
+          // technically this wouldn't cover the case where someone uploads twice within
+          // the hour that results in invalid local timestamps
+          // but that circumstance is surely vanishingly rare
+          var thisKey = payload.invalidTimestampData[0]['Raw-Device Type'];
+          payload.devices['invalidLocalTimstamp'] = {
+            simulator: simulatorMaker.make({
+              autoGenScheduleds: common.autoGenModels[thisKey] ? true : false,
+              defaults: { source: 'carelink' }
+            }),
+            processors: initializeProcessors({model: thisKey, units: units, colNames: colNames}),
+            data: payload.invalidTimestampData
+          };
+        }
         delete payload.theData;
+        delete payload.invalidTimestampData;
 
         progress(100);
         Object.keys(payload.devices).forEach(function(device){

--- a/lib/drivers/carelinkDriver.js
+++ b/lib/drivers/carelinkDriver.js
@@ -179,9 +179,15 @@ module.exports = function(simulatorMaker, api){
           convertRawValues(parsed.data[i]);
           parsed.data[i].dateObj = sundial.parseFromFormat(parsed.data[i]['Timestamp'], CARELINK_TS_FORMAT);
           parsed.data[i].deviceTime = sundial.formatDeviceTime(parsed.data[i].dateObj);
-          parsed.data[i].time = sundial.applyTimezone(parsed.data[i].deviceTime, cfg.timezone).toISOString();
+          var localDate = sundial.applyTimezone(parsed.data[i].deviceTime, cfg.timezone);
+          parsed.data[i].time = localDate.toISOString();
           parsed.data[i].timezoneOffset = sundial.getOffsetFromZone(parsed.data[i].time, cfg.timezone);
-          payload.theData.push(parsed.data[i]);
+          if (common.isValidLocalTimestamp(parsed.data[i].deviceTime, parsed.data[i].time, parsed.data[i].timezoneOffset)) {
+            payload.theData.push(parsed.data[i]);
+          }
+          else {
+            console.warn('Removed invalid local timestamp for selected timezone:', parsed.data[i].deviceTime);
+          }
         }
         delete parsed.data;
 

--- a/lib/drivers/carelinkDriver.js
+++ b/lib/drivers/carelinkDriver.js
@@ -187,6 +187,9 @@ module.exports = function(simulatorMaker, api){
             payload.theData.push(parsed.data[i]);
           }
           else {
+            // add a millisecond to all invalid timestamps to differentiate them
+            // and avoid potential duplicate clashes
+            parsed.data[i].time = localDate.toISOString().replace('.000Z', '.001Z');
             payload.invalidTimestampData.push(parsed.data[i]);
           }
         }

--- a/lib/drivers/carelinkDriver.js
+++ b/lib/drivers/carelinkDriver.js
@@ -49,18 +49,18 @@ function convertRawValues(e) {
   return e;
 }
 
-function initializeProcessors(timezone, opts) {
+function initializeProcessors(opts) {
   // Order of these matters, each processor delivers events to the simulator, so the order that the processors
   // are visited determines the order that events will be delivered to the simulator.  Keep this in mind when
   // re-ordering.
   return [
-    require('../carelink/settings.js')(timezone, opts),
-    require('../carelink/smbg.js')(timezone, opts),
-    require('../carelink/cbg.js')(timezone, opts),
-    require('../carelink/basal.js')(timezone),
-    require('../carelink/suspend.js')(timezone),
-    require('../carelink/bolusNWizard')(timezone, opts),
-    require('../carelink/timeChange')(timezone, opts)
+    require('../carelink/settings.js')(opts),
+    require('../carelink/smbg.js')(opts),
+    require('../carelink/cbg.js')(opts),
+    require('../carelink/basal.js')(),
+    require('../carelink/suspend.js')(),
+    require('../carelink/bolusNWizard')(opts),
+    require('../carelink/timeChange')(opts)
   ];
 }
 
@@ -173,21 +173,26 @@ module.exports = function(simulatorMaker, api){
           dynamicTyping: true
         });
         payload.colLabels = parsed.meta;
-        payload.theData = parsed.data;
+        payload.theData = [];
 
-        for (var i = 0; i < payload.theData.length; ++i) {
-          convertRawValues(payload.theData[i]);
-          payload.theData[i].deviceTime = sundial.parseFromFormat(payload.theData[i]['Timestamp'], CARELINK_TS_FORMAT);
+        for (var i = 0; i < parsed.data.length; ++i) {
+          convertRawValues(parsed.data[i]);
+          parsed.data[i].dateObj = sundial.parseFromFormat(parsed.data[i]['Timestamp'], CARELINK_TS_FORMAT);
+          parsed.data[i].deviceTime = sundial.formatDeviceTime(parsed.data[i].dateObj);
+          parsed.data[i].time = sundial.applyTimezone(parsed.data[i].deviceTime, cfg.timezone).toISOString();
+          parsed.data[i].timezoneOffset = sundial.getOffsetFromZone(parsed.data[i].time, cfg.timezone);
+          payload.theData.push(parsed.data[i]);
         }
+        delete parsed.data;
 
         payload.theData = _.filter(payload.theData, function(datum) {
           return typesToRead[datum['Raw-Type']];
         });
 
         payload.theData.sort(function(lhs, rhs){
-          if (lhs.deviceTime < rhs.deviceTime) {
+          if (lhs.dateObj < rhs.dateObj) {
             return -1;
-          } else if (lhs.deviceTime > rhs.deviceTime) {
+          } else if (lhs.dateObj > rhs.dateObj) {
             return 1;
           } else if (lhs['Raw-ID'] < rhs['Raw-ID']) {
             return -1;
@@ -257,7 +262,7 @@ module.exports = function(simulatorMaker, api){
                 autoGenScheduleds: common.autoGenModels[key] ? true : false,
                 defaults: { source: 'carelink' }
               });
-            device.processors = initializeProcessors(cfg.timezone, {model: key, units: units, colNames: colNames});
+            device.processors = initializeProcessors({model: key, units: units, colNames: colNames});
 
             device.data = [];
           }

--- a/lib/drivers/carelinkDriver.js
+++ b/lib/drivers/carelinkDriver.js
@@ -288,7 +288,10 @@ module.exports = function(simulatorMaker, api){
           payload.devices['invalidLocalTimstamp'] = {
             simulator: simulatorMaker.make({
               autoGenScheduleds: common.autoGenModels[thisKey] ? true : false,
-              defaults: { source: 'carelink' }
+              defaults: {
+                source: 'carelink',
+                annotations: [{code: 'spring-forward'}]
+              }
             }),
             processors: initializeProcessors({model: thisKey, units: units, colNames: colNames}),
             data: payload.invalidTimestampData

--- a/lib/objectBuilder.js
+++ b/lib/objectBuilder.js
@@ -55,7 +55,7 @@ module.exports = function () {
     timezoneOffset: REQUIRED
   };
   function setDefaults(info) {
-    deviceInfo = _.assign({}, deviceInfo, _.pick(info, 'deviceId', 'source', 'timezoneOffset'));
+    deviceInfo = _.assign({}, deviceInfo, _.pick(info, 'deviceId', 'source', 'timezoneOffset', 'annotations'));
   }
 
   function _createObject() {

--- a/test/carelink/testCommon.js
+++ b/test/carelink/testCommon.js
@@ -111,4 +111,25 @@ describe('common', function() {
       expect(String(common.convertBackToMmol(99.08))).to.equal('5.5');
     });
   });
+
+  describe('isValidLocalTimestamp', function() {
+    it('should be a function', function() {
+      expect(common.isValidLocalTimestamp).to.exist;
+      expect(typeof common.isValidLocalTimestamp).to.equal('function');
+    });
+
+    it('should return true when local timestamp is not in DST no man\'s land', function() {
+      var deviceTime = '2015-01-01T00:00:00';
+      var utcTime = '2015-01-01T05:00:00.000Z';
+      var prescribedOffset = -300;
+      expect(common.isValidLocalTimestamp(deviceTime, utcTime, prescribedOffset)).to.be.true;
+    });
+
+    it('should return false when local timestamp is in DST no man\'s land', function() {
+      var deviceTime = '2015-03-08T02:05:00';
+      var utcTime = '2015-03-08T07:05:00.000Z';
+      var prescribedOffset = -240;
+      expect(common.isValidLocalTimestamp(deviceTime, utcTime, prescribedOffset)).to.be.false;
+    });
+  });
 });


### PR DESCRIPTION
OK, so now I think this is the better solution than #88. We add a millisecond (by simple string substitution - replacing .000Z with .001Z - because we never have millisecond info from CareLink timestamps) to all the timestamps that are invalid in the chosen timezone to prevent duplicates, then upload all these as a separate "device" to prevent the simulator from crashing on overlapping data. This does mean there will be an additional upload metadata object for users whose data has this problem, but I don't actually think that's a bad thing.

This involved adding the ability to set a default annotation (the text for which will not appear in blip until a tideline change goes through), which is something we may or may not want to keep in the long term.

CC @kentquirk 