### PR TITLE
fix issues around (U.S.) DST changeover for Dexcom

### DIFF
--- a/lib/carelink/common.js
+++ b/lib/carelink/common.js
@@ -131,6 +131,22 @@ exports.convertBackToMmol = function(n) {
   return Math.floor(inMmol * 10 + 0.5) / 10;
 };
 
+// a timestamp between e.g., 2-3 a.m. on March 8th, 2015 in any U.S. timezone
+// is invalid (because of the change to Daylight Time at 2 a.m., when the clock jumps
+// straight to 3 a.m.)
+// this function identifies such timestamps
+// it doesn't really belong in sundial because the long-term solution to this kind of
+// problem is to "bootstrap" properly into UTC
+exports.isValidLocalTimestamp = function(deviceTime, utcTime, prescribedOffset) {
+  var conversionOffset = -(Date.parse(utcTime) - Date.parse(deviceTime + '.000Z'))/sundial.MIN_TO_MSEC;
+  if (prescribedOffset !== conversionOffset) {
+    return false;
+  }
+  else {
+    return true;
+  }
+};
+
 // TODO: delete after conclusion of Jaeb study
 exports.mergeJaebPayloads = function(obj1, obj2) {
   if (!_.isEmpty(obj1.jaebPayload) && !_.isEmpty(obj2.jaebPayload)) {

--- a/lib/drivers/dexcomDriver.js
+++ b/lib/drivers/dexcomDriver.js
@@ -645,7 +645,6 @@ module.exports = function (config) {
       }
       if (datum.annotation) {
         annotate.annotateEvent(cbg, datum.annotation);
-        console.log(cbg);
       }
       dataToPost.push(cbg);
     }

--- a/lib/drivers/dexcomDriver.js
+++ b/lib/drivers/dexcomDriver.js
@@ -19,6 +19,7 @@ var _ = require('lodash');
 var async = require('async');
 var sundial = require('sundial');
 var annotate = require('../eventAnnotations');
+var common = require('../carelink/common');
 
 var crcCalculator = require('../crc.js');
 var struct = require('../struct.js')();
@@ -199,6 +200,11 @@ module.exports = function (config) {
       rec.internalTime = sundial.formatDeviceTime(new Date(rec.systemTimeMsec).toISOString());
       rec.displayTime = sundial.formatDeviceTime(new Date(rec.displayTimeMsec).toISOString());
       rec.displayUtc = sundial.applyTimezone(rec.displayTime, cfg.timezone).toISOString();
+      if (!common.isValidLocalTimestamp(rec.displayTime, rec.displayUtc, sundial.getOffsetFromZone(rec.displayUtc, cfg.timezone))) {
+        rec.displayUtc = rec.displayUtc.replace('.000Z', '.001Z');
+        rec.annotation = {code: 'spring-forward'};
+      }
+
       rec.data = data.subarray(ctr, ctr + flen);
       ctr += flen;
 
@@ -575,7 +581,7 @@ module.exports = function (config) {
       for (var j = 0; j < page.data.length; ++j) {
         var reading = _.pick(page.data[j],
                              'displaySeconds', 'displayTime', 'displayUtc', 'internalTime', 'systemSeconds',
-                             'glucose', 'trendArrow', 'trendText');
+                             'glucose', 'trendArrow', 'trendText', 'annotation');
         reading.pagenum = page.header.pagenum;
         readings.push(reading);
       }
@@ -636,6 +642,10 @@ module.exports = function (config) {
         .done();
       if (annotation) {
         annotate.annotateEvent(cbg, annotation);
+      }
+      if (datum.annotation) {
+        annotate.annotateEvent(cbg, datum.annotation);
+        console.log(cbg);
       }
       dataToPost.push(cbg);
     }

--- a/lib/drivers/dexcomDriver.js
+++ b/lib/drivers/dexcomDriver.js
@@ -787,6 +787,16 @@ module.exports = function (config) {
       data.cbg_data = processEGVPages(data.egv_data);
       data.calibration_data = processMeterPages(data.meter_data);
       data.post_records = prepCBGData(data);
+      data.post_records = _.map(data.post_records, function(datum) {
+        // when we screwed up data around the change to DST in 2015, we were hardcoding
+        // a timezone of US/Pacific for everyone, so this is the only UTC interval that matters
+        // TODO: delete when this is guaranteed to not be an issue anymore
+        // should be around mid-April 2015 since Dexcom receivers only store ~30 days data
+        if (datum.time >= '2015-03-08T10:00:00.000Z' && datum.time < '2015-03-08T11:00:00.000Z') {
+          datum._forceUpdate = true;
+        }
+        return datum;
+      });
       data.post_records = data.post_records.concat(prepMeterData(data));
       var ids = {};
       for (var i = 0; i < data.post_records.length; ++i) {


### PR DESCRIPTION
This PR depends on [jellyfish 58](https://github.com/tidepool-org/jellyfish/pull/58). It allows us to recover data that wasn't uploaded due to invalid timestamps (given the hardcoded timezone) and uses the same "add a millisecond" strategy as #91 to differentiate "identical" UTC timestamps.

It depends on the jellyfish PR because sometimes the invalid member of the pair was uploaded (without the millisecond addition), and so we needed to force storage of a new version of all the datapoints within the one-hour UTC that produced a data overlap.

I've tested this on my own receiver that suffered from this problem, and it fixes the data exactly as expected.