### PR TITLE
fudge a millisecond only on spring forward overlap datapoints that would have been dropped before

### DIFF
--- a/lib/drivers/dexcomDriver.js
+++ b/lib/drivers/dexcomDriver.js
@@ -20,6 +20,7 @@ var async = require('async');
 var sundial = require('sundial');
 var annotate = require('../eventAnnotations');
 var common = require('../carelink/common');
+var util = require('util');
 
 var crcCalculator = require('../crc.js');
 var struct = require('../struct.js')();
@@ -200,10 +201,6 @@ module.exports = function (config) {
       rec.internalTime = sundial.formatDeviceTime(new Date(rec.systemTimeMsec).toISOString());
       rec.displayTime = sundial.formatDeviceTime(new Date(rec.displayTimeMsec).toISOString());
       rec.displayUtc = sundial.applyTimezone(rec.displayTime, cfg.timezone).toISOString();
-      if (!common.isValidLocalTimestamp(rec.displayTime, rec.displayUtc, sundial.getOffsetFromZone(rec.displayUtc, cfg.timezone))) {
-        rec.displayUtc = rec.displayUtc.replace('.000Z', '.001Z');
-        rec.annotation = {code: 'spring-forward'};
-      }
 
       rec.data = data.subarray(ctr, ctr + flen);
       ctr += flen;
@@ -631,6 +628,9 @@ module.exports = function (config) {
           threshold: 400
         };
       }
+      if (!common.isValidLocalTimestamp(datum.displayTime, datum.displayUtc, sundial.getOffsetFromZone(datum.displayUtc, cfg.timezone))) {
+        datum.annotation = {code: 'spring-forward'};
+      }
       var payload = { trend: datum.trendText, internalTime: datum.internalTime };
       var cbg = cfg.builder.makeCBG()
         .with_value(datum.glucose)
@@ -645,6 +645,7 @@ module.exports = function (config) {
       }
       if (datum.annotation) {
         annotate.annotateEvent(cbg, datum.annotation);
+        cbg._forceUpdate = true;
       }
       dataToPost.push(cbg);
     }
@@ -786,24 +787,22 @@ module.exports = function (config) {
       data.cbg_data = processEGVPages(data.egv_data);
       data.calibration_data = processMeterPages(data.meter_data);
       data.post_records = prepCBGData(data);
-      data.post_records = _.map(data.post_records, function(datum) {
-        // when we screwed up data around the change to DST in 2015, we were hardcoding
-        // a timezone of US/Pacific for everyone, so this is the only UTC interval that matters
-        // TODO: delete when this is guaranteed to not be an issue anymore
-        // should be around mid-April 2015 since Dexcom receivers only store ~30 days data
-        if (datum.time >= '2015-03-08T10:00:00.000Z' && datum.time < '2015-03-08T11:00:00.000Z') {
-          datum._forceUpdate = true;
-        }
-        return datum;
-      });
       data.post_records = data.post_records.concat(prepMeterData(data));
       var ids = {};
       for (var i = 0; i < data.post_records.length; ++i) {
         var id = data.post_records[i].time + '|' + data.post_records[i].deviceId;
         if (ids[id]) {
-          debug('duplicate! %s @ %d == %d', id, i, ids[id] - 1);
-          debug(data.post_records[ids[id] - 1]);
-          debug(data.post_records[i]);
+          debug(util.format('duplicate! %s @ %d == %d', id, i, ids[id] - 1));
+          var first = data.post_records[ids[id] - 1];
+          var second = data.post_records[i];
+          debug(first);
+          debug(second);
+          if (!common.isValidLocalTimestamp(first.deviceTime, first.time, sundial.getOffsetFromZone(first.time, cfg.timezone))) {
+            second.time = second.time.replace('.000Z', '.001Z');
+          }
+          else {
+            first.time = first.time.replace('.000Z', '.001Z');
+          }
         } else {
           ids[id] = i + 1;
         }


### PR DESCRIPTION
So I think this actually accomplishes the original goal of completely fixing the data. I really need to test on B's receiver again to be sure, but I think I'm now always only fudging a millisecond on the datapoint that was considered a duplicate before (and thus not stored). (I think I can guarantee this because I found the code where @kentquirk was logging duplicates, and I'm leveraging the order the "pairs" come in, which is deterministic across multiple uploads from the same receiver, but *not* deterministic in terms of which of the pair comes "first.")