### PR TITLE
regroup alarm switch statement according to proper alarmTypes

### DIFF
--- a/lib/drivers/insuletDriver.js
+++ b/lib/drivers/insuletDriver.js
@@ -424,17 +424,17 @@ module.exports = function (config) {
     AlrmHAZ_PUMP_VOL: { value: 14, name: 'AlrmHAZ_PUMP_VOL', explanation: 'empty reservoir', stopsDelivery: true },
     AlrmHAZ_PUMP_AUTO_OFF: { value: 15, name: 'AlrmHAZ_PUMP_AUTO_OFF', explanation: 'auto-off', stopsDelivery: true },
     AlrmHAZ_PUMP_EXPIRED: { value: 16, name: 'AlrmHAZ_PUMP_EXPIRED', explanation: 'pod expired', stopsDelivery: true },
-    AlrmHAZ_OCCL: { value: 17, name: 'AlrmHAZ_OCCL', explanation: 'pump site occluded', stopsDelivery: true },
-    AlrmHAZ_ACTIVATE: { value: 18, name: 'AlrmHAZ_ACTIVATE', explanation: 'pod is a lump of coal', stopsDelivery: false },
-    AlrmKEY: { value: 21, name: 'AlrmKEY', explanation: 'PDM stuck key detected', stopsDelivery: false },
+    AlrmHAZ_PUMP_OCCL: { value: 17, name: 'AlrmHAZ_PUMP_OCCL', explanation: 'pump site occluded', stopsDelivery: true },
+    AlrmHAZ_PUMP_ACTIVATE: { value: 18, name: 'AlrmHAZ_PUMP_ACTIVATE', explanation: 'pod is a lump of coal', stopsDelivery: false },
+    AlrmADV_KEY: { value: 21, name: 'AlrmADV_KEY', explanation: 'PDM stuck key detected', stopsDelivery: false },
     AlrmADV_PUMP_VOL: { value: 23, name: 'AlrmADV_PUMP_VOL', explanation: 'low reservoir', stopsDelivery: false },
     AlrmADV_PUMP_AUTO_OFF: { value: 24, name: 'AlrmADV_PUMP_AUTO_OFF', explanation: '15 minutes to auto-off warning', stopsDelivery: false },
     AlrmADV_PUMP_SUSPEND: { value: 25, name: 'AlrmADV_PUMP_SUSPEND', explanation: 'suspend done', stopsDelivery: false },
     AlrmADV_PUMP_EXP1: { value: 26, name: 'AlrmADV_PUMP_EXP1', explanation: 'pod expiration advisory', stopsDelivery: false },
     AlrmADV_PUMP_EXP2: { value: 27, name: 'AlrmADV_PUMP_EXP2', explanation: 'pod expiration alert', stopsDelivery: false },
     AlrmSYSTEM_ERROR28: { value: 28, name: 'AlrmSYSTEM_ERROR28', explanation: 'system error', stopsDelivery: 'unknown' },
-    AlrmEXPIRATION: { value: 37, name: 'AlrmEXPIRATION', explanation: 'pod expiration advisory', stopsDelivery: false },
-    AlrmPDM_AUTO_OFF: { value: 39, name: 'AlrmPDM_AUTO_OFF', explanation: 'auto-off', stopsDelivery: true }
+    AlrmEXP_WARNING: { value: 37, name: 'AlrmEXP_WARNING', explanation: 'pod expiration advisory', stopsDelivery: false },
+    AlrmHAZ_PDM_AUTO_OFF: { value: 39, name: 'AlrmHAZ_PDM_AUTO_OFF', explanation: 'auto-off', stopsDelivery: true }
   };
 
   var LOG_ERRORS = {
@@ -776,9 +776,10 @@ module.exports = function (config) {
       }
       var alarmText = getNameForValue(ALARM_TYPES, alarmValue);
       switch (alarmValue) {
+        // alarmType `other`
         // History - ALARM
-        case ALARM_TYPES.AlrmKEY.value:
-        case ALARM_TYPES.AlrmEXPIRATION.value:
+        case ALARM_TYPES.AlrmADV_KEY.value:
+        case ALARM_TYPES.AlrmEXP_WARNING.value:
         case ALARM_TYPES.AlrmSYSTEM_ERROR10.value:
         case ALARM_TYPES.AlrmSYSTEM_ERROR12.value:
         case ALARM_TYPES.AlrmSYSTEM_ERROR28.value:
@@ -794,8 +795,8 @@ module.exports = function (config) {
         case ALARM_TYPES.AlrmPDM_ERROR9.value:
         // History - REMOTE HAZ
         case ALARM_TYPES.AlrmHAZ_REMOTE.value:
-        case ALARM_TYPES.AlrmHAZ_ACTIVATE.value:
-        case ALARM_TYPES.AlrmADV_PUMP_VOL.value:
+        case ALARM_TYPES.AlrmHAZ_PUMP_ACTIVATE.value:
+        case ALARM_TYPES.AlrmADV_PUMP_AUTO_OFF.value:
         case ALARM_TYPES.AlrmADV_PUMP_SUSPEND.value:
         case ALARM_TYPES.AlrmADV_PUMP_EXP1.value:
         case ALARM_TYPES.AlrmADV_PUMP_EXP2.value:
@@ -807,17 +808,61 @@ module.exports = function (config) {
             })
             .done();
           break;
-        case ALARM_TYPES.AlrmPDM_AUTO_OFF.value:
         // Pump advisory and hazard alarm (non-History)
+        // alarmType `low_insulin`
+        case ALARM_TYPES.AlrmADV_PUMP_VOL.value:
+          postalarm = postalarm.with_alarmType('low_insulin')
+            .with_payload({
+              alarmText: alarmText,
+              explanation: ALARM_TYPES[alarmText].explanation,
+              stopsDelivery: ALARM_TYPES[alarmText].stopsDelivery
+            })
+            .done();
+          break;
+        // alarmType `no_insulin`
         case ALARM_TYPES.AlrmHAZ_PUMP_VOL.value:
+          postsuspend = makeSuspended(alarm);
+          postbasal = makeSuspendBasal(alarm);
+          postalarm = postalarm.with_alarmType('no_insulin')
+            .with_payload({
+              alarmText: getNameForValue(ALARM_TYPES, alarmValue),
+              explanation: ALARM_TYPES[alarmText].explanation,
+              stopsDelivery: ALARM_TYPES[alarmText].stopsDelivery
+            })
+            .with_status(postsuspend)
+            .done();
+          break;
+        // alarmType `occlusion`
+        case ALARM_TYPES.AlrmHAZ_PUMP_OCCL.value:
+          postsuspend = makeSuspended(alarm);
+          postbasal = makeSuspendBasal(alarm);
+          postalarm = postalarm.with_alarmType('occlusion')
+            .with_payload({
+              alarmText: getNameForValue(ALARM_TYPES, alarmValue),
+              explanation: ALARM_TYPES[alarmText].explanation,
+              stopsDelivery: ALARM_TYPES[alarmText].stopsDelivery
+            })
+            .with_status(postsuspend)
+            .done();
+          break;
+        // alarmType `no_delivery`
+        case ALARM_TYPES.AlrmHAZ_PUMP_EXPIRED.value:
+          postsuspend = makeSuspended(alarm);
+          postbasal = makeSuspendBasal(alarm);
+          postalarm = postalarm.with_alarmType('no_delivery')
+            .with_payload({
+              alarmText: getNameForValue(ALARM_TYPES, alarmValue),
+              explanation: ALARM_TYPES[alarmText].explanation,
+              stopsDelivery: ALARM_TYPES[alarmText].stopsDelivery
+            })
+            .with_status(postsuspend)
+            .done();
+          break;
+        // alarmType `auto_off`
+        case ALARM_TYPES.AlrmHAZ_PDM_AUTO_OFF.value:
         // TODO: clarify with Insulet or get data to figure out whether this (below) is
         // a warning or the actual auto-off; the spec is confused
         case ALARM_TYPES.AlrmHAZ_PUMP_AUTO_OFF.value:
-        case ALARM_TYPES.AlrmHAZ_PUMP_EXPIRED.value:
-        case ALARM_TYPES.AlrmHAZ_OCCL.value:
-        // TODO: clarify with Insulet or get data to figure out whether this (below) is
-        // a warning or the actual auto-off; the spec is confused
-        case ALARM_TYPES.AlrmADV_PUMP_AUTO_OFF.value:
           postsuspend = makeSuspended(alarm);
           postbasal = makeSuspendBasal(alarm);
           postalarm = postalarm.with_alarmType('auto_off')


### PR DESCRIPTION
At some point the switch statement for Insulet alarms got consolidated a bit *too much* - almost everything was getting created an an `other` alarmType, which is incorrect.

I also changed some of the alarm names again to match the spec exactly - it's too confusing for me looking back and forth when trying to verify that everything is being handled if they aren't exactly the same.

Discovered this in the course of working on the UTC bootstrapping because there are some challenges dealing with the alarms and their timestamps...

I'd like to get this in ASAP, so whoever can get to it @jh-bate @kentquirk?