### PR TITLE
update lodash to v3.6.0

### DIFF
--- a/lib/core/getIn.js
+++ b/lib/core/getIn.js
@@ -31,7 +31,7 @@ module.exports = function(obj, props, notFound) {
     }
 
     var child = state.child;
-    if (!_.has(child, prop)) {
+    if (!_.includes(child, prop)) {
       return {
         child: notFound,
         isNotFound: true

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "babyparse": "0.4.1",
     "blueimp-md5": "1.1.0",
     "commander": "2.7.1",
-    "lodash": "2.4.1",
+    "lodash": "3.6.0",
     "moment-timezone": "0.3.0",
     "react": "0.12.0",
     "sundial": "1.1.8",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,6 @@ var config = {
   },
   resolve: {
     alias: {
-      lodash: 'lodash/dist/lodash.js',
       mock: './mock/empty.js'
     }
   }


### PR DESCRIPTION
What it says on the tin.

It was increasingly frustrating working with a 2.x version of lodash because they don't allow you to view the documentation for older versions and some method names have changed.