### PR TITLE
use node 0.12 in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "0.12"
 script:
 - npm run jshint
 - npm test


### PR DESCRIPTION
The latest production uploader was already built using node 0.12.0, so Travis should be using it too!

Ping @kentquirk for review/merge.