### PR TITLE
ensure delete of index at top level (should only be in payload.logIndices)

### DIFF
--- a/lib/drivers/abbottFreeStyle.js
+++ b/lib/drivers/abbottFreeStyle.js
@@ -533,7 +533,10 @@ module.exports = function (config) {
 
     processData: function (progress, data, cb) {
       progress(0);
-      data.post_records = prepBGData(progress, data);
+      data.post_records = _.map(prepBGData(progress, data), function(d) {
+        delete d.index;
+        return d;
+      });
       progress(100);
       data.processData = true;
       console.log(data);

--- a/lib/objectBuilder.js
+++ b/lib/objectBuilder.js
@@ -108,6 +108,10 @@ module.exports = function () {
         else if (self.index != null) {
           payload = self.payload === OPTIONAL ? {} : _.clone(self.payload);
           self.payload = _.assign({}, payload, {logIndices: [self.index]});
+        /* NB: make sure to delete the index at the top level of each object
+        / before uploading...unfortunately cannot do this here as some
+        / Insulet objects get entirely built before the simulator, but
+        / the simulator needs the index */
         }
         // TODO: end deletion
 


### PR DESCRIPTION
Index was appearing in two places for the PX data...

Also added a comment in the objectBuilder about why the deletion can't happen when `.done()` is called (because it took me a min to remember why I didn't put it there).