### PR TITLE
fix for CLI failure

### DIFF
--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -178,7 +178,7 @@ api.upload.accounts = function(happyCb, sadCb) {
   });
 };
 
-function postBlockToPlatform(data, groupId, callback) {
+function postBlockToPlatform(data, groupId, blockIndex, callback) {
 
   var recCount = data.length;
   var happy = function () {
@@ -210,7 +210,7 @@ function postBlockToPlatform(data, groupId, callback) {
     }
   };
 
-  api.log('postBlockToPlatform: using id ', groupId);
+  api.log('postBlockToPlatform #' + blockIndex + ': using id ', groupId);
 
   tidepool.uploadDeviceDataForUser(data, groupId, function(err, result) {
     if (err) {
@@ -232,11 +232,11 @@ api.upload.toPlatform = function(data, sessionInfo, progress, groupId, cb) {
   var post_and_progress = function (data, callback) {
     progress(nblocks++ * 100.0 / blocks.length);
     //off to the platfrom we go
-    return postBlockToPlatform(data, groupId, callback);
+    return postBlockToPlatform(data, groupId, nblocks, callback);
   };
 
   var post_upload_meta = function (uploadMeta, callback) {
-    return postBlockToPlatform(uploadMeta, groupId, callback);
+    return postBlockToPlatform(uploadMeta, groupId, 0, callback);
   };
 
   var decorate_uploadid = function (data, uploadItem) {

--- a/lib/drivers/carelinkDriver.js
+++ b/lib/drivers/carelinkDriver.js
@@ -334,7 +334,7 @@ module.exports = function(simulatorMaker, api){
         debug('Carelink UploadData!');
         payload.post_records = [];
 
-        async.map(Object.keys(payload.devices), function(key, done) {
+        async.eachSeries(Object.keys(payload.devices), function(key, done) {
           var deviceRecords = payload.devices[key].simulator.getEvents();
           var deviceIds = _.uniq(_.pluck(deviceRecords, 'deviceId'));
           var sessionInfo = {


### PR DESCRIPTION
This is a "fix" for the intermittent "jellyfish" error when loading large data files split into multiple "devices."

Trello cards: https://trello.com/c/dYxbiv6g (current), and https://trello.com/c/u0NToaWr (older)

I'm going to include as much info as possible in this PR description for posterity, since there are a lot of weird things going on here.

### Replicating the error

From what I've seen, the error seems to be replicable when you freshly (re)start jellyfish (using `tp_restart jellyfish`) and then try to load one of the large, multiple-"device" files from the CareLink CLI tool. Notably, if you (re)start jellyfish and then load a file without these attributes (smaller and not split into multiple "devices"), *then* try the large, multiple-"device" file, it *will* go through. This suggests that jellyfish is starting up in some kind of not-quite-right state such that it isn't able to handle the multiple requests of the multiple-"device" file until it has already processed some other request(s). This theory around how to replicate the error would also explain why we've never (to anyone's direct knowledge) seen this error happen through the uploader UI: even in a situation when the uploader is processing data from an account containing a large, multiple-"device" CareLink CSV, that is not the *first* thing the uploader asks jellyfish to do. The first thing jellyfish is asked to do is to fetch the CareLink file.

### Details on the error

When the data processing is split into multiple "devices," the uploader uses `async.map` to iterate through the devices asynchronously, for each first uploading the upload metadata and waiting for that to succeed, then uploading the remainder of the data. The error that takes down jellyfish manifests as empty request parameters on the second of these upload metadata requests. What is particularly strange is that the request parameters can be logged as non-empty [at the top level of the first function](https://github.com/tidepool-org/jellyfish/blob/master/lib/jellyfishService.js#L234) in jellyfish's `async.waterfall` sequence when processing a data upload POST, but attempting to log the same params [deeper in the same function](https://github.com/tidepool-org/jellyfish/blob/master/lib/jellyfishService.js#L240) (within the `gatekeeperClient` call) *fails*.

### Potential "solutions"

As a first pass at getting us beyond this error, @jh-bate and I discussed just checking for the empty params and returning an error. When I tried to implement that, jellyfish just died on a *different* error: `"Can't set headers after they are sent."` So I started investigating that error, and the general consensus seems to be that such an error is caused by double calls of a callback. In short: callback hell.

We use [async](https://github.com/caolan/async) for handling all our asynchronous requests to servers and within services like jellyfish. I started poking around async's issues to see if there might be anything listed about double calls of a callback, and there is. I came across [async #735](https://github.com/caolan/async/pull/735) first, and then also [async #559](https://github.com/caolan/async/issues/559) and [async #535](https://github.com/caolan/async/pull/535). There is much discussion in the latter two issues, including some controversy over whether the double calling of a callback is really undesirable behavior on the part of the async library or just a matter of the programmer "doing it wrong." Rather than facedown the prospect of combing through the complexities of our callback hell to find the issue, I looked for another solution. [This comment](https://github.com/caolan/async/pull/735#issuecomment-83111953) caught my attention since it suggests that the proposed fix was not even necessary for `async.waterfall` and `async.eachSeries`. So I decided to try dropping `async.eachSeries` in where the uploader code previously had `async.map` to deal with the multiple "devices", and *voila!* it seems to work reliably.

### Downsides of this "solution"

`async.eachSeries` differs from `async.map` in that it will not process the multiple "devices" in parallel, but wait for the first to finish uploading before starting the second, and so on. When a CareLink upload is split into multiple "devices," each "device" is not of equal size, but rather there is typically one very large "device" and one very small one. Because of this, we are not gaining much by uploading multiple "devices" in parallel, so I don't think the performance hit from using `async.eachSeries` will be very significant, if at all. @jh-bate and I both believe, also, that implementing "delta uploads" (already on the roadmap) will more than make up for the cost of this "solution."

(700+ word PR description for less than a half dozen lines of code. New record??)