### PR TITLE
small debug string creation fix

### DIFF
--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -68,8 +68,13 @@ appActions.errorStages = {
 };
 
 function extractMessage(err) {
+  // if err.message is an object, that's because it's an error from jellyfish
   if (typeof err.message === 'object' && err.message.message) {
     return err.message.message;
+  }
+  // sometimes the jellyfish errors don't have a `message`, only a `reason`?? *shrug*
+  else if (typeof err.message === 'object' && err.message.reason) {
+    return err.message.reason;
   }
   else {
     return err.message;


### PR DESCRIPTION
Discovered in the course of diagnosing issues with the OneTouch driver errors (not) surfacing.

Borked the commit message, should say: properly provide debug info for jellyfish messages with only a `reason` instead of a `message`.

Ping @jh-bate for a quick review.