### PR TITLE
upload target fix

### DIFF
--- a/lib/components/UploadSettings.jsx
+++ b/lib/components/UploadSettings.jsx
@@ -58,8 +58,8 @@ var UploadSettings = React.createClass({
     }
 
     var options = _.map(sortedGroups, function(group) {
-      //some people simply aren't `patients` and might be setup without data storage
-      if(_.isEmpty(group.profile.patient) || group.profile.patient.isOtherPerson){
+      // for child accounts
+      if (group.profile.patient.isOtherPerson){
         return (
           <option key={group.userid} value={group.userid}>{group.profile.patient.fullName}</option>
         );

--- a/lib/components/UploadSettings.jsx
+++ b/lib/components/UploadSettings.jsx
@@ -28,17 +28,18 @@ var UploadSettings = React.createClass({
   },
 
   availableUploadGroups: function(){
-    //can only upload for yourself
+    // can only upload for yourself
     if (_.isEmpty(this.props.user.uploadGroups) || this.props.user.uploadGroups.length <= 1) {
       return null;
     }
 
-    //only groups we can upload too, e.g. some people simply aren't `patients` and might be setup without data storage
+    // only groups we can upload to
+    // e.g. some people simply aren't `patients` and might be setup without data storage
     var available = _.filter(this.props.user.uploadGroups, function(group) {
       return _.isEmpty(group.profile.patient) === false;
     });
 
-    //and now return them sorted them by name
+    // and now return them sorted them by name
     return _.sortBy(available, function(group) {
       if (group.profile.patient.isOtherPerson) {
         return group.profile.patient.fullName;

--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -236,23 +236,26 @@ appActions.login = function(credentials, options, cb) {
   });
 };
 
-//make sure we have the correct default targetId
+// make sure we have the correct default targetId
 appActions._getDefaultTargetId = function(loggedInUser){
-  //default to the logged in users id
+  // default to the logged in user's id
   var userid = loggedInUser.userid;
 
-  //even though we have multiple groups there may still only be one upload account
-  if (_.isEmpty(loggedInUser.uploadGroups) === false || loggedInUser.uploadGroups.length > 1) {
+  var possibilities = _.filter(loggedInUser.uploadGroups, function(group) {
+    // if the account isn't marked with patient details we don't upload to it
+    return _.isEmpty(group.profile.patient) === false;
+  });
 
-    var possibilities = _.filter(loggedInUser.uploadGroups, function(group) {
-      //if the account isn't marked with patient details we don't upload to it
-      return _.isEmpty(group.profile) === false || _.isEmpty(group.profile.patient) === false;
-    });
-
-    //is there only one possible default?
-    if (possibilities.length === 1){
-      return possibilities[0].userid;
-    }
+  // is there only one possible default?
+  if (possibilities.length === 1) {
+    return possibilities[0].userid;
+  }
+  else if (possibilities.length === 0) {
+    // TODO: this should surface as a new app 'page' with an error message
+    // stating that the logged in user doesn't have data storage set up for his/herself
+    // nor upload permission to any other accounts
+    // then there should be a prompting to go to blip and set up data storage
+    console.warn(new Error('No data storage for logged in user and no permissions to upload for others!'));
   }
   return userid;
 };

--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -119,7 +119,7 @@ appActions.bindApp = function(app) {
 appActions.changeGroup = function(e) {
   var userid = e.target.value;
 
-  //reset upload state when changing group
+  // reset upload state when changing group
   for(var i in this.app.state.uploads) {
     appActions.reset(i);
   }
@@ -389,19 +389,19 @@ appActions._logError = function(error, friendlyMessage, properties) {
 appActions._mergeDevicesWithUploads = function(devices, uploads) {
   var self = this;
 
-  // Map connected devices to upload ids
+  // map connected devices to upload ids
   var connectedDeviceMap = _.reduce(devices, function(acc, d) {
     var upload = self._newUploadFromDevice(d);
     acc[self._getUploadId(upload)] = d;
     return acc;
   }, {});
 
-  // Work only on device uploads
+  // work only on device uploads
   var deviceUploads = _.filter(uploads, function(upload) {
     return upload.source.type === 'device';
   });
 
-  // Mark device uploads that are disconnected
+  // mark device uploads that are disconnected
   // and add any newly connected devices at the end of the list
   var newDeviceMap = _.clone(connectedDeviceMap);
   _.forEach(deviceUploads, function(upload) {
@@ -422,7 +422,7 @@ appActions._mergeDevicesWithUploads = function(devices, uploads) {
     deviceUploads.push(self._newUploadFromDevice(d));
   });
 
-  // Add back carelink upload at beginning of list
+  // add back CareLink upload at beginning of list
   var carelinkUpload = _.find(uploads, function(upload) {
     return upload.source.type === 'carelink';
   });
@@ -582,7 +582,7 @@ appActions._setUploadStart = function(uploadIndex, options) {
       percentage: 0
     };
 
-    // Remember carelink username we're uploading from
+    // remember CareLink username we're uploading from
     if (options.username) {
       progress.username = options.username;
     }
@@ -634,7 +634,7 @@ appActions._handleUploadError = function(uploadIndex, error) {
   var self = this;
   this._updateUpload(uploadIndex, function(upload) {
 
-    //log the errors
+    // log the errors
     self._logMetric(
       self.trackedState.UPLOAD_FAILED +' '+self._getUploadId(upload),
       {type: upload.source.type ,source:upload.source.driverId, error: error }

--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -246,7 +246,7 @@ appActions._getDefaultTargetId = function(loggedInUser){
 
     var possibilities = _.filter(loggedInUser.uploadGroups, function(group) {
       //if the account isn't marked with patient details we don't upload to it
-      return _.isEmpty(group.profile.patient) === false;
+      return _.isEmpty(group.profile) === false || _.isEmpty(group.profile.patient) === false;
     });
 
     //is there only one possible default?

--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -236,16 +236,39 @@ appActions.login = function(credentials, options, cb) {
   });
 };
 
+//make sure we have the correct default targetId
+appActions._getDefaultTargetId = function(loggedInUser){
+  //default to the logged in users id
+  var userid = loggedInUser.userid;
+
+  //even though we have multiple groups there may still only be one upload account
+  if (_.isEmpty(loggedInUser.uploadGroups) === false || loggedInUser.uploadGroups.length > 1) {
+
+    var possibilities = _.filter(loggedInUser.uploadGroups, function(group) {
+      //if the account isn't marked with patient details we don't upload to it
+      return _.isEmpty(group.profile.patient) === false;
+    });
+
+    //is there only one possible default?
+    if (possibilities.length === 1){
+      return possibilities[0].userid;
+    }
+  }
+  return userid;
+};
+
 appActions._afterLoginPage = function(user, cb) {
   var self = this;
 
+  var defaultTargetId = self._getDefaultTargetId(user);
   var devices = localStore.getItem('devices') || {};
-  var targetDevices = devices[user.userid];
+  var targetDevices = devices[defaultTargetId];
+
 
   if (!_.isEmpty(targetDevices)) {
     self.app.setState({
       user: user,
-      targetId: user.userid,
+      targetId: defaultTargetId,
       targetDevices: targetDevices,
       page: 'main'
     });
@@ -255,7 +278,7 @@ appActions._afterLoginPage = function(user, cb) {
 
   self.app.setState({
     user: user,
-    targetId: user.userid,
+    targetId: defaultTargetId,
     targetDevices: [],
     page: 'settings'
   });

--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -56,6 +56,7 @@ appActions.errorText = {
 appActions.errorStages = {
   STAGE_SETUP : { code: 'E_SETUP' , friendlyMessage: 'Error during setup' },
   STAGE_LOGIN : { code: 'E_LOGIN' , friendlyMessage: 'Error during login' },
+  STAGE_AFTER_LOGIN : { code: 'E_AFTER_LOGIN' , friendlyMessage: 'You have no upload access - please set up data storage in blip or ask for permission to upload to another person\'s account.' },
   STAGE_LOGOUT : { code: 'E_LOGOUT' , friendlyMessage: 'Error during logout' },
   STAGE_DETECT_DEVICES : { code: 'E_DETECTING_DEVICES' , friendlyMessage: 'Error detecting devices' },
   STAGE_PICK_FILE : { code: 'E_SELECTING_FILE' , friendlyMessage: 'Error during file selection' },
@@ -255,7 +256,9 @@ appActions._getDefaultTargetId = function(loggedInUser){
     // stating that the logged in user doesn't have data storage set up for his/herself
     // nor upload permission to any other accounts
     // then there should be a prompting to go to blip and set up data storage
-    console.warn(new Error('No data storage for logged in user and no permissions to upload for others!'));
+    var err = new Error('No data storage for logged in user and no permissions to upload for others!');
+    this.addMoreInfoToError(err, this.errorStages['STAGE_AFTER_LOGIN']);
+    console.warn(err.debug);
   }
   return userid;
 };

--- a/test/ui/testAppActions.js
+++ b/test/ui/testAppActions.js
@@ -75,7 +75,7 @@ describe('appActions', function() {
       api.user = {};
       api.user.account = function(cb) { cb(); };
       api.user.profile = function(cb) { cb(); };
-      api.user.getUploadGroups = function(cb) { cb(null,[{userid: '11'}]); };
+      api.user.getUploadGroups = function(cb) { cb(null,[{profile:{},userid: '11'}]); };
       api.setHosts = function() {};
     });
 
@@ -116,7 +116,7 @@ describe('appActions', function() {
       api.init = function(options, cb) { cb(null, {token: '1234'}); };
       api.user.account = function(cb) { cb(null, {userid: '11'}); };
       api.user.profile = function(cb) { cb(null, {fullName: 'bob'}); };
-      api.user.getUploadGroups = function(cb) { cb(null,[{userid: '11'},{userid: '13'}]); };
+      api.user.getUploadGroups = function(cb) { cb(null,[{profile:{},userid: '11'},{profile:{},userid: '13'}]); };
 
       appActions.load(function(err) {
         if (err) throw err;
@@ -129,7 +129,7 @@ describe('appActions', function() {
       api.init = function(options, cb) { cb(null, {token: '1234'}); };
       api.user.account = function(cb) { cb(null, {userid: '12'}); };
       api.user.profile = function(cb) { cb(null, {fullName: 'alice'}); };
-      api.user.getUploadGroups = function(cb) { cb(null,[{userid: '12'},{userid: '11'}]); };
+      api.user.getUploadGroups = function(cb) { cb(null,[{profile:{}, userid: '12'},{profile:{},userid: '11'}]); };
 
       appActions.load(function(err) {
         if (err) throw err;
@@ -142,14 +142,14 @@ describe('appActions', function() {
       api.init = function(options, cb) { cb(null, {token: '1234'}); };
       api.user.account = function(cb) { cb(null, {userid: '11'}); };
       api.user.profile = function(cb) { cb(null, {fullName: 'bob'}); };
-      api.user.getUploadGroups = function(cb) { cb(null,[{userid: '11'},{userid: '13'}]); };
+      api.user.getUploadGroups = function(cb) { cb(null,[{profile:{}, userid: '11'},{profile:{},userid: '13'}]); };
 
       appActions.load(function(err) {
         if (err) throw err;
         expect(app.state.user).to.deep.equal({
           userid: '11',
           profile: {fullName: 'bob'},
-          uploadGroups: [ { userid: '11' }, { userid: '13'} ]
+          uploadGroups: [ { profile:{},userid: '11' }, { profile:{},userid: '13'} ]
         });
         done();
       });
@@ -157,7 +157,7 @@ describe('appActions', function() {
 
     it('sets target user id as logged-in user id', function(done) {
       api.init = function(options, cb) { cb(null, {token: '1234'}); };
-      api.user.account = function(cb) { cb(null, {userid: '11'}); };
+      api.user.account = function(cb) { cb(null, {profile:{},userid: '11'}); };
 
       appActions.load(function(err) {
         if (err) throw err;
@@ -175,7 +175,7 @@ describe('appActions', function() {
       api.user = {};
       api.user.login = function(credentials, options, cb) { cb(); };
       api.user.profile = function(cb) { cb(); };
-      api.user.getUploadGroups = function(cb) { cb(null,[{userid: '11'}]); };
+      api.user.getUploadGroups = function(cb) { cb(null,[{profile:{},userid: '11'}]); };
       api.metrics = { track : function(one, two) { loginMetricsCall.one = one; loginMetricsCall.two = two;  }};
     });
 
@@ -195,7 +195,7 @@ describe('appActions', function() {
       };
       api.user.account = function(cb) { cb(null, {userid: '11'}); };
       api.user.profile = function(cb) { cb(null, {fullName: 'bob'}); };
-      api.user.getUploadGroups = function(cb) { cb(null,[{userid: '11'},{userid: '13'}]); };
+      api.user.getUploadGroups = function(cb) { cb(null,[{profile:{},userid: '11'},{profile:{},userid: '13'}]); };
 
       appActions.login({}, {}, function(err) {
         if (err) throw err;
@@ -211,7 +211,7 @@ describe('appActions', function() {
       };
       api.user.account = function(cb) { cb(null, {userid: '12'}); };
       api.user.profile = function(cb) { cb(null, {fullName: 'alice'}); };
-      api.user.getUploadGroups = function(cb) { cb(null,[{userid: '12'},{userid: '11'}]); };
+      api.user.getUploadGroups = function(cb) { cb(null,[{profile:{},userid: '12'},{profile:{},userid: '11'}]); };
 
       appActions.login({}, {}, function(err) {
         if (err) throw err;
@@ -233,7 +233,7 @@ describe('appActions', function() {
         expect(app.state.user).to.deep.equal({
           userid: '11',
           profile: {fullName: 'bob'},
-          uploadGroups: [ { userid: '11' } ]
+          uploadGroups: [ { profile:{}, userid: '11' } ]
         });
         done();
       });


### PR DESCRIPTION
I think this fixes the issues I'm still seeing in #120, but I'm putting it up separately in case there's still confusion about the properties of the accounts we're concerned with (although I went over these with Nick to check my testing scenario, and he thought what I was doing sounded right).

The key changes (relating to my comments on bits of the logic in #120) are in commit b36f1740a560e7a531b207d055d8217345490abc - I'd look at that diff. Then I started working on surfacing the situation when someone who has no data storage set up for their own account and no permission to upload on behalf of someone else logs in, but I quickly realized that's a larger task because we can't surface the error through the upload errors - it should just be a different "page" of the app I think. So for now this just logs a warning in the console.