### PR TITLE
handle outdated uploader version error

### DIFF
--- a/lib/components/App.jsx
+++ b/lib/components/App.jsx
@@ -28,6 +28,7 @@ var UploadList = require('./UploadList.jsx');
 var ViewDataLink = require('./ViewDataLink.jsx');
 var UploadSettings = require('./UploadSettings.jsx');
 var DeviceSelection = require('./DeviceSelection.jsx');
+var UpdatePlease = require('./UpdatePlease.jsx');
 
 var config = require('../config');
 
@@ -123,6 +124,12 @@ var App = React.createClass({
             groupsDropdown={!this.onlyMe()} />
           {this.renderViewDataLink()}
         </div>
+      );
+    }
+
+    if (page === 'error') {
+      return (
+        <UpdatePlease link={''} />
       );
     }
 

--- a/lib/components/App.jsx
+++ b/lib/components/App.jsx
@@ -134,6 +134,8 @@ var App = React.createClass({
 
     if (page === 'error') {
       return (
+        // TODO: add the link to help page on tidepool.org or knowledge base
+        // re: how to update the uploader
         <UpdatePlease link={''} />
       );
     }

--- a/lib/components/UpdatePlease.jsx
+++ b/lib/components/UpdatePlease.jsx
@@ -22,11 +22,18 @@ var UpdatePlease = React.createClass({
     link: React.PropTypes.string.isRequired
   },
   render: function() {
+    var text = {
+      OUT_OF_DATE: 'Your uploader is out-of-date.',
+      TO_UPDATE: 'To update it, please follow ',
+      LINK_TEXT: 'these instructions',
+      TRY_AGAIN: 'Then try your upload again!'
+    };
+
     return (
       <div className="UpdatePlease">
-        <p>Your uploader is out-of-date.</p>
-        <p className='most-important'>Please follow the instructions <a href={this.props.link}>here</a> to update it.</p>
-        <p>Then try your upload again!</p>
+        <p>{text.OUT_OF_DATE}</p>
+        <p className='most-important'>{text.TO_UPDATE}<a href={this.props.link}>{text.LINK_TEXT}</a>.</p>
+        <p>{text.TRY_AGAIN}</p>
       </div>
     );
   }

--- a/lib/components/UpdatePlease.jsx
+++ b/lib/components/UpdatePlease.jsx
@@ -1,0 +1,35 @@
+/*
+* == BSD2 LICENSE ==
+* Copyright (c) 2014, Tidepool Project
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the associated License, which is identical to the BSD 2-Clause
+* License as published by the Open Source Initiative at opensource.org.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE. See the License for more details.
+*
+* You should have received a copy of the License along with this program; if
+* not, you can obtain one from Tidepool Project at tidepool.org.
+* == BSD2 LICENSE ==
+*/
+
+var React = require('react');
+
+var UpdatePlease = React.createClass({
+  propTypes: {
+    link: React.PropTypes.string.isRequired
+  },
+  render: function() {
+    return (
+      <div className="UpdatePlease">
+        <p>Your uploader is out-of-date.</p>
+        <p className='most-important'>Please follow the instructions <a href={this.props.link}>here</a> to update it.</p>
+        <p>Then try your upload again!</p>
+      </div>
+    );
+  }
+});
+
+module.exports = UpdatePlease;

--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -62,6 +62,7 @@ appActions.errorStages = {
   STAGE_PICK_FILE : { code: 'E_SELECTING_FILE' , friendlyMessage: 'Error during file selection' },
   STAGE_READ_FILE : { code: 'E_READING_FILE' , friendlyMessage: 'Error trying to read file' },
   STAGE_UPLOAD : { code: 'E_UPLOADING' , friendlyMessage: 'Error uploading data' },
+  STAGE_METADATA_UPLOAD : { code: 'E_METADATA_UPLOAD' , friendlyMessage: 'Error uploading upload metadata'},
   STAGE_DEVICE_UPLOAD : { code: 'E_DEVICE_UPLOAD' , friendlyMessage: 'Error uploading device data' },
   STAGE_DEVICE_DETECT : { code: 'E_DEVICE_DETECT' , friendlyMessage: 'Error trying to detect a device' },
   STAGE_CARELINK_UPLOAD : { code: 'E_CARELINK_UPLOAD' , friendlyMessage: 'Error uploading CareLink data' },
@@ -660,6 +661,12 @@ appActions._handleUploadError = function(uploadIndex, error) {
     }
     return upload;
   });
+
+  if (error.code === appActions.errorStages['STAGE_METADATA_UPLOAD'].code) {
+    this.app.setState({
+      page: 'error'
+    });
+  }
 };
 
 appActions._addToUploadHistory = function(upload, instance) {

--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -76,6 +76,12 @@ function extractMessage(err) {
   }
   // if err.message is an object, that's because it's an error from jellyfish
   else if (typeof err.message === 'object' && err.message.message) {
+    if (typeof err.message.message === 'object' && err.message.message.code === 'outdatedVersion') {
+      var stage = appActions.errorStages['STAGE_METADATA_UPLOAD'];
+      err.code = stage.code;
+      err.friendlyMessage = stage.friendlyMessage;
+      return err.message.message.text;
+    }
     return err.message.message;
   }
   // sometimes the jellyfish errors don't have a `message`, only a `reason`?? *shrug*

--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -75,18 +75,17 @@ function extractMessage(err) {
     return err.error || 'Unknown error message';
   }
   // if err.message is an object, that's because it's an error from jellyfish
-  else if (typeof err.message === 'object' && err.message.message) {
-    if (typeof err.message.message === 'object' && err.message.message.code === 'outdatedVersion') {
+  else if (typeof err.message === 'object') {
+    if (err.message.code === 'outdatedVersion') {
       var stage = appActions.errorStages['STAGE_METADATA_UPLOAD'];
       err.code = stage.code;
       err.friendlyMessage = stage.friendlyMessage;
-      return err.message.message.text;
+      return err.message.text;
     }
-    return err.message.message;
-  }
-  // sometimes the jellyfish errors don't have a `message`, only a `reason`?? *shrug*
-  else if (typeof err.message === 'object' && err.message.reason) {
-    return err.message.reason;
+    // sometimes the jellyfish errors don't have a `message`, only a `reason`?? *shrug*
+    else if (err.message.reason) {
+      return err.message.reason;
+    }
   }
   else {
     return err.message;

--- a/styles/components/App.less
+++ b/styles/components/App.less
@@ -39,7 +39,7 @@
 
 @App-mainPageBorder: 1px;
 
-.App--main .App-page, .App--settings .App-page {
+.App--main .App-page, .App--settings .App-page, .App--error .App-page {
   width: 550px;
   background-color: rgba(255, 255, 255, 0.75);
   border: @App-mainPageBorder solid @gray-border;

--- a/styles/components/DeviceSelection.less
+++ b/styles/components/DeviceSelection.less
@@ -1,8 +1,6 @@
 .DeviceSelection {
-  min-height: 300px;
-  justify-content: center;
+  .center-container;
 }
-
 .DeviceSelection-headline {
   width: 250px;
   margin: 20px auto 20px auto;

--- a/styles/components/UpdatePlease.less
+++ b/styles/components/UpdatePlease.less
@@ -1,0 +1,21 @@
+.UpdatePlease {
+  .center-container;
+
+  a {
+    .blue-link;
+  }
+
+  p {
+    font-size: 1.2em;
+    text-align: center;
+    // our box-flex mixin wreaked havoc here and was making spans display flex
+    // (effectively block)
+    // TODO: fix that at the source
+    span {
+      display: inline;
+    }
+    &.most-important {
+      font-weight: bold;
+    }
+  }
+}

--- a/styles/core/mixins.less
+++ b/styles/core/mixins.less
@@ -34,3 +34,21 @@
   padding-right: 15px;
   overflow-y: scroll;
 }
+
+// used so far for DeviceSelection and UpdatePlease
+.center-container {
+  min-height: 300px;
+  justify-content: center;
+}
+
+// a common link style
+.blue-link {
+  color: lighten(@purple-dark, 20%);
+
+  &:hover,
+  &:focus,
+  &:active {
+    color: @blue;
+    text-decoration: none;
+  }
+}

--- a/styles/main.less
+++ b/styles/main.less
@@ -35,6 +35,7 @@
 @import "components/Login.less";
 @import "components/ProgressBar.less";
 @import "components/Scan.less";
+@import "components/UpdatePlease.less";
 @import "components/Upload.less";
 @import "components/UploadList.less";
 @import "components/UploadSettings.less";

--- a/test/ui/testAppActions.js
+++ b/test/ui/testAppActions.js
@@ -824,6 +824,30 @@ describe('appActions', function() {
       });
     });
 
+    it('redirects to the `error` page if jellyfish errors because uploader is out-of-date', function(done) {
+      now = '2014-01-31T22:00:00-05:00';
+      device.detect = function(driverId, options, cb) { return cb(null, {}); };
+      device.upload = function(driverId, options, cb) {
+        now = '2014-01-31T22:00:30-05:00';
+        options.progress('fetchData', 50);
+        var err = new Error('Oops, we got an error');
+        err.code = 'E_METADATA_UPLOAD';
+        return cb(err);
+      };
+      app.state.targetId = '11';
+      app.state.uploads = [{
+        source: {
+          type: 'device',
+          driverId: 'DexcomG4'
+        }
+      }];
+
+      appActions.upload(0, {}, function(err) {
+        expect(app.state.page).to.equal('error');
+        done();
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
The only TODO left here is the link to the page on tidepool.org or the knowledge base instructing how to update the uploader (there is a TODO comment in App.jsx about this). Since no one should ever see the error page where that link is displayed until we make the minimum version something higher than the default 0.99.0, this *can* be merged and published, and should be.