### PR TITLE
add KB link

### DIFF
--- a/lib/components/App.jsx
+++ b/lib/components/App.jsx
@@ -136,7 +136,7 @@ var App = React.createClass({
       return (
         // TODO: add the link to help page on tidepool.org or knowledge base
         // re: how to update the uploader
-        <UpdatePlease link={''} />
+        <UpdatePlease link={this.state.howToUpdateKBLink} />
       );
     }
 

--- a/lib/components/UpdatePlease.jsx
+++ b/lib/components/UpdatePlease.jsx
@@ -32,7 +32,7 @@ var UpdatePlease = React.createClass({
     return (
       <div className="UpdatePlease">
         <p>{text.OUT_OF_DATE}</p>
-        <p className='most-important'>{text.TO_UPDATE}<a href={this.props.link}>{text.LINK_TEXT}</a>.</p>
+        <p className='most-important'>{text.TO_UPDATE}<a target="_blank" href={this.props.link}>{text.LINK_TEXT}</a>.</p>
         <p>{text.TRY_AGAIN}</p>
       </div>
     );

--- a/lib/state/appState.js
+++ b/lib/state/appState.js
@@ -54,12 +54,12 @@ appState.getInitial = function() {
     //   name: 'OneTouch UltraMini',
     //   key: 'onetouchmini',
     //   source: {type: 'device', driverId: 'OneTouchMini'}
+    // },
+    // {
+    //   name: 'Bayer Contour Next',
+    //   key: 'bayercontournext',
+    //   source: {type: 'device', driverId: 'BayerContourNext'}
     // }
-    {
-      name: 'Bayer Contour Next',
-      key: 'bayercontournext',
-      source: {type: 'device', driverId: 'BayerContourNext'}
-    }
   ];
 
   if (config.CARELINK) {

--- a/lib/state/appState.js
+++ b/lib/state/appState.js
@@ -68,6 +68,7 @@ appState.getInitial = function() {
 
   return {
     dropMenu: false,
+    howToUpdateKBLink: 'https://tidepool-project.helpscoutdocs.com/article/6-how-to-install-or-upgrade-the-tidepool-uploader-gen',
     page: 'loading',
     user: null,
     targetId: null,


### PR DESCRIPTION
So the dogfooding revealed a bit of a brain fart. The current prod uploader didn't yet have the link to the KB article for how to update the uploader (because it didn't exist when we first added the "you need to update your uploader page") but the current prod uploader is the one we expect people to be get getting the "outdated uploader" error with when we start enforcing a minimum uploader version with the release of BtUTC.

So this is a quick fix to add the link that we will try to publish today to prod, and hopefully many people will get the update over the weekend!