### PR TITLE
use sundial's new getTimezones

### DIFF
--- a/lib/components/App.jsx
+++ b/lib/components/App.jsx
@@ -189,8 +189,7 @@ var App = React.createClass({
       <TimezoneSelection
         timezoneLabel={'Choose timezone'}
         onTimezoneChange={this.appActions.changeTimezone.bind(this.appActions)}
-        targetTimezone={this.state.targetTimezone}
-        targetTimezoneLabel={this.state.targetTimezoneLabel} />
+        targetTimezone={this.state.targetTimezone} />
     );
   },
 

--- a/lib/components/TimezoneSelection.jsx
+++ b/lib/components/TimezoneSelection.jsx
@@ -46,7 +46,6 @@ var TimezoneSelection = React.createClass({
         onChange={this.props.onTimezoneChange}
         options={opts}
         placeholder={'Type to search...'}
-        // if for whatever reason we don't have the label, just display the actual timezone name
         value={this.props.targetTimezone} />
     );
   },

--- a/lib/components/TimezoneSelection.jsx
+++ b/lib/components/TimezoneSelection.jsx
@@ -40,13 +40,6 @@ var TimezoneSelection = React.createClass({
       .concat(sortByOffset(timezones.hoisted))
       .concat(sortByOffset(timezones.theRest));
 
-    var targetTimezoneLabel = null;
-    if (this.props.targetTimezone !== null) {
-      targetTimezoneLabel = _.find(timezones, function(tz) {
-        return tz.value === self.props.targetTimezone;
-      });
-    }
-
     return (
       <Select clearable={false}
         name={'timezoneSelect'}
@@ -54,7 +47,7 @@ var TimezoneSelection = React.createClass({
         options={opts}
         placeholder={'Type to search...'}
         // if for whatever reason we don't have the label, just display the actual timezone name
-        value={targetTimezoneLabel || this.props.targetTimezone}/>
+        value={this.props.targetTimezone} />
     );
   },
 

--- a/lib/components/TimezoneSelection.jsx
+++ b/lib/components/TimezoneSelection.jsx
@@ -24,26 +24,37 @@ var TimezoneSelection = React.createClass({
   propTypes: {
     onTimezoneChange: React.PropTypes.func.isRequired,
     timezoneLabel : React.PropTypes.string.isRequired,
-    targetTimezone: React.PropTypes.string,
-    targetTimezoneLabel: React.PropTypes.string
+    targetTimezone: React.PropTypes.string
   },
 
-  buildTzSelector:function(){
-    var opts = _.map(sundial.getTimezones(), function(tz, i) {
-      // we have to concatenate the name and label for each timezone
-      // because a name can map to more than one label, and that causes
-      // React to choke because the component keys are not unique
-      // TODO: change the list of timezones in sundial so that all are unique
-      // and we shouldn't have to continue using this hack!
-      return { value : tz.name + '_' + tz.label, label : tz.label };
-    });
+  buildTzSelector: function() {
+    var self = this;
+    function sortByOffset(timezones) {
+      return _.sortBy(timezones, function(tz) {
+        return tz.offset;
+      });
+    }
+    var timezones = sundial.getTimezones();
+    var opts = sortByOffset(timezones.bigFour)
+      .concat(sortByOffset(timezones.unitedStates))
+      .concat(sortByOffset(timezones.hoisted))
+      .concat(sortByOffset(timezones.theRest));
+
+    var targetTimezoneLabel = null;
+    if (this.props.targetTimezone !== null) {
+      targetTimezoneLabel = _.find(timezones, function(tz) {
+        return tz.value === self.props.targetTimezone;
+      });
+    }
 
     return (
-      <Select name='timezoneSelect'
-        // if for whatever reason we don't have the label, just display the actual timezone name
-        value={this.props.targetTimezoneLabel || this.props.targetTimezone}
+      <Select clearable={false}
+        name={'timezoneSelect'}
+        onChange={this.props.onTimezoneChange}
         options={opts}
-        onChange={this.props.onTimezoneChange} />
+        placeholder={'Type to search...'}
+        // if for whatever reason we don't have the label, just display the actual timezone name
+        value={targetTimezoneLabel || this.props.targetTimezone}/>
     );
   },
 

--- a/lib/components/UploadSettings.jsx
+++ b/lib/components/UploadSettings.jsx
@@ -57,12 +57,14 @@ var UploadSettings = React.createClass({
 
     var disable = this.props.isUploadInProgress ? true : false;
 
-    return (<Select
+    return (
+      <Select clearable={false}
         disabled={disable}
-        name='uploadGroupSelect'
-        value={this.props.targetId}
+        name={'uploadGroupSelect'}
+        onChange={this.props.onGroupChange}
         options={opts}
-        onChange={this.props.onGroupChange} />);
+        value={this.props.targetId} />
+    );
   },
   render: function() {
     // we're already doing a check to see if we want to render in App.jsx

--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -111,18 +111,6 @@ function getTargetTimezone(deviceList) {
   }
 }
 
-function getTargetTimezoneLabel(deviceList) {
-  var uniqLabels = _.uniq(_.pluck(deviceList, 'timezoneLabel'));
-  if (uniqLabels.length === 1) {
-    return uniqLabels[0];
-  }
-  // if we find more than one timezone or 0 timezones, we return null
-  // and you'll get sent back to the settings page (or stay there)
-  else {
-    return null;
-  }
-}
-
 appActions.addMoreInfoToError = function(err, stage) {
   var name = err.name;
   err.version = config.namedVersion;
@@ -157,33 +145,25 @@ appActions.changeGroup = function(userid) {
   var devicesById = localStore.getItem('devices') || {};
   var targetDevices = devicesById[userid] || [];
   var targetTimezone = getTargetTimezone(targetDevices);
-  var targetTimezoneLabel = getTargetTimezoneLabel(targetDevices);
 
   if (_.isEmpty(targetDevices) || _.isEmpty(targetTimezone)) {
     this.app.setState({
       targetId: userid,
       targetDevices: targetDevices,
       targetTimezone: targetTimezone,
-      targetTimezoneLabel: targetTimezoneLabel,
       page: 'settings'
     });
   }
   this.app.setState({
     targetId: userid,
     targetDevices: _.pluck(targetDevices, 'key'),
-    targetTimezone: targetTimezone,
-    targetTimezoneLabel: targetTimezoneLabel
+    targetTimezone: targetTimezone
   });
 };
 
 appActions.changeTimezone = function(timezone) {
-  // to clear some really annoying React warnings and make it possible to store
-  // and display the timezone label the user selected instead of the timezone name
-  // we have to concatenate the two, then split them back up :/
-  var splitTimezone = timezone.split('_');
   this.app.setState({
-    targetTimezone: splitTimezone[0],
-    targetTimezoneLabel: splitTimezone[1]
+    targetTimezone: timezone
   });
 };
 
@@ -316,7 +296,6 @@ appActions._afterLoginPage = function(user, cb) {
   var targetDevicesWithTimezones = devices[defaultTargetId];
   var targetDevices = _.pluck(targetDevicesWithTimezones, 'key');
   var targetTimezone = getTargetTimezone(targetDevicesWithTimezones);
-  var targetTimezoneLabel = getTargetTimezoneLabel(targetDevicesWithTimezones);
 
   if (!_.isEmpty(targetDevices) && !_.isEmpty(targetTimezone)) {
     self.app.setState({
@@ -324,7 +303,6 @@ appActions._afterLoginPage = function(user, cb) {
       targetId: defaultTargetId,
       targetDevices: targetDevices,
       targetTimezone: targetTimezone,
-      targetTimezoneLabel: targetTimezoneLabel,
       page: 'main'
     });
 
@@ -336,7 +314,6 @@ appActions._afterLoginPage = function(user, cb) {
     targetId: defaultTargetId,
     targetDevices: [],
     targetTimezone: null,
-    targetTimezoneLabel: null,
     page: 'settings'
   });
 
@@ -410,15 +387,13 @@ appActions.addOrRemoveTargetDevice = function(e) {
 appActions.storeUserTargets = function(targetId) {
   // timezone
   var targetTimezone = this.app.state.targetTimezone;
-  var targetTimezoneLabel = this.app.state.targetTimezoneLabel;
   // devices
   var devicesById = localStore.getItem('devices') || {};
   var targetDevices = this.app.state.targetDevices;
   var devicesWithTimezoneToStore = _.map(targetDevices, function(deviceKey) {
     return {
       key: deviceKey,
-      timezone: targetTimezone,
-      timezoneLabel: targetTimezoneLabel
+      timezone: targetTimezone
     };
   });
   devicesById[targetId] = devicesWithTimezoneToStore;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "react": "0.12.0",
     "react-select": "0.4.6",
     "stack-trace": "0.0.9",
-    "sundial": "1.3.0",
+    "sundial": "1.4.0",
     "tidepool-platform-client": "0.16.5"
   },
   "devDependencies": {

--- a/styles/core/dropdowns.less
+++ b/styles/core/dropdowns.less
@@ -1,3 +1,11 @@
+// jebeck's additions
+
+// because we're setting display: flex on every div
+// and it turns out that interferes with text-overflow :(
+.Select-placeholder {
+  display: block;
+}
+
 
 /**
  * React Select

--- a/test/ui/testAppActions.js
+++ b/test/ui/testAppActions.js
@@ -843,9 +843,8 @@ describe('appActions', function() {
 
     it('updates the timezone ', function() {
       app.state.targetTimezone = 'foo';
-      appActions.changeTimezone('bar_Bar');
+      appActions.changeTimezone('bar');
       expect(app.state.targetTimezone).to.equal('bar');
-      expect(app.state.targetTimezoneLabel).to.equal('Bar');
     });
 
   });


### PR DESCRIPTION
Fixes an issue caused by the overly complicated gymnastics trying to fit our old timezone list into react-select's data model.

Also removed the 'x' for "clearability" in the dropdowns and ensured long timezone names will be elided in the selection box (both per @skrugman's guidance).

A remaining task is to make the dropdown wider so that long timezone names don't break onto two lines in the dropdown list - that turned out to be a much bigger task than anticipated due to some unfortunate magic numbers in the CSS.