### PR TITLE
slightly smaller straps for those boots

### DIFF
--- a/lib/TimezoneOffsetUtil.js
+++ b/lib/TimezoneOffsetUtil.js
@@ -34,7 +34,9 @@ module.exports = function(timezone, mostRecent, changes) {
   var MS_IN_SEC = 1000, SEC_IN_MIN = 60;
 
   var offsetIntervals = [];
-  var timezoneOffset = null, conversionOffset = 0, currentIndex = null;
+  var timezoneOffset = null;
+  var clockDriftOffset = 0, conversionOffset = 0;
+  var currentIndex = null;
 
   this.findOffsetDifferences = function(event) {
     var offsetDiff = Math.round(
@@ -55,15 +57,10 @@ module.exports = function(timezone, mostRecent, changes) {
     var MAX_DIFF = 1560;
     if (Math.abs(difference.offsetDifference) <= MAX_DIFF) {
       timezoneOffset += difference.offsetDifference;
-      difference.conversionOffset = difference.rawDifference - difference.offsetDifference * SEC_IN_MIN * MS_IN_SEC;
-    }
-    // if the change was larger than the threshold for adjustment to timezoneOffset
-    // then the entirety of the change is factored into the conversionOffset 
-    if (difference.conversionOffset === undefined) {
-      conversionOffset += difference.rawDifference;
+      clockDriftOffset += difference.rawDifference - difference.offsetDifference * SEC_IN_MIN * MS_IN_SEC;
     }
     else {
-      conversionOffset += difference.conversionOffset;
+      conversionOffset += difference.rawDifference;
     }
   }
 
@@ -96,6 +93,7 @@ module.exports = function(timezone, mostRecent, changes) {
       if (i === 0) {
         change.time = sundial.applyTimezoneAndConversionOffset(change.jsDate, timezone, conversionOffset).toISOString();
         change.timezoneOffset = sundial.getOffsetFromZone(change.time, timezone);
+        change.clockDriftOffset = clockDriftOffset;
         change.conversionOffset = conversionOffset;
         delete change.jsDate;
         timezoneOffset = change.timezoneOffset;
@@ -106,6 +104,7 @@ module.exports = function(timezone, mostRecent, changes) {
           startIndex: change.index,
           endIndex: null,
           timezoneOffset: change.timezoneOffset,
+          clockDriftOffset: change.clockDriftOffset,
           conversionOffset: change.conversionOffset
         });
         adjustOffsets(change);
@@ -113,6 +112,7 @@ module.exports = function(timezone, mostRecent, changes) {
       else {
         change.time = sundial.findTimeFromDeviceTimeAndOffsets(change.jsDate, timezoneOffset, conversionOffset).toISOString();
         change.timezoneOffset = timezoneOffset;
+        change.clockDriftOffset = clockDriftOffset;
         change.conversionOffset = conversionOffset;
         delete change.jsDate;
         adjustOffsets(change);
@@ -122,6 +122,7 @@ module.exports = function(timezone, mostRecent, changes) {
           startIndex: change.index,
           endIndex: currentIndex,
           timezoneOffset: change.timezoneOffset,
+          clockDriftOffset: change.clockDriftOffset,
           conversionOffset: change.conversionOffset
         });
         currentIndex = change.index;
@@ -135,6 +136,7 @@ module.exports = function(timezone, mostRecent, changes) {
       startIndex: null,
       endIndex: currentIndex,
       timezoneOffset: timezoneOffset,
+      clockDriftOffset: clockDriftOffset,
       conversionOffset: conversionOffset
     });
   }
@@ -150,6 +152,7 @@ module.exports = function(timezone, mostRecent, changes) {
           var retObj = {
             time: utc,
             timezoneOffset: currentInterval.timezoneOffset,
+            clockDriftOffset: currentInterval.clockDriftOffset,
             conversionOffset: currentInterval.conversionOffset
           };
           if (index != null) {
@@ -192,6 +195,7 @@ module.exports = function(timezone, mostRecent, changes) {
         return {
           time: utc,
           timezoneOffset: sundial.getOffsetFromZone(utc, timezone),
+          clockDriftOffset: 0,
           conversionOffset: 0
         };
       };
@@ -215,6 +219,7 @@ module.exports = function(timezone, mostRecent, changes) {
     }
     obj.time = res.time;
     obj.timezoneOffset = res.timezoneOffset;
+    obj.clockDriftOffset = res.clockDriftOffset;
     obj.conversionOffset = res.conversionOffset;
     if (obj.index == null) {
       annotate.annotateEvent(obj, 'uncertain-timestamp');

--- a/lib/components/DeviceSelection.jsx
+++ b/lib/components/DeviceSelection.jsx
@@ -22,7 +22,9 @@ var cx = require('react/lib/cx');
 var DeviceSelection = React.createClass({
   propTypes: {
     uploads: React.PropTypes.array.isRequired,
-    targetId: React.PropTypes.string.isRequired,
+    // targetId can be null when logged in user is not a data storage account
+    // for example a clinic worker
+    targetId: React.PropTypes.string,
     targetDevices: React.PropTypes.array.isRequired,
     timezoneIsSelected: React.PropTypes.bool.isRequired,
     onCheckChange: React.PropTypes.func.isRequired,

--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -285,6 +285,11 @@ appActions._getDefaultTargetId = function(loggedInUser){
     this.addMoreInfoToError(err, this.errorStages['STAGE_AFTER_LOGIN']);
     console.warn(err.debug);
   }
+  else if (possibilities.length > 1) {
+    if (_.isEmpty(loggedInUser.profile.patient)) {
+      return null;
+    }
+  }
   return userid;
 };
 

--- a/test/ui/testAppActions.js
+++ b/test/ui/testAppActions.js
@@ -141,7 +141,7 @@ describe('appActions', function() {
     it('goes to main page if local session found and targeted devices fetched from localStore', function(done) {
       api.init = function(options, cb) { cb(null, {token: '1234'}); };
       api.user.account = function(cb) { cb(null, {userid: '11'}); };
-      api.user.profile = function(cb) { cb(null, {fullName: 'Bob'}); };
+      api.user.profile = function(cb) { cb(null, {fullName: 'Bob', patient: {about: 'Foo'}}); };
 
       appActions.load(function(err) {
         if (err) throw err;
@@ -181,6 +181,7 @@ describe('appActions', function() {
     it('sets target user id as logged-in userid if data storage exists for logged-in user', function(done) {
       api.init = function(options, cb) { cb(null, {token: '1234'}); };
       api.user.account = function(cb) { cb(null, {userid: '11'}); };
+      api.user.profile = function(cb) { cb(null, {fullName: 'Bob', patient: {about: 'Foo'}}); };
 
       appActions.load(function(err) {
         if (err) throw err;
@@ -221,6 +222,8 @@ describe('appActions', function() {
     });
 
     it('goes to settings page by default', function(done) {
+      api.user.profile = function(cb) { cb(null, {fullName: 'Bob', patient: {about: 'Foo'}}); };
+
       appActions.login({}, {}, function(err) {
         if (err) throw err;
         expect(app.state.page).to.equal('settings');
@@ -234,6 +237,7 @@ describe('appActions', function() {
       api.user.login = function(credentials, options, cb) {
         cb(null, {user: {userid: '11'}});
       };
+      api.user.profile = function(cb) { cb(null, {fullName: 'Bob', patient: {about: 'Foo'}}); };
 
       appActions.login({}, {}, function(err) {
         if (err) throw err;
@@ -247,6 +251,7 @@ describe('appActions', function() {
       api.user.login = function(credentials, options, cb) {
         cb(null, {user: {userid: '12'}});
       };
+      api.user.profile = function(cb) { cb(null, {fullName: 'Bob', patient: {about: 'Foo'}}); };
 
       appActions.login({}, {}, function(err) {
         if (err) throw err;
@@ -292,6 +297,7 @@ describe('appActions', function() {
       api.user.login = function(credentials, options, cb) {
         cb(null, {user: {userid: '11'}});
       };
+      api.user.profile = function(cb) { cb(null, {fullName: 'Bob', patient: {about: 'Foo'}}); };
 
       appActions.login({}, {}, function(err) {
         if (err) throw err;


### PR DESCRIPTION
**WIP**

Introduces `clockDriftOffset`, separate from `conversionOffset`. The former is stored but not factored into the generation of the `time` field (to prevent uploading of duplicates). `conversionOffset` is reserved for changes larger than anything conceivable as a timezone offset change (i.e., device set to wrong date, month, year).