### PR TITLE
smaller & prettier straps for those boots

### DIFF
--- a/lib/TimezoneOffsetUtil.js
+++ b/lib/TimezoneOffsetUtil.js
@@ -34,7 +34,9 @@ module.exports = function(timezone, mostRecent, changes) {
   var MS_IN_SEC = 1000, SEC_IN_MIN = 60;
 
   var offsetIntervals = [];
-  var timezoneOffset = null, conversionOffset = 0, currentIndex = null;
+  var timezoneOffset = null;
+  var clockDriftOffset = 0, conversionOffset = 0;
+  var currentIndex = null;
 
   this.findOffsetDifferences = function(event) {
     var offsetDiff = Math.round(
@@ -55,15 +57,10 @@ module.exports = function(timezone, mostRecent, changes) {
     var MAX_DIFF = 1560;
     if (Math.abs(difference.offsetDifference) <= MAX_DIFF) {
       timezoneOffset += difference.offsetDifference;
-      difference.conversionOffset = difference.rawDifference - difference.offsetDifference * SEC_IN_MIN * MS_IN_SEC;
-    }
-    // if the change was larger than the threshold for adjustment to timezoneOffset
-    // then the entirety of the change is factored into the conversionOffset 
-    if (difference.conversionOffset === undefined) {
-      conversionOffset += difference.rawDifference;
+      clockDriftOffset += difference.rawDifference - difference.offsetDifference * SEC_IN_MIN * MS_IN_SEC;
     }
     else {
-      conversionOffset += difference.conversionOffset;
+      conversionOffset += difference.rawDifference;
     }
   }
 
@@ -96,6 +93,7 @@ module.exports = function(timezone, mostRecent, changes) {
       if (i === 0) {
         change.time = sundial.applyTimezoneAndConversionOffset(change.jsDate, timezone, conversionOffset).toISOString();
         change.timezoneOffset = sundial.getOffsetFromZone(change.time, timezone);
+        change.clockDriftOffset = clockDriftOffset;
         change.conversionOffset = conversionOffset;
         delete change.jsDate;
         timezoneOffset = change.timezoneOffset;
@@ -106,6 +104,7 @@ module.exports = function(timezone, mostRecent, changes) {
           startIndex: change.index,
           endIndex: null,
           timezoneOffset: change.timezoneOffset,
+          clockDriftOffset: change.clockDriftOffset,
           conversionOffset: change.conversionOffset
         });
         adjustOffsets(change);
@@ -113,6 +112,7 @@ module.exports = function(timezone, mostRecent, changes) {
       else {
         change.time = sundial.findTimeFromDeviceTimeAndOffsets(change.jsDate, timezoneOffset, conversionOffset).toISOString();
         change.timezoneOffset = timezoneOffset;
+        change.clockDriftOffset = clockDriftOffset;
         change.conversionOffset = conversionOffset;
         delete change.jsDate;
         adjustOffsets(change);
@@ -122,6 +122,7 @@ module.exports = function(timezone, mostRecent, changes) {
           startIndex: change.index,
           endIndex: currentIndex,
           timezoneOffset: change.timezoneOffset,
+          clockDriftOffset: change.clockDriftOffset,
           conversionOffset: change.conversionOffset
         });
         currentIndex = change.index;
@@ -135,6 +136,7 @@ module.exports = function(timezone, mostRecent, changes) {
       startIndex: null,
       endIndex: currentIndex,
       timezoneOffset: timezoneOffset,
+      clockDriftOffset: clockDriftOffset,
       conversionOffset: conversionOffset
     });
   }
@@ -150,6 +152,7 @@ module.exports = function(timezone, mostRecent, changes) {
           var retObj = {
             time: utc,
             timezoneOffset: currentInterval.timezoneOffset,
+            clockDriftOffset: currentInterval.clockDriftOffset,
             conversionOffset: currentInterval.conversionOffset
           };
           if (index != null) {
@@ -192,6 +195,7 @@ module.exports = function(timezone, mostRecent, changes) {
         return {
           time: utc,
           timezoneOffset: sundial.getOffsetFromZone(utc, timezone),
+          clockDriftOffset: 0,
           conversionOffset: 0
         };
       };
@@ -215,6 +219,7 @@ module.exports = function(timezone, mostRecent, changes) {
     }
     obj.time = res.time;
     obj.timezoneOffset = res.timezoneOffset;
+    obj.clockDriftOffset = res.clockDriftOffset;
     obj.conversionOffset = res.conversionOffset;
     if (obj.index == null) {
       annotate.annotateEvent(obj, 'uncertain-timestamp');

--- a/lib/carelink/carelinkSimulator.js
+++ b/lib/carelink/carelinkSimulator.js
@@ -64,15 +64,7 @@ function annotateEvent(event, ann){
  * @returns {number} number of millis in current day
  */
 function computeMillisInCurrentDay(e){
-  var msFromMidnight = sundial.getMsFromMidnight(e.time, e.timezoneOffset);
-  var fifteenMinsInMs = 15*60*1000;
-  // adjustments for clock drift screw up our logic to see if a basal
-  // matches a schedule, so we round to the nearest fifteen mins
-  // to increase the chance of matching up with a schedule
-  if (e.conversionOffset && e.conversionOffset !== 0) {
-    return Math.round(msFromMidnight/fifteenMinsInMs)*fifteenMinsInMs;
-  }
-  return msFromMidnight;
+  return sundial.getMsFromMidnight(e.time, e.timezoneOffset);
 }
 
 
@@ -163,8 +155,8 @@ exports.make = function(config){
    *
    * @param time the timestamp to push time forward to
    */
-  function pushBasalClockForward(time){
-    var timeMillis = Date.parse(time);
+  function pushBasalClockForward(time, conversionOffset){
+    var timeMillis = Date.parse(time) + conversionOffset;
 
     /**
      * Processes the individual parts of a basal event, pushing one of them (the "soonest")
@@ -217,11 +209,7 @@ exports.make = function(config){
               if (currSchedule == null || currSchedule.length === 0) {
                 parts.splice(doneIndex, 1);
               } else {
-                var millisInDay = computeMillisInCurrentDay({
-                  time: doneTime,
-                  timezoneOffset: sched.timezoneOffset,
-                  conversionOffset: sched.conversionOffset
-                });
+                var millisInDay = computeMillisInCurrentDay({time: doneTime, timezoneOffset: sched.timezoneOffset});
                 for (i = 0; i < currSchedule.length; ++i) {
                   if (currSchedule[i].start >= millisInDay) {
                     break;
@@ -324,7 +312,7 @@ exports.make = function(config){
        */
       if (currStatus != null && currStatus.status === 'suspended' && (currStatus.payload && currStatus.payload.cause === 'low_glucose')) {
         ensureTimestamp(event);
-        pushBasalClockForward(event.time);
+        pushBasalClockForward(event.time, event.conversionOffset);
         return;
       }
       // this is the case where our nextBasal generation in resume generates a `duplicate`
@@ -371,7 +359,7 @@ exports.make = function(config){
         }
       }
       ensureTimestamp(event);
-      pushBasalClockForward(event.time);
+      pushBasalClockForward(event.time, event.conversionOffset);
 
       var currSchedule = null;
       if (currSettings != null) {
@@ -448,7 +436,7 @@ exports.make = function(config){
     basalTemp: function(){
       var event = combineArguments(arguments);
 
-      pushBasalClockForward(event.time);
+      pushBasalClockForward(event.time, event.conversionOffset);
 
       if (currBasal != null) {
         if (currBasal.annotations &&
@@ -613,7 +601,7 @@ exports.make = function(config){
       // related to basal schedule changes changing the `suppressed` inside the suspend basal
       var eventMillis = Date.parse(event.time);
       currBasal.duration = eventMillis - Date.parse(currBasal.time);
-      pushBasalClockForward(event.time);
+      pushBasalClockForward(event.time, event.conversionOffset);
       events.push(deviceEventResume);
 
       var nextBasal = null;
@@ -705,7 +693,7 @@ exports.make = function(config){
       // related to basal schedule changes changing the `suppressed` inside the suspend basal
       var eventMillis = Date.parse(event.time);
       currBasal.duration = eventMillis - Date.parse(currBasal.time);
-      pushBasalClockForward(event.time);
+      pushBasalClockForward(event.time, event.conversionOffset);
       events.push(deviceEventResume);
 
       // fabricate a nextBasal from the basal that was suppressed by the suspend
@@ -817,7 +805,7 @@ exports.make = function(config){
       // related to basal schedule changes changing the `suppressed` inside the suspend basal
       var eventMillis = Date.parse(event.time);
       currBasal.duration = eventMillis - Date.parse(currBasal.time);
-      pushBasalClockForward(event.time);
+      pushBasalClockForward(event.time, event.conversionOffset);
       events.push(deviceEventResume);
 
       /**
@@ -863,7 +851,7 @@ exports.make = function(config){
      */
     pumpSettings: function(){
       var event = ensureTimestamp(combineArguments(arguments));
-      pushBasalClockForward(event.time);
+      pushBasalClockForward(event.time, event.conversionOffset);
 
       currSettings = addEvent(bob.makePumpSettings(), event);
       // generate basal event(s) according to the current schedule
@@ -968,7 +956,7 @@ exports.make = function(config){
       setCurrStatus(deviceEventSuspend);
       events.push(deviceEventSuspend);
 
-      pushBasalClockForward(event.time);
+      pushBasalClockForward(event.time, event.conversionOffset);
 
       // now build a basal event with `deliveryType: 'suspend'`
       // we don't have duration info yet, so we'll save it in currBasal to finish later

--- a/lib/carelink/carelinkSimulator.js
+++ b/lib/carelink/carelinkSimulator.js
@@ -70,8 +70,7 @@ function computeMillisInCurrentDay(e){
   // matches a schedule, so we round to the nearest fifteen mins
   // to increase the chance of matching up with a schedule
   if (e.conversionOffset && e.conversionOffset !== 0) {
-    var result = Math.round(msFromMidnight/fifteenMinsInMs)*fifteenMinsInMs;
-    return result === 864e5 ? 0 : result;
+    return Math.round(msFromMidnight/fifteenMinsInMs)*fifteenMinsInMs;
   }
   return msFromMidnight;
 }

--- a/lib/carelink/carelinkSimulator.js
+++ b/lib/carelink/carelinkSimulator.js
@@ -155,8 +155,8 @@ exports.make = function(config){
    *
    * @param time the timestamp to push time forward to
    */
-  function pushBasalClockForward(time, conversionOffset){
-    var timeMillis = Date.parse(time) + conversionOffset;
+  function pushBasalClockForward(time){
+    var timeMillis = Date.parse(time);
 
     /**
      * Processes the individual parts of a basal event, pushing one of them (the "soonest")
@@ -312,7 +312,7 @@ exports.make = function(config){
        */
       if (currStatus != null && currStatus.status === 'suspended' && (currStatus.payload && currStatus.payload.cause === 'low_glucose')) {
         ensureTimestamp(event);
-        pushBasalClockForward(event.time, event.conversionOffset);
+        pushBasalClockForward(event.time);
         return;
       }
       // this is the case where our nextBasal generation in resume generates a `duplicate`
@@ -359,7 +359,7 @@ exports.make = function(config){
         }
       }
       ensureTimestamp(event);
-      pushBasalClockForward(event.time, event.conversionOffset);
+      pushBasalClockForward(event.time);
 
       var currSchedule = null;
       if (currSettings != null) {
@@ -436,7 +436,7 @@ exports.make = function(config){
     basalTemp: function(){
       var event = combineArguments(arguments);
 
-      pushBasalClockForward(event.time, event.conversionOffset);
+      pushBasalClockForward(event.time);
 
       if (currBasal != null) {
         if (currBasal.annotations &&
@@ -601,7 +601,7 @@ exports.make = function(config){
       // related to basal schedule changes changing the `suppressed` inside the suspend basal
       var eventMillis = Date.parse(event.time);
       currBasal.duration = eventMillis - Date.parse(currBasal.time);
-      pushBasalClockForward(event.time, event.conversionOffset);
+      pushBasalClockForward(event.time);
       events.push(deviceEventResume);
 
       var nextBasal = null;
@@ -693,7 +693,7 @@ exports.make = function(config){
       // related to basal schedule changes changing the `suppressed` inside the suspend basal
       var eventMillis = Date.parse(event.time);
       currBasal.duration = eventMillis - Date.parse(currBasal.time);
-      pushBasalClockForward(event.time, event.conversionOffset);
+      pushBasalClockForward(event.time);
       events.push(deviceEventResume);
 
       // fabricate a nextBasal from the basal that was suppressed by the suspend
@@ -805,7 +805,7 @@ exports.make = function(config){
       // related to basal schedule changes changing the `suppressed` inside the suspend basal
       var eventMillis = Date.parse(event.time);
       currBasal.duration = eventMillis - Date.parse(currBasal.time);
-      pushBasalClockForward(event.time, event.conversionOffset);
+      pushBasalClockForward(event.time);
       events.push(deviceEventResume);
 
       /**
@@ -851,7 +851,7 @@ exports.make = function(config){
      */
     pumpSettings: function(){
       var event = ensureTimestamp(combineArguments(arguments));
-      pushBasalClockForward(event.time, event.conversionOffset);
+      pushBasalClockForward(event.time);
 
       currSettings = addEvent(bob.makePumpSettings(), event);
       // generate basal event(s) according to the current schedule
@@ -956,7 +956,7 @@ exports.make = function(config){
       setCurrStatus(deviceEventSuspend);
       events.push(deviceEventSuspend);
 
-      pushBasalClockForward(event.time, event.conversionOffset);
+      pushBasalClockForward(event.time);
 
       // now build a basal event with `deliveryType: 'suspend'`
       // we don't have duration info yet, so we'll save it in currBasal to finish later


### PR DESCRIPTION
**WIP**

Introduces `clockDriftOffset`, separate from `conversionOffset`. The former is stored but not factored into the generation of the `time` field (to prevent uploading of duplicates). `conversionOffset` is reserved for changes larger than anything conceivable as a timezone offset change (i.e., device set to wrong date, month, year).