### PR TITLE
S3 Upload (chrome-uploader)

### DIFF
--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -330,7 +330,7 @@ api.upload.fetchCarelinkData = function(payload, cb) {
     if (err) {
       return cb(err);
     }
-    return tidepool.getCarelinkData(syncTask._id, cb);
+    return tidepool.getCarelinkData(syncTask.id, cb);
   });
 };
 

--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -764,6 +764,7 @@ appActions._uploadCarelink = function(credentials, options, cb) {
   var self = this;
 
   var payload = {
+    targetUserId: options.targetId,
     carelinkUsername: credentials.username,
     carelinkPassword: credentials.password,
     daysAgo: config.DEFAULT_CARELINK_DAYS


### PR DESCRIPTION
@jh-bate @jebeck Changes to chrome-uploader for S3 uploads. Renamed `_id` to `id` on syncTask for consistently.  Added new, required `targetUserId`. Data is now stored under user it pertains to rather than the uploading user.