### PR TITLE
Bayer Contour USB

### DIFF
--- a/lib/core/device.js
+++ b/lib/core/device.js
@@ -44,7 +44,8 @@ device._deviceDrivers = {
   'InsuletOmniPod': insuletOmniPod,
   'OneTouchUltra2': oneTouchUltra2,
   'BayerContourNext': bayerContourNext,
-  'BayerContourNextUsb': bayerContourNext
+  'BayerContourNextUsb': bayerContourNext,
+  'BayerContourUsb': bayerContourNext
 };
 
 device._deviceComms = {
@@ -53,7 +54,8 @@ device._deviceComms = {
   'AbbottFreeStyle': serialDevice,
   'OneTouchUltra2': serialDevice,
   'BayerContourNext': hidDevice,
-  'BayerContourNextUsb': hidDevice
+  'BayerContourNextUsb': hidDevice,
+  'BayerContourUsb': hidDevice
 };
 
 device._silentComms = {};

--- a/lib/core/deviceInfo.js
+++ b/lib/core/deviceInfo.js
@@ -38,5 +38,6 @@ module.exports = {
   'InsuletOmniPod': infoBuilder('Insulet OmniPod', 'Upload .ibf file from PDM.'),
   'OneTouchUltra2': infoBuilder('OneTouch Ultra2', ''),
   'BayerContourNext': infoBuilder('Bayer Contour Next', 'Blood glucose meter'),
-  'BayerContourNextUsb': infoBuilder('Bayer Contour Next USB', 'Blood glucose meter')
+  'BayerContourNextUsb': infoBuilder('Bayer Contour Next USB', 'Blood glucose meter'),
+  'BayerContourUsb': infoBuilder('Bayer Contour USB', 'Blood glucose meter')
 };

--- a/lib/drivers/docs/bayerContourNext.md
+++ b/lib/drivers/docs/bayerContourNext.md
@@ -1,8 +1,9 @@
-# Bayer Contour Next 
+# Bayer Contour Next
 
 Supported devices:
 - Bayer Contour Next
 - Bayer Contour Next USB
+- Bayer Contour USB
 
 ## Checklist for Blood Glucose Meter Implementation
 

--- a/lib/state/appState.js
+++ b/lib/state/appState.js
@@ -64,6 +64,11 @@ appState.getInitial = function() {
        name: 'Bayer Contour Next USB',
        key: 'bayercontournextusb',
        source: {type: 'device', driverId: 'BayerContourNextUsb'}
+    },
+    {
+       name: 'Bayer Contour USB',
+       key: 'bayercontourusb',
+       source: {type: 'device', driverId: 'BayerContourUsb'}
     }
   ];
 

--- a/manifest.json
+++ b/manifest.json
@@ -85,6 +85,13 @@
           "mode": "HID",
           "vendorId": 6777,
           "productId": 29712
+        },
+        {
+          "deviceName": "BayerContourUsb",
+          "driverId": "BayerContourUsb",
+          "mode": "HID",
+          "vendorId": 6777,
+          "productId": 24578
         }
       ]
     }


### PR DESCRIPTION
The Bayer Contour USB works with same driver as:

- Bayer Contour Next
- Bayer Contour Next USB

All that was needed was to add the right VID/PID combination.