### PR TITLE
add a default case to catch alarm codes not documented in the spec

### DIFF
--- a/lib/drivers/insuletDriver.js
+++ b/lib/drivers/insuletDriver.js
@@ -896,6 +896,13 @@ module.exports = function (config) {
             .with_status(postsuspend)
             .done();
           break;
+        // for alarm codes not documented in the spec
+        default:
+          if (postalarm) {
+            postalarm = postalarm.with_alarmType('other')
+              .done();
+          }
+          break;
       }
       if (postalarm != null) {
         postrecords.push(postalarm);


### PR DESCRIPTION
In response to a bug report.

A small change to catch OmniPod alarm codes not documented in the spec and finish building proper objects with them. Since these aren't documented, leaving the `payload` (which usually contains more details) blank.