### PR TITLE
move logic for creating a bucket for CGM data inside check for uploads we're reading

### DIFF
--- a/lib/drivers/carelinkDriver.js
+++ b/lib/drivers/carelinkDriver.js
@@ -243,13 +243,13 @@ module.exports = function(simulatorMaker, api) {
           for (var j = 0; j < payload.cgmData.length; ++j) {
             var cgmKey = payload.cgmData[j][RAW_DEVICE_TYPE] + CGM_SUFFIX;
             var cgm = payload.devices[cgmKey];
-            if (cgm == null) {
-              cgm = {};
-              payload.devices[cgmKey] = cgm;
-
-              cgm.data = [];
-            }
             if (uploads[payload.cgmData[j][RAW_UPLOAD_ID]] != null) {
+              if (cgm == null) {
+                cgm = {};
+                payload.devices[cgmKey] = cgm;
+
+                cgm.data = [];
+              }
               cgm.data.push(payload.cgmData[j]);
             }
           }


### PR DESCRIPTION
What it says on the tin.

In response to a support issue. The issue here is that if there are overlapping (in time) uploads from the same model of device, we only take the very last upload. So in this case where there was CGM data in an early upload but not in the most recent, we ended up creating a bucket for CGM data that did not exist in the most recent upload, and we expected it to be non-empty.