### PR TITLE
Bypassing the detect function for Dexcom to fix serial port issue on El Capitan

### DIFF
--- a/lib/drivers/dexcomDriver.js
+++ b/lib/drivers/dexcomDriver.js
@@ -718,7 +718,7 @@ module.exports = function (config) {
     for (var i = 0; i < pagedata.length; ++i) {
       var page = pagedata[i].parsed_payload;
       for (var j = 0; j < page.data.length; ++j) {
-        var reading = _.pick(page.data[j], 'displaySeconds', 'displayDate', 'internalTime', 
+        var reading = _.pick(page.data[j], 'displaySeconds', 'displayDate', 'internalTime',
                              'systemSeconds', 'meterValue');
         reading.pagenum = page.header.pagenum;
         readings.push(reading);
@@ -857,9 +857,11 @@ module.exports = function (config) {
 
 
   return {
-    // using the default detect for this driver
-    // detect: function(cb) {
-    // },
+    //bypassing the detect function for now
+    detect: function (obj, cb) {
+      debug('Dexcom Detect!');
+      cb(null, obj);
+    },
 
     // this function starts the chain, so it has to create but not accept
     // the result (data) object; it's then passed down the rest of the chain
@@ -936,7 +938,7 @@ module.exports = function (config) {
                 data.user_setting_data = result;
                 progress(100);
                 cb(err, data);
-              }); 
+              });
             }
           });
         } else {


### PR DESCRIPTION
On El Capitan, something goes wrong during serial port disconnect and reconnect. This is an issue because between the `detect` and `process` functions we do a disconnect/reconnect.

Bypassing the default `detect` function should not cause any issues, as it does a *connect->getConfigInfo->disconnect->cleanup*, which is repeated directly afterwards in the `process` function with a *connect->getConfigInfo->fetchData->processData->uploadData->disconnect*. This can be verified in `driverManager.js` from line 72 onwards.

Known bug(s):
- If the Dexcom is not unplugged and reconnected after upload, it won't connect again and may need to be power-cycled