### PR TITLE
correct building of date & time changes, albeit separately

### DIFF
--- a/lib/drivers/tandemTslimDriver.js
+++ b/lib/drivers/tandemTslimDriver.js
@@ -1042,49 +1042,50 @@
   };
 
   var buildTimeChangeRecords = function (data, postrecords) {
-    var timeChangeLogs = filterLogEntries([PUMP_LOG_RECORDS.LID_TIME_CHANGED, PUMP_LOG_RECORDS.LID_DATE_CHANGED],
-      data.log_records);
+    var timeChangeLogs = filterLogEntries(
+      [PUMP_LOG_RECORDS.LID_TIME_CHANGED],
+      data.log_records
+    );
 
-    timeChangeLogs.forEach(function(change) {
-      var change_ts = change.header_ts;
-        //console.log(change);
-        var fromTime = change_ts - sundial.floor(change_ts, 'day', cfg.timezone);
-        var toTime = fromTime;
-        var fromDay = sundial.floor(change_ts, 'day', cfg.timezone); //TODO this doesn't appear to actually work because of UTC issues.
-        var toDay = fromDay;
-        if (change.header_id == PUMP_LOG_RECORDS.LID_DATE_CHANGED.value) {
-          toDay =  BASE_TIME + change.date_after * sundial.MIN_TO_MSEC * 60 * 24;
-          fromDay = BASE_TIME + change.date_prior * sundial.MIN_TO_MSEC * 60 * 24;
-        }
-        else if (change.header_id == PUMP_LOG_RECORDS.LID_TIME_CHANGED.value) {
-          toTime = change.time_after;
-          fromTime = change.time_prior;
-        }
-        change.jsDate = new Date(change.rawTimestamp);
-        var lastIndex = change.index;
-        change = cfg.builder.makeDeviceEventTimeChange()
-          .with_time(change.timestamp)
-          .with_deviceTime(change.deviceTime)
-          .with_timezoneOffset(change.timezoneOffset)
-          .with_conversionOffset(0)
-          .with_change({
-            from: sundial.formatDeviceTime(new Date(fromTime + fromDay.valueOf()).toISOString()),
-            to: sundial.formatDeviceTime(new Date(toTime + toDay.valueOf()).toISOString()),
-            agent:'manual'
-          });
-        change.index = lastIndex;  
-        change.done();
-        console.log(change, fromTime, fromDay, fromTime + fromDay.valueOf(), toTime, toDay, toDay.valueOf() + toTime);
-        postrecords.push(change);
-    });
+    var dateChangeLogs = filterLogEntries(
+      [PUMP_LOG_RECORDS.LID_DATE_CHANGED],
+      data.log_records
+    );
 
-    var tzoUtil;
-    if (postrecords.length > 0) {
-     tzoUtil = new TZOUtil(cfg.timezone, postrecords[0].time, postrecords);
+    for (var i = 0; i < timeChangeLogs.length; ++i) {
+      var tc = timeChangeLogs[i];
+      var tc_base = sundial.floor(tc.rawTimestamp, 'day').valueOf();
+      var timechange = cfg.builder.makeDeviceEventTimeChange()
+        .with_change({
+          from: sundial.formatDeviceTime(tc_base + tc.time_prior),
+          to: sundial.formatDeviceTime(tc_base + tc.time_after),
+          agent: 'manual'
+        })
+        .with_deviceTime(tc.deviceTime)
+        .set('index', tc.index);
+      postrecords.push(timechange);
     }
-    else {
-      tzoUtil = new TZOUtil(cfg.timezone, data.log_records[data.log_records.length - 1].timestamp, postrecords);
+
+    for (var j = 0; j < dateChangeLogs.length; ++j) {
+      var dc = dateChangeLogs[j];
+      console.log(dc);
+      var dc_base = BASE_TIME;
+      var datechange = cfg.builder.makeDeviceEventTimeChange()
+        .with_change({
+          from: sundial.formatDeviceTime(BASE_TIME + dc.date_prior * 864e5),
+          to: sundial.formatDeviceTime(BASE_TIME + dc.date_after * 864e5),
+          agent: 'manual'
+        })
+        .with_deviceTime(dc.deviceTime)
+        .set('index', dc.index);
+      postrecords.push(datechange);
     }
+
+    var tzoUtil = new TZOUtil(
+      cfg.timezone,
+      data.log_records[data.log_records.length - 1].timestamp,
+      postrecords
+    );
 
     cfg.tzoUtil = tzoUtil;
     return postrecords;


### PR DESCRIPTION
@gniezen you'll need to start here.

There is a lot to be done before we even get to a stub simulator... This corrects the building of `timeChange` objects, but unfortunately when you change the date & time, we can only get those as two separate events, which may or may not work for bootstrapping - I'm not sure yet.

Next steps are to apply bootstrapping throughout the driver. The current code does not quite follow the strategy discussed in [the BtUTC doc](https://github.com/tidepool-org/chrome-uploader/blob/master/docs/BootstrappingToUTC.md) and is incorrect and/or misleading in some places. We can discuss today.