### PR TITLE
Bolus cleanup

### DIFF
--- a/lib/drivers/tandemTslimDriver.js
+++ b/lib/drivers/tandemTslimDriver.js
@@ -1272,11 +1272,13 @@ module.exports = function (config) {
         }
       }
       if (bolus.bolus_size !== undefined || bolus.insulin_delivered !== undefined) {
-        record = record.with_normal(bolus.insulin_delivered);
         //Tandem represents values with false precision (https://en.wikipedia.org/wiki/False_precision),
         // so we have to specify the number of significant digits when comparing
         if (bolus.bolus_size.toPrecision(SIGNIFICANT_DIGITS) != bolus.insulin_delivered.toPrecision(SIGNIFICANT_DIGITS)) {
+          record = record.with_normal(bolus.insulin_delivered);
           record = record.with_expectedNormal(bolus.bolex_size);
+        }else{
+          record = record.with_normal(bolus.bolus_size); // if there's no significant difference, record the full amount
         }
       }
       if ((bolus.type == 'standard' || bolus.type == 'quickbolus') &&
@@ -1322,7 +1324,6 @@ module.exports = function (config) {
         records.push(wizard_record);
       }
     }
-    console.log('Bolus records:', records);
     return records;
   };
 

--- a/lib/drivers/tandemTslimDriver.js
+++ b/lib/drivers/tandemTslimDriver.js
@@ -567,6 +567,8 @@ module.exports = function (config) {
     }
   };
 
+  var SIGNIFICANT_DIGITS = 5;
+
   var BASE_TIME = Date.UTC(2008, 0, 1, 0, 0, 0).valueOf(); /* new Date(2008, 0, 1, 0, 0, 0).valueOf();*/
   var addTimestamp = function (o, rawTime) {
     o.rawTimestamp = BASE_TIME + rawTime * sundial.SEC_TO_MSEC;
@@ -1271,7 +1273,9 @@ module.exports = function (config) {
       }
       if (bolus.bolus_size !== undefined || bolus.insulin_delivered !== undefined) {
         record = record.with_normal(bolus.insulin_delivered);
-        if (bolus.bolus_size != bolus.insulin_delivered) {
+        //Tandem represents values with false precision (https://en.wikipedia.org/wiki/False_precision),
+        // so we have to specify the number of significant digits when comparing
+        if (bolus.bolus_size.toPrecision(SIGNIFICANT_DIGITS) != bolus.insulin_delivered.toPrecision(SIGNIFICANT_DIGITS)) {
           record = record.with_expectedNormal(bolus.bolex_size);
         }
       }

--- a/lib/drivers/tandemTslimDriver.js
+++ b/lib/drivers/tandemTslimDriver.js
@@ -1104,7 +1104,7 @@ module.exports = function (config) {
         schedule.push({ rate: Math.fround(tdep['basalRate']), start: tdep['startTime'] });
         carbSchedule.push({ amount: Math.fround(tdep['carbRatio']), start: tdep['startTime'] });
         sensitivitySchedule.push({ amount: tdep['ISF'], 'start': tdep['startTime'] });
-        targetSchedule.push({ low: tdep['TargetBG'], high: tdep['TargetBG'], start: tdep['startTime'] });
+        targetSchedule.push({ target: tdep['TargetBG'], start: tdep['startTime'] });
       });
       basalSchedules[scheduleName] = schedule;
       carbSchedules[scheduleName] = carbSchedule;
@@ -1312,8 +1312,6 @@ module.exports = function (config) {
           .with_insulinCarbRatio(bolus.carb_ratio)
           .with_insulinSensitivity(bolus.isf)
           .with_bgTarget({
-            low: bolus.target_bg,
-            high: bolus.target_bg,
             target: bolus.target_bg
           })
           .with_bolus(record)


### PR DESCRIPTION
**WIP**: Don't merge

To fix:
- discard differences in programmed vs. actual delivery below a certain threshold
- verify or fix `expectedDuration` on extended or dual boluses that were cancelled after some insulin delivered 