### PR TITLE
Calculates duration for extended bolus that was cancelled

### DIFF
--- a/lib/drivers/tandemTslimDriver.js
+++ b/lib/drivers/tandemTslimDriver.js
@@ -1334,18 +1334,22 @@ module.exports = function (config) {
 
       // wizard records
       if (_.includes(['standard', 'extended'], bolus.bolus_option) &&
-        bolus.bolus_type_str === 'carb') {
+        (bolus.correction_bolus_included || (bolus.food_bolus_size > 0))) {
+        // a wizard bolus can be a correction bolus or food bolus (or both)
+
+        var netBolus = null;
+        if(bolus.correction_bolus_included) {
+          netBolus = bolus.correction_bolus_size + bolus.food_bolus_size;
+        }else{
+          netBolus = bolus.food_bolus_size;
+        }
+
         var wizard_record = cfg.builder.makeWizard()
           .with_deviceTime(bolus.wizardDeviceTime)
           .with_recommended({
             carb: bolus.food_bolus_size,
             correction: bolus.correction_bolus_size,
-            // TODO: this is WRONG
-            // this field is "after any user override"
-            // which means it's not the net *recommendation*
-            // it's the total requested bolus
-            // we will likely have to reverse-engineer the "net" calculation
-            net: bolus.total_bolus_size
+            net: netBolus
           })
           .with_bgInput(bolus.bg)
           .with_carbInput(bolus.carb_amount)

--- a/lib/drivers/tandemTslimDriver.js
+++ b/lib/drivers/tandemTslimDriver.js
@@ -1238,6 +1238,9 @@ module.exports = function (config) {
         event.header_id == PUMP_LOG_RECORDS.LID_BOLEX_ACTIVATED.value) {
         bolus.startDeviceTime = event.deviceTime;
       }
+      if(event.header_id == PUMP_LOG_RECORDS.LID_BOLEX_COMPLETED.value) {
+        bolus.endDeviceTime = event.deviceTime;
+      }
       if (event.header_id == PUMP_LOG_RECORDS.LID_BOLUS_REQUESTED_MSG1.value) {
         bolus.bc_iob = event.iob;
         bolus.wizardDeviceTime = event.deviceTime;
@@ -1262,14 +1265,22 @@ module.exports = function (config) {
       }
       record = record.with_deviceTime(bolus.deviceTime);
       if (bolus.bolex_size !== undefined) {
-        record = record.with_duration(bolus.duration)
-          .with_extended(bolus.bolex_insulin_delivered);
-        if (bolus.bolex_size != bolus.bolex_insulin_delivered) {
+        //extended bolus
+        if (bolus.bolex_size.toPrecision(SIGNIFICANT_DIGITS)  != bolus.bolex_insulin_delivered.toPrecision(SIGNIFICANT_DIGITS) ) {
+          // extended bolus was cancelled
+          record = record.with_duration(Date.parse(bolus.endDeviceTime) - Date.parse(bolus.startDeviceTime));
+
           if (bolus.bolex_insulin_delivered === undefined) { // cancelled before any insulin was given on dual bolus
             record = record.with_extended(0);
+          }else{
+            record = record.with_extended(bolus.bolex_insulin_delivered);
           }
           record = record.with_expectedExtended(bolus.bolex_size)
             .with_expectedDuration(bolus.duration);
+        }else{
+          //extended bolus completed
+          record = record.with_extended(bolus.bolex_size); //TODO: change this to insulin_delivered if we're rounding
+          record = record.with_duration(bolus.duration);
         }
       }
       if (bolus.bolus_size !== undefined || bolus.insulin_delivered !== undefined) {
@@ -1279,7 +1290,7 @@ module.exports = function (config) {
           record = record.with_normal(bolus.insulin_delivered);
           record = record.with_expectedNormal(bolus.bolex_size);
         }else{
-          record = record.with_normal(bolus.bolus_size); // if there's no significant difference, record the full amount
+          record = record.with_normal(bolus.bolus_size); //TODO: change this to insulin_delivered if we're rounding
         }
       }
       if ((bolus.type == 'standard' || bolus.type == 'quickbolus') &&

--- a/lib/drivers/tandemTslimDriver.js
+++ b/lib/drivers/tandemTslimDriver.js
@@ -278,25 +278,43 @@ module.exports = function (config) {
       value: 0x3B,
       name: 'Extended Bolus Activated Event',
       format: 'h..ff....',
-      fields: ['bolus_id', 'iob', 'bolex_size']
+      fields: ['bolus_id', 'iob', 'bolex_size'],
+      postprocess: function (rec) {
+        rec.bolex_size = rec.bolex_size.toFixedNumber(SIGNIFICANT_DIGITS);
+        rec.iob = rec.iob.toFixedNumber(SIGNIFICANT_DIGITS);
+      }
     },
     LID_BOLEX_COMPLETED: {
       value: 0x15,
       name: 'Extended Portion of a Bolus Complete Event',
       format: '..hfff',
-      fields: ['bolus_id', 'iob', 'bolex_insulin_delivered', 'bolex_insulin_requested']
+      fields: ['bolus_id', 'iob', 'bolex_insulin_delivered', 'bolex_insulin_requested'],
+      postprocess: function (rec) {
+        rec.bolex_insulin_delivered = rec.bolex_insulin_delivered.toFixedNumber(SIGNIFICANT_DIGITS);
+        rec.bolex_insulin_requested = rec.bolex_insulin_requested.toFixedNumber(SIGNIFICANT_DIGITS);
+        rec.iob = rec.iob.toFixedNumber(SIGNIFICANT_DIGITS);
+      }
     },
     LID_BOLUS_ACTIVATED: {
       value: 0x37,
       name: 'Bolus Activated Event',
       format: 'h..ff....',
-      fields: ['bolus_id', 'iob', 'bolus_size']
+      fields: ['bolus_id', 'iob', 'bolus_size'],
+      postprocess: function (rec) {
+        rec.bolus_size = rec.bolus_size.toFixedNumber(SIGNIFICANT_DIGITS);
+        rec.iob = rec.iob.toFixedNumber(SIGNIFICANT_DIGITS);
+      }
     },
     LID_BOLUS_COMPLETED: {
       value: 0x14,
       name: 'Bolus Completed Event',
       format: '..hfff',
-      fields: ['bolus_id', 'iob', 'insulin_delivered', 'insulin_requested']
+      fields: ['bolus_id', 'iob', 'insulin_delivered', 'insulin_requested'],
+      postprocess: function (rec) {
+        rec.insulin_delivered = rec.insulin_delivered.toFixedNumber(SIGNIFICANT_DIGITS);
+        rec.insulin_requested = rec.insulin_requested.toFixedNumber(SIGNIFICANT_DIGITS);
+        rec.iob = rec.iob.toFixedNumber(SIGNIFICANT_DIGITS);
+      }
     },
     LID_BOLUS_REQUESTED_MSG1: {
       value: 0x40,
@@ -311,6 +329,7 @@ module.exports = function (config) {
           rec.bolus_type_str = 'carb';
         }
         rec.carb_ratio = rec.carb_ratio * 0.001;
+        rec.iob = rec.iob.toFixedNumber(SIGNIFICANT_DIGITS);
       }
     },
     LID_BOLUS_REQUESTED_MSG2: {
@@ -335,7 +354,12 @@ module.exports = function (config) {
       value: 0x42,
       name: 'Bolus Requested Event 3 of 3',
       format: 'h..fff',
-      fields: ['bolus_id', 'food_bolus_size', 'correction_bolus_size', 'total_bolus_size']
+      fields: ['bolus_id', 'food_bolus_size', 'correction_bolus_size', 'total_bolus_size'],
+      postprocess: function (rec) {
+        rec.food_bolus_size = rec.food_bolus_size.toFixedNumber(SIGNIFICANT_DIGITS);
+        rec.correction_bolus_size = rec.correction_bolus_size.toFixedNumber(SIGNIFICANT_DIGITS);
+        rec.total_bolus_size = rec.total_bolus_size.toFixedNumber(SIGNIFICANT_DIGITS);
+      }
     },
     LID_CANNULA_FILLED: {
       value: 0x3D,
@@ -420,7 +444,7 @@ module.exports = function (config) {
       fields: ['idp', 'modification', 'bolus_status', 'insulin_duration', 'max_bolus_size', 'bolus_entry_type'],
       postprocess: function (rec) {
         rec.insulin_duration = rec.insulin_duration * sundial.MIN_TO_MSEC;
-        rec.max_bolus_size = rec.max_bolus_size * 0.001;
+        rec.max_bolus_size = (rec.max_bolus_size * 0.001).toFixedNumber(SIGNIFICANT_DIGITS);
         // TODO: status
       }
     },
@@ -573,7 +597,13 @@ module.exports = function (config) {
     }
   };
 
+  // Tandem represents values with false precision (https://en.wikipedia.org/wiki/False_precision),
+  // so we have to specify the number of significant digits
   var SIGNIFICANT_DIGITS = 5;
+  Number.prototype.toFixedNumber = function(significant){
+    var pow = Math.pow(10,significant);
+    return +( Math.round(this*pow) / pow );
+  }
 
   var BASE_TIME = Date.UTC(2008, 0, 1, 0, 0, 0).valueOf(); /* new Date(2008, 0, 1, 0, 0, 0).valueOf();*/
   var addTimestamp = function (o, rawTime) {
@@ -1281,8 +1311,7 @@ module.exports = function (config) {
       if (bolus.bolex_size !== undefined) {
         // extended bolus
         // first case: extended bolus was cancelled
-        if (bolus.bolex_size.toPrecision(SIGNIFICANT_DIGITS) !==
-          bolus.bolex_insulin_delivered.toPrecision(SIGNIFICANT_DIGITS)) {
+        if (bolus.bolex_size !== bolus.bolex_insulin_delivered) {
           record = record.with_duration(
             Date.parse(bolus.endDeviceTime) - Date.parse(bolus.extendedStartDeviceTime)
           );
@@ -1298,20 +1327,17 @@ module.exports = function (config) {
         }
         // other case: extended bolus completed
         else {
-          record = record.with_extended(bolus.bolex_size); //TODO: change this to insulin_delivered if we're rounding
+          record = record.with_extended(bolus.insulin_delivered);
           record = record.with_duration(bolus.duration);
         }
       }
       if (bolus.bolus_size !== undefined || bolus.insulin_delivered !== undefined) {
-        // Tandem represents values with false precision (https://en.wikipedia.org/wiki/False_precision),
-        // so we have to specify the number of significant digits when comparing
-        if (bolus.bolus_size.toPrecision(SIGNIFICANT_DIGITS) !==
-          bolus.insulin_delivered.toPrecision(SIGNIFICANT_DIGITS)) {
+        if (bolus.bolus_size !== bolus.insulin_delivered) {
           record = record.with_normal(bolus.insulin_delivered);
           record = record.with_expectedNormal(bolus.bolex_size);
         }
         else {
-          record = record.with_normal(bolus.bolus_size); //TODO: change this to insulin_delivered if we're rounding
+          record = record.with_normal(bolus.insulin_delivered);
         }
       }
       // non-extended bolus cancelled before any insulin was given

--- a/lib/drivers/tandemTslimDriver.js
+++ b/lib/drivers/tandemTslimDriver.js
@@ -1327,7 +1327,7 @@ module.exports = function (config) {
         }
         // other case: extended bolus completed
         else {
-          record = record.with_extended(bolus.insulin_delivered);
+          record = record.with_extended(bolus.bolex_insulin_delivered);
           record = record.with_duration(bolus.duration);
         }
       }

--- a/lib/drivers/tandemTslimDriver.js
+++ b/lib/drivers/tandemTslimDriver.js
@@ -603,7 +603,7 @@ module.exports = function (config) {
   Number.prototype.toFixedNumber = function(significant){
     var pow = Math.pow(10,significant);
     return +( Math.round(this*pow) / pow );
-  }
+  };
 
   var BASE_TIME = Date.UTC(2008, 0, 1, 0, 0, 0).valueOf(); /* new Date(2008, 0, 1, 0, 0, 0).valueOf();*/
   var addTimestamp = function (o, rawTime) {

--- a/lib/drivers/tandemTslimDriver.js
+++ b/lib/drivers/tandemTslimDriver.js
@@ -1364,9 +1364,10 @@ module.exports = function (config) {
         // a wizard bolus can be a correction bolus or food bolus (or both)
 
         var netBolus = null;
-        if(bolus.correction_bolus_included) {
+        if (bolus.correction_bolus_included) {
           netBolus = bolus.correction_bolus_size + bolus.food_bolus_size;
-        }else{
+        }
+        else {
           netBolus = bolus.food_bolus_size;
         }
 
@@ -1375,7 +1376,7 @@ module.exports = function (config) {
           .with_recommended({
             carb: bolus.food_bolus_size,
             correction: bolus.correction_bolus_size,
-            net: netBolus
+            net: netBolus.toFixedNumber(SIGNIFICANT_DIGITS)
           })
           .with_bgInput(bolus.bg)
           .with_carbInput(bolus.carb_amount)

--- a/lib/drivers/tandemTslimDriver.js
+++ b/lib/drivers/tandemTslimDriver.js
@@ -304,6 +304,12 @@ module.exports = function (config) {
       format: 'hbbhhfi',
       fields: ['bolus_id', 'bolus_type', 'correction_bolus_included', 'carb_amount', 'bg', 'iob', 'carb_ratio'],
       postprocess: function (rec) {
+        if (rec.bolus_type === 0) {
+          rec.bolus_type_str = 'insulin';
+        }
+        else if (rec.bolus_type === 1) {
+          rec.bolus_type_str = 'carb';
+        }
         rec.carb_ratio = rec.carb_ratio * 0.001;
       }
     },
@@ -314,13 +320,13 @@ module.exports = function (config) {
       fields: ['bolus_id', 'options', 'standard_percent', 'duration', 'isf', 'target_bg', 'user_override', 'declined_correction'],
       postprocess: function (rec) {
         if (rec.options === 0) {
-          rec.type = 'standard';
+          rec.bolus_option = 'standard';
         }
         else if (rec.options === 1) {
-          rec.type = 'extended';
+          rec.bolus_option = 'extended';
         }
         else if (rec.options == 2) {
-          rec.type = 'quickbolus';
+          rec.bolus_option = 'quickbolus';
         }
         rec.duration = rec.duration * sundial.MIN_TO_MSEC;
       }
@@ -1224,24 +1230,32 @@ module.exports = function (config) {
   };
 
   var buildBolusRecords = function (data, records) {
-    var bolusLogs = filterLogEntries([PUMP_LOG_RECORDS.LID_BOLUS_ACTIVATED, PUMP_LOG_RECORDS.LID_BOLUS_COMPLETED,
-      PUMP_LOG_RECORDS.LID_BOLEX_ACTIVATED, PUMP_LOG_RECORDS.LID_BOLEX_COMPLETED,
-      PUMP_LOG_RECORDS.LID_BOLUS_REQUESTED_MSG1, PUMP_LOG_RECORDS.LID_BOLUS_REQUESTED_MSG2,
-      PUMP_LOG_RECORDS.LID_BOLUS_REQUESTED_MSG3],
-      data.log_records);
+    var bolusLogs = filterLogEntries([
+        PUMP_LOG_RECORDS.LID_BOLUS_ACTIVATED,
+        PUMP_LOG_RECORDS.LID_BOLUS_COMPLETED,
+        PUMP_LOG_RECORDS.LID_BOLEX_ACTIVATED,
+        PUMP_LOG_RECORDS.LID_BOLEX_COMPLETED,
+        PUMP_LOG_RECORDS.LID_BOLUS_REQUESTED_MSG1,
+        PUMP_LOG_RECORDS.LID_BOLUS_REQUESTED_MSG2,
+        PUMP_LOG_RECORDS.LID_BOLUS_REQUESTED_MSG3
+      ],
+      data.log_records
+    );
     console.log('Boluses:', bolusLogs);
     var boluses = {};
-    bolusLogs.forEach(function (event) {
+    bolusLogs.forEach(function(event) {
       var bolusId = event.bolus_id;
       var bolus = _.defaults({ bolus_id: bolusId }, boluses[bolusId], event);
-      if (event.header_id == PUMP_LOG_RECORDS.LID_BOLUS_ACTIVATED.value ||
-        event.header_id == PUMP_LOG_RECORDS.LID_BOLEX_ACTIVATED.value) {
+      if (event.header_id === PUMP_LOG_RECORDS.LID_BOLUS_ACTIVATED.value) {
         bolus.startDeviceTime = event.deviceTime;
       }
-      if(event.header_id == PUMP_LOG_RECORDS.LID_BOLEX_COMPLETED.value) {
+      if (event.header_id === PUMP_LOG_RECORDS.LID_BOLEX_ACTIVATED.value) {
+        bolus.extendedStartDeviceTime = event.deviceTime;
+      }
+      if (event.header_id === PUMP_LOG_RECORDS.LID_BOLEX_COMPLETED.value) {
         bolus.endDeviceTime = event.deviceTime;
       }
-      if (event.header_id == PUMP_LOG_RECORDS.LID_BOLUS_REQUESTED_MSG1.value) {
+      if (event.header_id === PUMP_LOG_RECORDS.LID_BOLUS_REQUESTED_MSG1.value) {
         bolus.bc_iob = event.iob;
         bolus.wizardDeviceTime = event.deviceTime;
       }
@@ -1252,7 +1266,7 @@ module.exports = function (config) {
       var record;
 
       // bolus records
-      if (bolus.bolex_size !== undefined || bolus.type == 'extended') {
+      if (bolus.bolex_size !== undefined || bolus.type === 'extended') {
         if (bolus.bolus_size !== undefined || bolus.bolus_insulin_requested !== undefined) {
           record = cfg.builder.makeDualBolus();
         }
@@ -1265,57 +1279,72 @@ module.exports = function (config) {
       }
       record = record.with_deviceTime(bolus.deviceTime);
       if (bolus.bolex_size !== undefined) {
-        //extended bolus
-        if (bolus.bolex_size.toPrecision(SIGNIFICANT_DIGITS)  != bolus.bolex_insulin_delivered.toPrecision(SIGNIFICANT_DIGITS) ) {
-          // extended bolus was cancelled
-          record = record.with_duration(Date.parse(bolus.endDeviceTime) - Date.parse(bolus.startDeviceTime));
-
-          if (bolus.bolex_insulin_delivered === undefined) { // cancelled before any insulin was given on dual bolus
+        // extended bolus
+        // first case: extended bolus was cancelled
+        if (bolus.bolex_size.toPrecision(SIGNIFICANT_DIGITS) !==
+          bolus.bolex_insulin_delivered.toPrecision(SIGNIFICANT_DIGITS)) {
+          record = record.with_duration(
+            Date.parse(bolus.endDeviceTime) - Date.parse(bolus.extendedStartDeviceTime)
+          );
+          // cancelled before any insulin was given on dual bolus
+          if (bolus.bolex_insulin_delivered === undefined) {
             record = record.with_extended(0);
-          }else{
+          }
+          else {
             record = record.with_extended(bolus.bolex_insulin_delivered);
           }
           record = record.with_expectedExtended(bolus.bolex_size)
             .with_expectedDuration(bolus.duration);
-        }else{
-          //extended bolus completed
+        }
+        // other case: extended bolus completed
+        else {
           record = record.with_extended(bolus.bolex_size); //TODO: change this to insulin_delivered if we're rounding
           record = record.with_duration(bolus.duration);
         }
       }
       if (bolus.bolus_size !== undefined || bolus.insulin_delivered !== undefined) {
-        //Tandem represents values with false precision (https://en.wikipedia.org/wiki/False_precision),
+        // Tandem represents values with false precision (https://en.wikipedia.org/wiki/False_precision),
         // so we have to specify the number of significant digits when comparing
-        if (bolus.bolus_size.toPrecision(SIGNIFICANT_DIGITS) != bolus.insulin_delivered.toPrecision(SIGNIFICANT_DIGITS)) {
+        if (bolus.bolus_size.toPrecision(SIGNIFICANT_DIGITS) !==
+          bolus.insulin_delivered.toPrecision(SIGNIFICANT_DIGITS)) {
           record = record.with_normal(bolus.insulin_delivered);
           record = record.with_expectedNormal(bolus.bolex_size);
-        }else{
+        }
+        else {
           record = record.with_normal(bolus.bolus_size); //TODO: change this to insulin_delivered if we're rounding
         }
       }
-      if ((bolus.type == 'standard' || bolus.type == 'quickbolus') &&
-        bolus.bolus_size === undefined) { // cancelled before any insulin was given
+      // non-extended bolus cancelled before any insulin was given
+      if ((bolus.type == 'standard' || bolus.type === 'quickbolus') &&
+        bolus.bolus_size === undefined) {
         record.with_normal(0)
           .with_expectedNormal(bolus.insulin_requested);
       }
-      if (bolus.type == 'extended' && bolus.bolex_size === undefined) { // cancelled before any insulin was given
+      // extended bolus cancelled before any insulin was given
+      if (bolus.type == 'extended' && bolus.bolex_size === undefined) {
         record.with_duration(0)
           .with_extended(0)
           .with_expectedDuration(bolus.duration)
           .with_expectedExtended(bolus.bolex_insulin_requested);
       }
-      record = record.set('index',bolus.index);
+      record = record.set('index', bolus.index);
       cfg.tzoUtil.fillInUTCInfo(record, bolus.jsDate);
       console.log(boluses[key], record);
       records.push(record.done());
 
       // wizard records
-      if (bolus.total_bolus_size !== undefined && bolus.target_bg !== 0 && bolus.target_bg) {
+      if (_.includes(['standard', 'extended'], bolus.bolus_option) &&
+        bolus.bolus_type_str === 'carb') {
         var wizard_record = cfg.builder.makeWizard()
           .with_deviceTime(bolus.wizardDeviceTime)
           .with_recommended({
             carb: bolus.food_bolus_size,
             correction: bolus.correction_bolus_size,
+            // TODO: this is WRONG
+            // this field is "after any user override"
+            // which means it's not the net *recommendation*
+            // it's the total requested bolus
+            // we will likely have to reverse-engineer the "net" calculation
             net: bolus.total_bolus_size
           })
           .with_bgInput(bolus.bg)


### PR DESCRIPTION
- Used the time of the "Extended Bolus Completed" (`LID_BOLEX_COMPLETED`) event to determine the actual duration of the extended bolus in the case where it was cancelled. 
- Refactored the extended bolus code to make it a bit clearer.