### PR TITLE
Serial send fix

### DIFF
--- a/lib/drivers/tandemTslimDriver.js
+++ b/lib/drivers/tandemTslimDriver.js
@@ -600,6 +600,7 @@ module.exports = function (config) {
   };
 
   var TIMEOUT_ERROR = 'Timeout while attempting to talk to pump';
+  var SEND_INC = 5;  // amount to increment interval by if serial send pending
 
   var BASE_TIME = Date.UTC(2008, 0, 1, 0, 0, 0).valueOf(); /* new Date(2008, 0, 1, 0, 0, 0).valueOf();*/
   var addTimestamp = function (o, rawTime) {
@@ -826,6 +827,17 @@ module.exports = function (config) {
     cfg.deviceComms.writeSerial(commandPacket, callback);
   };
 
+  var backoff = function(err, sendFrequency, callback) {
+      if(sendFrequency < (SEND_INC*10)) {
+        sendFrequency += SEND_INC; //back off a bit
+        console.log('now sending every ', sendFrequency, ' ms');
+        return sendFrequency;
+      }else{
+        // giving up
+        callback(Error('Please keep Uploader window in foreground and try again.'));
+      }
+  };
+
   var tandemLogRequester = function (start, end, progress, callback) {
     // TODO implement and test multi-record download commands (my pump doesn't support the command) -- Matthias
 
@@ -839,6 +851,8 @@ module.exports = function (config) {
     var delay = [];
     var percentage = 0;
     var prevPercentage = 0;
+    var sendFrequency = SEND_INC;
+
     var abortCallback = function () {
       if (alarm_seq == receive_seq) {
         console.log('no activity in 5 seconds');
@@ -861,15 +875,19 @@ module.exports = function (config) {
       if (!recovering) {
         tandemCommand(COMMANDS.LOG_ENTRY_SEQ_REQ, [send_seq++], function (err) {
           if(err) {
-            clearInterval(sendTimer);
-            callback(err,null);
+            if(err.message === 'pending') {
+              sendFrequency = backoff(err,sendFrequency,callback);
+            }else{
+              clearInterval(sendTimer);
+              callback(err,null);
+            }
           }
         });
       }
       if (send_seq > end) {
         clearInterval(sendTimer);
       }
-    }, 5); //if we spin too quickly on this (1ms), packets don't get sent when window doesn't have focus
+    }, sendFrequency); //if we spin too quickly on this, packets don't get sent when window doesn't have focus
 
     var listenTimer = setInterval(function () {
       //console.log('awaiting packets');
@@ -934,6 +952,7 @@ module.exports = function (config) {
     var receive_seq = start;
     var alarm_seq = -1;
     var recovering = false;
+    var sendFrequency = SEND_INC;
 
     // this contains only the log events that we consider to define
     // a set of events that can truly be considered "pump data"
@@ -972,15 +991,19 @@ module.exports = function (config) {
       if (!recovering) {
         tandemCommand(COMMANDS.LOG_ENTRY_SEQ_REQ, [send_seq--], function (err) {
           if(err) {
-            clearInterval(sendTimer);
-            callback(err,null);
+            if(err.message === 'pending') {
+              sendFrequency = backoff(err,sendFrequency,callback);
+            }else{
+              clearInterval(sendTimer);
+              callback(err,null);
+            }
           }
         });
       }
       if (send_seq < end_seq) { // we've gone back far enough
         clearInterval(sendTimer);
       }
-    }, 5); //if we spin too quickly on this (1ms), packets don't get sent when window doesn't have focus
+    }, sendFrequency); //if we spin too quickly on this, packets don't get sent when window doesn't have focus
 
     var listenTimer = setInterval(function () {
       while (cfg.deviceComms.hasAvailablePacket()) {

--- a/lib/drivers/tandemTslimDriver.js
+++ b/lib/drivers/tandemTslimDriver.js
@@ -1637,8 +1637,6 @@ module.exports = function (config) {
 
     connect: function (progress, data, cb) {
       console.log('connecting');
-      data.deviceInfo.bitrate = 921600;
-      data.deviceInfo.ctsFlowControl = true;
       cfg.deviceComms.connect(data.deviceInfo, tandemPacketHandler, probe, function (err) {
         if(err) {
           cb(err,null);

--- a/lib/serialDevice.js
+++ b/lib/serialDevice.js
@@ -34,7 +34,7 @@ var moduleCounter = 1;
 
 var SEND_ERRORS = {
   'disconnected' : 'Disconnected. Reconnect the device.',
-  'pending' : 'A send was already pending.',
+  'pending' : 'pending', // this should be handled, not displayed
   'timeout' : 'The send timed out.',
   'system_error' : 'A system error occurred. Reconnect the device.'
 };

--- a/manifest.json
+++ b/manifest.json
@@ -69,7 +69,9 @@
           "driverId": "TandemTslim",
           "mode": "serial",
           "vendorId": 1155,
-          "productId": 22336
+          "productId": 22336,
+          "bitrate": 921600,
+          "ctsFlowControl": true
         },
         {
 		  "deviceName": "OneTouchUltra2 w/FTDI cable",

--- a/manifest.json
+++ b/manifest.json
@@ -71,7 +71,8 @@
           "vendorId": 1155,
           "productId": 22336,
           "bitrate": 921600,
-          "ctsFlowControl": true
+          "ctsFlowControl": true,
+          "sendTimeout": 5000
         },
         {
 		  "deviceName": "OneTouchUltra2 w/FTDI cable",


### PR DESCRIPTION
When the Uploader window is not in focus, the thread priority changes and packets in the serial port buffer are not send immediately. As we're sending and receiving packets in parallel instead of sequentially, this means we have to wait a bit longer before trying to send the packet again. This PR implements a backoff algorithm when a serial port send is pending.