### PR TITLE
fix debug mode \o/

### DIFF
--- a/lib/driverManager.js
+++ b/lib/driverManager.js
@@ -22,11 +22,6 @@ var statusManager = require('./statusManager.js');
 var debug = require('./bows')('DriverManager');
 
 var isChromeApp = (typeof chrome !== 'undefined');
-if (!isChromeApp) {
-  /* jshint ignore:start */
-  var __DEBUG__;
-  /* jshint ignore:end */
-}
 
 module.exports = function (driverObjects, configs) {
   var drivers = {};
@@ -158,6 +153,7 @@ module.exports = function (driverObjects, configs) {
 
       // no try/catch for local development is the easiest/only(?) way to get good stack traces!
       if (__DEBUG__ === true) {
+        debug('DriverManager set up in debug mode: all non-device comms errors will throw in console.');
         async.waterfall([
           drvr.setup.bind(drvr, deviceInfo, stat.progressForStep(0)),
           drvr.connect.bind(drvr, stat.progressForStep(1)),
@@ -174,6 +170,7 @@ module.exports = function (driverObjects, configs) {
         });
       }
       else {
+        debug('DriverManager set up in normal mode: all errors will surface in UI only.');
         async.waterfall([
           drvr.setup.bind(drvr, deviceInfo, stat.progressForStep(0)),
           connect,


### PR DESCRIPTION
JavaScript/webpack trivia question: why did this reverse the breakage of debug mode even when `isChromeApp === true`?

(Somehow the stuff inside the `if` block was *locally* (that is, only in this module) messing up the global `__DEBUG__` variable, even when the `if` block wasn't triggered. Huh?)