### PR TITLE
fix Tandem read only from most recent pump shut down when non-DEBUG mode

### DIFF
--- a/lib/drivers/tandemTslimDriver.js
+++ b/lib/drivers/tandemTslimDriver.js
@@ -1720,25 +1720,33 @@ module.exports = function (config) {
       */
       if (!__DEBUG__) {
         data.log_records = _.takeRightWhile(data.log_records, function(rec) {
-          if (rec.change_type && rec.change_type === 'pump_shut_down') {
+          if (rec.change_types &&
+            rec.change_types.search('pump_shut_down') !== -1) {
+            debug('Most recent pump shut down:', rec);
             return false;
           }
           return true;
         });
+        debug('Will process', data.log_records.length, 'log records.');
       }
 
-      postrecords = buildSettingsRecords(data, postrecords);
-      if (!_.isEmpty(postrecords)) {
-        settings = postrecords[0];
-      }
-      postrecords = buildTimeChangeRecords(data, postrecords);
-      postrecords = buildBolusRecords(data, postrecords);
+      if (!_.isEmpty(data.log_records)) {
+        postrecords = buildSettingsRecords(data, postrecords);
+        if (!_.isEmpty(postrecords)) {
+          settings = postrecords[0];
+        }
+        postrecords = buildTimeChangeRecords(data, postrecords);
+        postrecords = buildBolusRecords(data, postrecords);
 
-      postrecords = buildBasalRecords(data, postrecords);
-      postrecords = buildNewDayRecords(data, postrecords);
-      postrecords = buildBGRecords(data, postrecords);
-      // sort by time for the simulator
-      postrecords = _.sortBy(postrecords, function(d) { return d.time; });
+        postrecords = buildBasalRecords(data, postrecords);
+        postrecords = buildNewDayRecords(data, postrecords);
+        postrecords = buildBGRecords(data, postrecords);
+        // sort by time for the simulator
+        postrecords = _.sortBy(postrecords, function(d) { return d.time; });
+      }
+      else {
+        throw new Error('No records since most recent pump shut down; nothing to upload.');
+      }
       var simulator = tandemSimulatorMaker.make({settings: settings, profiles:data.profiles});
 
       for (var n = 0; n < postrecords.length; ++n) {


### PR DESCRIPTION
What it says on the tin. I hadn't adjusted the check for a shut down since we changed the way we read basal change types. /o\

Review please @gniezen and let's publish a new build to the devel Chrome store.