### PR TITLE
Added a note about the non-termination of `npm start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ WARNING! THIS SOURCE CODE IS UNDER ACTIVE DEVELOPMENT AND IS KNOWN TO BE INCOMPL
 1. Clone this repository.
 1. Run `npm install`
 1. Set the config for the environment you want to target (see Config section below)
-1. Run `npm start` (will bundle files, and watch for changes)
+1. Run `npm start` (will bundle files, and watch for changes.  When it stops printing output you can continue to the next step.)
 1. Open Chrome. Go to chrome://extensions and turn on Developer mode (checkbox on the top line).
 1. Click "Load Unpacked Extension".
 1. Choose the directory you checked out above and click OK.


### PR DESCRIPTION
A very small addition to the compilation steps documentation for the chrome uploader to reduce a little confusion, and to file my agreement to the VCLA:

I agree to the terms of Tidepool Project’s Volunteer/Contributor License Agreement v1.0
as it exists at http://tidepool-org.github.io/TidepoolVCLA.pdf on November 16, 2015.