### PR TITLE
fix hide devices

### DIFF
--- a/lib/components/App.jsx
+++ b/lib/components/App.jsx
@@ -75,8 +75,6 @@ var App = React.createClass({
       return this.renderSignupLink();
     }
 
-    appState.hideUnavailableDevices();
-
     return <LoggedInAs
       dropMenu={this.state.dropMenu}
       user={this.state.user}

--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -178,7 +178,9 @@ appActions.load = function(cb) {
   var getOS = function(cb) {
     if (typeof chrome !== 'undefined') { // test environment is not chrome
       chrome.runtime.getPlatformInfo(function (platformInfo) {
-        self.app._os = platformInfo.os;
+        self.app.setState({_os: platformInfo.os}, function() {
+          self._hideUnavailableDevices();
+        });
         cb();
       });
     }else{
@@ -378,17 +380,17 @@ appActions.detectDevices = function(cb) {
   });
 };
 
-appActions.hideUnavailableDevices = function() {
+appActions._hideUnavailableDevices = function() {
   var uploads = _.cloneDeep(this.app.state.uploads);
   // this.app._os can be "mac", "win", "android", "cros", "linux", or "openbsd"
-  if (this.app._os === 'mac') {
+  if (this.app.state._os === 'mac') {
     uploads = _.reject(uploads, function(d) {
       return d.key === 'precisionxtra' ||
       d.key === 'abbottfreestylelite' ||
       d.key === 'abbottfreestylefreedomlite';
     });
   }
-  else if (this.app._os === 'win') {
+  else if (this.app.state._os === 'win') {
     uploads = _.reject(uploads, function(d) {
       return d.key === 'tandem';
     });

--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -378,6 +378,24 @@ appActions.detectDevices = function(cb) {
   });
 };
 
+appActions.hideUnavailableDevices = function() {
+  var uploads = _.cloneDeep(this.app.state.uploads);
+  // this.app._os can be "mac", "win", "android", "cros", "linux", or "openbsd"
+  if (this.app._os === 'mac') {
+    uploads = _.reject(uploads, function(d) {
+      return d.key === 'precisionxtra' ||
+      d.key === 'abbottfreestylelite' ||
+      d.key === 'abbottfreestylefreedomlite';
+    });
+  }
+  else if (this.app._os === 'win') {
+    uploads = _.reject(uploads, function(d) {
+      return d.key === 'tandem';
+    });
+  }
+  this.app.setState({uploads: uploads});
+};
+
 appActions.chooseDevices = function() {
   this.app.setState({
     page: 'settings',

--- a/lib/state/appState.js
+++ b/lib/state/appState.js
@@ -109,14 +109,6 @@ appState.getInitial = function() {
   };
 };
 
-appState.hideUnavailableDevices = function() {
-  if(this.app._os === 'mac') { // this.app._os can be "mac", "win", "android", "cros", "linux", or "openbsd"
-    this.app.state.uploads = _.reject(this.app.state.uploads, function(d){
-      return d.key === 'precisionxtra' || d.key === 'abbottfreestylelite' || d.key === 'abbottfreestylefreedomlite';
-    });
-  }
-};
-
 appState.isLoggedIn = function() {
   return Boolean(this.app.state.user);
 };

--- a/test/ui/testAppActions.js
+++ b/test/ui/testAppActions.js
@@ -556,12 +556,12 @@ describe('appActions', function() {
 
     describe('[windows]', function() {
       beforeEach(function() {
-        app._os = 'win';
+        app.setState({_os: 'win'});
       });
 
       it('excludes only Tandem', function() {
         expect(app.state.uploads.length).to.equal(10);
-        appActions.hideUnavailableDevices();
+        appActions._hideUnavailableDevices();
         expect(app.state.uploads.length).to.equal(9);
         expect(_.findWhere(app.state.uploads, {key: 'tandem'})).to.not.be.ok;
       });
@@ -569,12 +569,12 @@ describe('appActions', function() {
 
     describe('[mac]', function() {
       beforeEach(function() {
-        app._os = 'mac';
+        app.setState({_os: 'mac'});
       });
 
       it('excludes all Abbott devices', function() {
         expect(app.state.uploads.length).to.equal(10);
-        appActions.hideUnavailableDevices();
+        appActions._hideUnavailableDevices();
         expect(app.state.uploads.length).to.equal(7);
         expect(_.findWhere(app.state.uploads, {key: 'precisionxtra'})).to.not.be.ok;
         expect(_.findWhere(app.state.uploads, {key: 'abbottfreestylelite'})).to.not.be.ok;

--- a/test/ui/testAppActions.js
+++ b/test/ui/testAppActions.js
@@ -548,6 +548,41 @@ describe('appActions', function() {
 
   });
 
+  describe('hideUnavailableDevices', function() {
+    beforeEach(function() {
+      var state = appState.getInitial();
+      app.setState(state);
+    });
+
+    describe('[windows]', function() {
+      beforeEach(function() {
+        app._os = 'win';
+      });
+
+      it('excludes only Tandem', function() {
+        expect(app.state.uploads.length).to.equal(10);
+        appActions.hideUnavailableDevices();
+        expect(app.state.uploads.length).to.equal(9);
+        expect(_.findWhere(app.state.uploads, {key: 'tandem'})).to.not.be.ok;
+      });
+    });
+
+    describe('[mac]', function() {
+      beforeEach(function() {
+        app._os = 'mac';
+      });
+
+      it('excludes all Abbott devices', function() {
+        expect(app.state.uploads.length).to.equal(10);
+        appActions.hideUnavailableDevices();
+        expect(app.state.uploads.length).to.equal(7);
+        expect(_.findWhere(app.state.uploads, {key: 'precisionxtra'})).to.not.be.ok;
+        expect(_.findWhere(app.state.uploads, {key: 'abbottfreestylelite'})).to.not.be.ok;
+        expect(_.findWhere(app.state.uploads, {key: 'abbottfreestylefreedomlite'})).to.not.be.ok;
+      });
+    });
+  });
+
   describe('chooseDevices', function() {
     beforeEach(function() {
       app.state = {

--- a/test/ui/testAppState.js
+++ b/test/ui/testAppState.js
@@ -43,43 +43,6 @@ describe('appState', function() {
     expect(appState.app.state.FOO).to.equal('bar');
   });
 
-  describe('Hide BGMs in UI if not available for a specific OS', function() {
-
-    it('checks devices listed for Windows', function() {
-
-      app._os = 'win';
-      app.state = appState.getInitial();
-      appState.hideUnavailableDevices();
-
-      // should be available
-      expect(_.findWhere(app.state.uploads, {key: 'precisionxtra'})).to.be.ok;
-      expect(_.findWhere(app.state.uploads, {key: 'bayercontournext'})).to.be.ok;
-      expect(_.findWhere(app.state.uploads, {key: 'bayercontournextusb'})).to.be.ok;
-      expect(_.findWhere(app.state.uploads, {key: 'bayercontourusb'})).to.be.ok;
-      expect(_.findWhere(app.state.uploads, {key: 'abbottfreestylelite'})).to.be.ok;
-      expect(_.findWhere(app.state.uploads, {key: 'abbottfreestylefreedomlite'})).to.be.ok;
-
-    });
-
-    it('checks devices listed for Mac', function() {
-
-      app._os = 'mac';
-      app.state = appState.getInitial();
-      appState.hideUnavailableDevices();
-
-      // should be available
-      expect(_.findWhere(app.state.uploads, {key: 'bayercontournextusb'})).to.be.ok;
-      expect(_.findWhere(app.state.uploads, {key: 'bayercontourusb'})).to.be.ok;
-      expect(_.findWhere(app.state.uploads, {key: 'bayercontournext'})).to.be.ok;
-
-      // should not be available
-      expect(_.findWhere(app.state.uploads, {key: 'precisionxtra'})).to.not.be.ok;
-      expect(_.findWhere(app.state.uploads, {key: 'abbottfreestylelite'})).to.not.be.ok;
-      expect(_.findWhere(app.state.uploads, {key: 'abbottfreestylefreedomlite'})).to.not.be.ok;
-    });
-
-  });
-
   describe('isLoggedIn', function() {
 
     it('returns true if there is a logged-in user object', function() {


### PR DESCRIPTION
A decision was made - given ongoing issues with Tandem on Windows - to remove Tandem from the device menu on Windows machines. When I went to go do this, I discovered that the implementation of `hideUnavailableDevices` was pretty problematic - located in appState instead of appActions where it logically belongs, being called during the React render cycle (surprised this wasn't causing an Invariant Violation, TBH), and mutating React state directly instead of using `setState`. This branch fixes these shortcomings.

This PR also includes the change to hide Tandem on Windows machines.

Ping @gniezen for review.