### PR TITLE
Fixing Tandem driver issues on Windows

### DIFF
--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -598,8 +598,9 @@ module.exports = function (config) {
   };
 
   var pending = false;    //if serial send is pending, we have to wait before we send again
-  var SEND_FREQ = 5;  // time between sending serial packets
+  var INTERVAL_FREQ = 5;  // time between sending serial packets
   var SEND_WAIT = 800; // time to wait when serial send is pending
+  var RETRY_TIMEOUT = 1000; // time to wait before retrying to send packet
 
   var BASE_TIME = Date.UTC(2008, 0, 1, 0, 0, 0).valueOf(); /* new Date(2008, 0, 1, 0, 0, 0).valueOf(); */
   var addTimestamp = function (o, rawTime) {
@@ -782,7 +783,7 @@ module.exports = function (config) {
           callback(err,null);
         }
       });
-    },1000);
+    },RETRY_TIMEOUT);
 
     var listenTimer = setInterval(function () {
       if (cfg.deviceComms.hasAvailablePacket()) {
@@ -876,7 +877,7 @@ module.exports = function (config) {
                       }
                     });
                   }
-                },1000);
+                },RETRY_TIMEOUT);
               });
             }
             else {
@@ -913,7 +914,7 @@ module.exports = function (config) {
         };
         processPacket(cfg.deviceComms.nextPacket());
       }
-    }, 5);
+    }, INTERVAL_FREQ);
 
     var sendTimer = setInterval(function () {
       if (send_seq % 1000 === 0) {
@@ -930,7 +931,7 @@ module.exports = function (config) {
           send_seq++;
         }
       }
-    }, SEND_FREQ); // if we spin too quickly on this, packets don't get sent when window doesn't have focus
+    }, INTERVAL_FREQ); // if we spin too quickly on this, packets don't get sent when window doesn't have focus
   };
 
   var newestEventRequester = function (start, end, progress, callback) {
@@ -985,7 +986,7 @@ module.exports = function (config) {
                       }
                     });
                   }
-                },1000);
+                ,RETRY_TIMEOUT);
               });
             }
             else {
@@ -1026,7 +1027,7 @@ module.exports = function (config) {
         };
         processPacket(cfg.deviceComms.nextPacket());
       }
-    }, 5);
+    }, INTERVAL_FREQ);
 
     var sendTimer = setInterval(function () {
       if (send_seq % 1000 === 0) {
@@ -1043,7 +1044,7 @@ module.exports = function (config) {
           send_seq--;
         }
       }
-    }, SEND_FREQ); // if we spin too quickly on this, packets don't get sent when window doesn't have focus
+    }, INTERVAL_FREQ); // if we spin too quickly on this, packets don't get sent when window doesn't have focus
   };
 
   var tandemCommandResponse = function (command, args, callback) {

--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -927,8 +927,7 @@ module.exports = function (config) {
     var end_seq = end;
     var receive_seq = start;
     var recovering = false;
-    var percentage = 0;
-    var prevPercentage = 0;
+    var percentage_seq = 0;
 
     // this contains only the log events that we consider to define
     // a set of events that can truly be considered "pump data"
@@ -972,11 +971,11 @@ module.exports = function (config) {
               receive_seq = pkt.payload['header_log_seq_no'] - 1;
               recovering = false;
 
-              percentage = ((start-receive_seq)/(start-end) * 5);
-              if(percentage > (prevPercentage+1)) {
-                // only update progress to UI if there's an increase of at least 1 percent
-                prevPercentage = percentage;
-                progress(percentage);
+              percentage_seq += 1;
+              if(percentage_seq % 200 === 0) {
+                // increase percentage every 200 records
+                var percentage = percentage_seq/200;
+                progress(percentage < 5 ? percentage : 5); //up to a max of 5 percent
               }
 
               if (headerIdFilter.indexOf(pkt.payload.header_id) === -1 || pkt.payload.name  === undefined) {

--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -845,8 +845,11 @@ module.exports = function (config) {
     var recovering = false;
     var percentage = 0;
     var prevPercentage = 0;
+    var retryRecoverTimer;
 
     var listenTimer = setInterval(function () {
+      if(pending)
+        console.log("pending");
       while (cfg.deviceComms.hasAvailablePacket() && !pending) {
         var processPacket = function (pkt) {
           if (pkt.valid &&
@@ -856,18 +859,29 @@ module.exports = function (config) {
               if (!recovering) {
                 recovering = true;
                 debug('recovering ', receive_seq, '(received ',pkt.payload['header_log_seq_no'], ')');
+                send_seq = receive_seq + 1;
               }
 
-              send_seq = receive_seq + 1;
               tandemCommand(COMMANDS.LOG_ENTRY_SEQ_REQ, [receive_seq], function (err) {
                 if(err) {
                   callback(err,null);
                 }
+                retryRecoverTimer = setTimeout(function() {
+                  if(recovering) {
+                    debug('Retrying to recover..',receive_seq);
+                    tandemCommand(COMMANDS.LOG_ENTRY_SEQ_REQ, [receive_seq], function (err) {
+                      if(err) {
+                        callback(err,null);
+                      }
+                    });
+                  }
+                },1000);
               });
             }
             else {
               if (recovering) {
                 debug('recovered ', receive_seq, pkt);
+                clearTimeout(retryRecoverTimer);
               }
               receive_seq = pkt.payload['header_log_seq_no'] + 1;
               recovering = false;

--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -795,7 +795,7 @@ module.exports = function (config) {
           console.log('Packet not valid');
         }
       }
-    }, 20); // spin on this one quickly
+    }, 1); // spin on this one quickly
   };
 
   var tandemCommand = function (command, args, callback) {

--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -189,7 +189,7 @@ module.exports = function (config) {
       version: 36102,
       format: 'i',
       fields: ['seqNum'],
-      response: 125
+      response: RESPONSES.LOG_ENTRY_TE
     },
     LOG_ENTRY_SEQ_MULTI_REQ: {
       value: 152,
@@ -876,14 +876,11 @@ module.exports = function (config) {
               receive_seq = pkt.payload['header_log_seq_no'] + 1;
               recovering = false;
 
-              if(start !== end) {
-                // only update progress if not binary search
-                percentage = ((receive_seq-start)/(end-start) * 90)+10;
-                if(percentage > (prevPercentage+1)) {
-                  // only update progress to UI if there's an increase of at least 1 percent
-                  prevPercentage = percentage;
-                  progress(percentage);
-                }
+              percentage = ((receive_seq-start)/(end-start) * 90)+10;
+              if(percentage > (prevPercentage+1)) {
+                // only update progress to UI if there's an increase of at least 1 percent
+                prevPercentage = percentage;
+                progress(percentage);
               }
 
               if (receive_seq % 1000 === 0) {
@@ -991,7 +988,6 @@ module.exports = function (config) {
               else{
                 clearInterval(sendTimer);
                 clearInterval(listenTimer);
-                cfg.deviceComms.flush(); // making sure we flush the buffers
                 debug('Found newest event: ',pkt);
                 progress(5);
                 callback(null,pkt);
@@ -1165,7 +1161,7 @@ module.exports = function (config) {
       }
       minIndex = start_seq;
       currentIndex = (minIndex + maxIndex) / 2 | 0;
-      tandemLogRequester(currentIndex, currentIndex, progress, binarySearch);
+      tandemCommandResponse(COMMANDS.LOG_ENTRY_SEQ_REQ, [currentIndex], binarySearch);
     }
 
     function binarySearch(err, result) {
@@ -1193,7 +1189,7 @@ module.exports = function (config) {
           if (currentIndex < start_seq) {
             currentIndex = start_seq;
           }
-          tandemLogRequester(currentIndex, currentIndex, progress, binarySearch);
+          tandemCommandResponse(COMMANDS.LOG_ENTRY_SEQ_REQ, [currentIndex], binarySearch);
         } else {
 
           debug('90 day, closest record: ', result);

--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -752,10 +752,8 @@ module.exports = function (config) {
   var tandemPacketHandler = function (buffer) {
     // first, discard bytes that can't start a packet
     while ((buffer.len() > 0) && (buffer.get(0) !== SYNC_BYTE)) {
-      console.log("Discarding ", buffer.get(0));
       buffer.discard(1);
     }
-    console.log("Received ", buffer.bytes());
 
     if (buffer.len() < 9) { // all complete packets must be at least this long
       return null; // not enough there yet
@@ -767,7 +765,6 @@ module.exports = function (config) {
       // remove the now-processed packet
       buffer.discard(packet.packet_len);
     }
-    console.log("Packet: ", packet);
     if (packet.valid) {
       return packet;
     }
@@ -779,7 +776,7 @@ module.exports = function (config) {
   var listenForPacket = function (command,args,callback) {
 
     var retryTimer = setTimeout(function() {
-      console.log('Retrying with ',command, ' ',args,'..');
+      console.log('Retrying with ',command, ', ',args);
       tandemCommand(command, args, function (err) {
         if(err) {
           callback(err,null);
@@ -788,18 +785,17 @@ module.exports = function (config) {
     },1000);
 
     var listenTimer = setInterval(function () {
-      while (cfg.deviceComms.hasAvailablePacket()) {
+      if (cfg.deviceComms.hasAvailablePacket()) {
         var pkt = cfg.deviceComms.nextPacket();
-        console.log("Pkt:", pkt);
         if (pkt.valid && (command.response.value === pkt.descriptor)) {
           clearTimeout(retryTimer);
           clearInterval(listenTimer);
-          return callback(null, pkt);
+          callback(null, pkt);
         }else{
           console.log('Packet not valid');
         }
       }
-    }, 1); // spin on this one quickly
+    }, 20); // spin on this one quickly
   };
 
   var tandemCommand = function (command, args, callback) {
@@ -811,23 +807,23 @@ module.exports = function (config) {
       payload = new Uint8Array(payload_len);
       struct.pack(payload, 0, format, args);
     }
-    console.log("requesting ", args);
 
     var commandPacket = buildPacket(command, payload_len, payload);
     cfg.deviceComms.writeSerial(commandPacket, function(err) {
       if(err) {
         console.log('Write error:',err);
-        if(err.message === 'pending') {
+        if(err.name === 'pending' || err.name === 'timeout') {
           pending = true;
+          callback();
           setTimeout(function() {
             pending = false;
-            console.log('Retrying to send packet ', command);
-            cfg.deviceComms.writeSerial(commandPacket,function(err){
-              if(err) {
-                callback(new Error('Retry send pending'));
-              }
-            });
-          },SEND_INC_MAX*2);
+          },SEND_INC_MAX);
+        } else if(err.name === 'system_error') {
+          pending = true;
+          callback();
+          cfg.deviceComms.changeBitRate(cfg.deviceInfo.bitrate,function(){
+            pending=false;
+          });
         }
         else{
           callback(err);
@@ -860,9 +856,7 @@ module.exports = function (config) {
             if (receive_seq != pkt.payload['header_log_seq_no']) {
               if (!recovering) {
                 recovering = true;
-                if(start !== end) { //only increase sequence if not binary search
-                  send_seq = receive_seq + 1;
-                }
+                send_seq = receive_seq + 1;
                 debug('recovering ', receive_seq);
                 tandemCommand(COMMANDS.LOG_ENTRY_SEQ_REQ, [receive_seq], function (err) {
                   if(err) {
@@ -886,7 +880,6 @@ module.exports = function (config) {
                 debug('recovered ', receive_seq, pkt);
               }
               receive_seq = pkt.payload['header_log_seq_no'] + 1;
-              console.log('next receive:', receive_seq);
               recovering = false;
 
               if(start !== end) {
@@ -902,7 +895,6 @@ module.exports = function (config) {
               if (receive_seq % 1000 === 0) {
                 debug('received ', receive_seq, ' of ', end);
               }
-              callback(null, pkt);
               if (receive_seq > end) {
                 if (__DEBUG__) {
                   var end_exec = Date.now();
@@ -910,8 +902,10 @@ module.exports = function (config) {
                   debug('Execution time of tandemLogRequester: ' + time);
                 }
                 cfg.deviceComms.flush(); // making sure we flush the buffers
+                clearInterval(sendTimer);
                 clearInterval(listenTimer);
               }
+              callback(null, pkt);
             }
           }
         };
@@ -924,15 +918,15 @@ module.exports = function (config) {
         debug('requesting ', send_seq);
       }
       if (!recovering && !pending) {
-        tandemCommand(COMMANDS.LOG_ENTRY_SEQ_REQ, [send_seq++], function (err) {
+        tandemCommand(COMMANDS.LOG_ENTRY_SEQ_REQ, [send_seq], function (err) {
           if(err) {
             clearInterval(sendTimer);
             callback(err,null);
           }
         });
       }
-      if (send_seq > end) {
-        clearInterval(sendTimer);
+      if (send_seq < end) {
+        send_seq++;
       }
     }, sendFrequency); // if we spin too quickly on this, packets don't get sent when window doesn't have focus
   };
@@ -962,7 +956,6 @@ module.exports = function (config) {
     var listenTimer = setInterval(function () {
       while (cfg.deviceComms.hasAvailablePacket()) {
         var processPacket = function (pkt) {
-          console.log("receiving ",pkt.payload['header_log_seq_no']);
           if (pkt.valid &&
             pkt.descriptor === RESPONSES.LOG_ENTRY_TE.value &&
             pkt.payload['header_log_seq_no'] <= receive_seq) {
@@ -1181,7 +1174,6 @@ module.exports = function (config) {
     }
 
     function binarySearch(err, result) {
-      console.log("binary search result: ",result);
       if (err) {
         debug('error retrieving record during binary search ', result);
         callback(err, null);

--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -848,7 +848,7 @@ module.exports = function (config) {
     var sendFrequency = SEND_INC;
 
     var listenTimer = setInterval(function () {
-      while (cfg.deviceComms.hasAvailablePacket()) {
+      if (cfg.deviceComms.hasAvailablePacket()) {
         var processPacket = function (pkt) {
           if (pkt.valid &&
             pkt.descriptor === RESPONSES.LOG_ENTRY_TE.value &&
@@ -873,7 +873,7 @@ module.exports = function (config) {
                   });
                 }
                 console.log('Out of order: ',receive_seq, ' ', pkt.payload['header_log_seq_no'] );
-              } // drop out-of-order packets on the floor; they will be re-requested.
+              }
             }
             else {
               if (recovering) {
@@ -911,7 +911,7 @@ module.exports = function (config) {
         };
         processPacket(cfg.deviceComms.nextPacket());
       }
-    }, 1);
+    }, 5);
 
     var sendTimer = setInterval(function () {
       if (send_seq % 1000 === 0) {
@@ -954,7 +954,7 @@ module.exports = function (config) {
     ];
 
     var listenTimer = setInterval(function () {
-      while (cfg.deviceComms.hasAvailablePacket()) {
+      if (cfg.deviceComms.hasAvailablePacket()) {
         var processPacket = function (pkt) {
           if (pkt.valid &&
             pkt.descriptor === RESPONSES.LOG_ENTRY_TE.value &&
@@ -979,7 +979,7 @@ module.exports = function (config) {
                   });
                 }
                 console.log('Out of order: ',receive_seq, ' ', pkt.payload['header_log_seq_no'] );
-              }// drop out-of-order packets on the floor; they will be re-requested.
+              }
             }
             else {
               if (recovering) {
@@ -1012,7 +1012,7 @@ module.exports = function (config) {
         };
         processPacket(cfg.deviceComms.nextPacket());
       }
-    }, 1);
+    }, 5);
 
     var sendTimer = setInterval(function () {
       if (send_seq % 1000 === 0) {

--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -752,10 +752,8 @@ module.exports = function (config) {
   var tandemPacketHandler = function (buffer) {
     // first, discard bytes that can't start a packet
     while ((buffer.len() > 0) && (buffer.get(0) !== SYNC_BYTE)) {
-      //console.log("Discarding ", buffer.get(0));
       buffer.discard(1);
     }
-    //console.log("Received ", buffer.bytes());
 
     if (buffer.len() < 9) { // all complete packets must be at least this long
       return null; // not enough there yet
@@ -767,7 +765,6 @@ module.exports = function (config) {
       // remove the now-processed packet
       buffer.discard(packet.packet_len);
     }
-    //console.log("Packet: ", packet);
     if (packet.valid) {
       return packet;
     }
@@ -810,7 +807,6 @@ module.exports = function (config) {
       payload = new Uint8Array(payload_len);
       struct.pack(payload, 0, format, args);
     }
-    //console.log("requesting ", args);
 
     var commandPacket = buildPacket(command, payload_len, payload);
     cfg.deviceComms.writeSerial(commandPacket, function(err) {
@@ -947,7 +943,6 @@ module.exports = function (config) {
     var listenTimer = setInterval(function () {
       while (cfg.deviceComms.hasAvailablePacket() && !pending) {
         var processPacket = function (pkt) {
-          //console.log("receiving ",pkt.payload['header_log_seq_no']);
           if (pkt.valid &&
             pkt.descriptor === RESPONSES.LOG_ENTRY_TE.value &&
             pkt.payload['header_log_seq_no'] <= receive_seq) {
@@ -972,9 +967,9 @@ module.exports = function (config) {
               recovering = false;
 
               percentage_seq += 1;
-              if(percentage_seq % 200 === 0) {
-                // increase percentage every 200 records
-                var percentage = percentage_seq/200;
+              if(percentage_seq % 100 === 0) {
+                // increase percentage every 100 records
+                var percentage = percentage_seq/100;
                 progress(percentage < 5 ? percentage : 5); //up to a max of 5 percent
               }
 
@@ -1164,7 +1159,6 @@ module.exports = function (config) {
     }
 
     function binarySearch(err, result) {
-      //console.log("binary search result: ",result);
       if (err) {
         debug('error retrieving record during binary search ', result);
         callback(err, null);

--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -851,7 +851,7 @@ module.exports = function (config) {
     var prevPercentage = 0;
 
     var listenTimer = setInterval(function () {
-      while (cfg.deviceComms.hasAvailablePacket()) {
+      while (cfg.deviceComms.hasAvailablePacket() && !pending) {
         var processPacket = function (pkt) {
           if (pkt.valid &&
             pkt.descriptor === RESPONSES.LOG_ENTRY_TE.value &&
@@ -868,7 +868,7 @@ module.exports = function (config) {
                   callback(err,null);
                 }
               });
-            }            
+            }
             else {
               if (recovering) {
                 debug('recovered ', receive_seq, pkt);
@@ -947,7 +947,7 @@ module.exports = function (config) {
     ];
 
     var listenTimer = setInterval(function () {
-      while (cfg.deviceComms.hasAvailablePacket()) {
+      while (cfg.deviceComms.hasAvailablePacket() && !pending) {
         var processPacket = function (pkt) {
           //console.log("receiving ",pkt.payload['header_log_seq_no']);
           if (pkt.valid &&

--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -848,8 +848,6 @@ module.exports = function (config) {
     var retryRecoverTimer;
 
     var listenTimer = setInterval(function () {
-      if(pending)
-        console.log("pending");
       while (cfg.deviceComms.hasAvailablePacket() && !pending) {
         var processPacket = function (pkt) {
           if (pkt.valid &&

--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -597,6 +597,7 @@ module.exports = function (config) {
     return +( Math.round(this*pow) / pow );
   };
 
+  var pending = false;    //if serial send is pending, we have to wait before we send again
   var SEND_INC = 5;  // amount to increment interval by if serial send pending
   var SEND_INC_MAX = 100; // maximum time between sending packets
 
@@ -750,13 +751,11 @@ module.exports = function (config) {
 
   var tandemPacketHandler = function (buffer) {
     // first, discard bytes that can't start a packet
-    var discardCount = 0;
-    while ((buffer.len() > discardCount) && (buffer.contains(SYNC_BYTE) === false)) {
-      ++discardCount;
+    while ((buffer.len() > 0) && (buffer.get(0) !== SYNC_BYTE)) {
+      console.log("Discarding ", buffer.get(0));
+      buffer.discard(1);
     }
-    if (discardCount) {
-      buffer.discard(discardCount);
-    }
+    console.log("Received ", buffer.bytes());
 
     if (buffer.len() < 9) { // all complete packets must be at least this long
       return null; // not enough there yet
@@ -768,7 +767,7 @@ module.exports = function (config) {
       // remove the now-processed packet
       buffer.discard(packet.packet_len);
     }
-
+    console.log("Packet: ", packet);
     if (packet.valid) {
       return packet;
     }
@@ -777,12 +776,23 @@ module.exports = function (config) {
     }
   };
 
-  var listenForPacket = function (callback) {
+  var listenForPacket = function (command,args,callback) {
+
+    var retryTimer = setTimeout(function() {
+      console.log('Retrying with ',command, ' ',args,'..');
+      tandemCommand(command, args, function (err) {
+        if(err) {
+          callback(err,null);
+        }
+      });
+    },1000);
 
     var listenTimer = setInterval(function () {
       while (cfg.deviceComms.hasAvailablePacket()) {
         var pkt = cfg.deviceComms.nextPacket();
-        if (pkt.valid) {
+        console.log("Pkt:", pkt);
+        if (pkt.valid && (command.response.value === pkt.descriptor)) {
+          clearTimeout(retryTimer);
           clearInterval(listenTimer);
           return callback(null, pkt);
         }else{
@@ -801,20 +811,31 @@ module.exports = function (config) {
       payload = new Uint8Array(payload_len);
       struct.pack(payload, 0, format, args);
     }
+    console.log("requesting ", args);
 
     var commandPacket = buildPacket(command, payload_len, payload);
-    cfg.deviceComms.writeSerial(commandPacket, callback);
-  };
-
-  var backoff = function(err, sendFrequency, callback) {
-      if(sendFrequency < (SEND_INC_MAX)) {
-        sendFrequency += SEND_INC; // back off a bit
-        console.log('now sending every ', sendFrequency, ' ms');
-        return sendFrequency;
+    cfg.deviceComms.writeSerial(commandPacket, function(err) {
+      if(err) {
+        console.log('Write error:',err);
+        if(err.message === 'pending') {
+          pending = true;
+          setTimeout(function() {
+            pending = false;
+            console.log('Retrying to send packet ', command);
+            cfg.deviceComms.writeSerial(commandPacket,function(err){
+              if(err) {
+                callback(new Error('Retry send pending'));
+              }
+            });
+          },SEND_INC_MAX*2);
+        }
+        else{
+          callback(err);
+        }
       }else{
-        // giving up
-        callback(Error('Please keep Uploader window in foreground and try again.'));
+        callback();
       }
+    });
   };
 
   var tandemLogRequester = function (start, end, progress, callback) {
@@ -839,7 +860,9 @@ module.exports = function (config) {
             if (receive_seq != pkt.payload['header_log_seq_no']) {
               if (!recovering) {
                 recovering = true;
-                send_seq = receive_seq + 1;
+                if(start !== end) { //only increase sequence if not binary search
+                  send_seq = receive_seq + 1;
+                }
                 debug('recovering ', receive_seq);
                 tandemCommand(COMMANDS.LOG_ENTRY_SEQ_REQ, [receive_seq], function (err) {
                   if(err) {
@@ -847,6 +870,14 @@ module.exports = function (config) {
                   }
                 });
               } else{
+                if(recovering) {
+                  //out-of-order, re-request
+                  tandemCommand(COMMANDS.LOG_ENTRY_SEQ_REQ, [receive_seq], function (err) {
+                    if(err) {
+                      callback(err,null);
+                    }
+                  });
+                }
                 console.log('Out of order: ',receive_seq, ' ', pkt.payload['header_log_seq_no'] );
               } // drop out-of-order packets on the floor; they will be re-requested.
             }
@@ -855,6 +886,7 @@ module.exports = function (config) {
                 debug('recovered ', receive_seq, pkt);
               }
               receive_seq = pkt.payload['header_log_seq_no'] + 1;
+              console.log('next receive:', receive_seq);
               recovering = false;
 
               if(start !== end) {
@@ -877,6 +909,7 @@ module.exports = function (config) {
                   var time = end_exec - start_exec;
                   debug('Execution time of tandemLogRequester: ' + time);
                 }
+                cfg.deviceComms.flush(); // making sure we flush the buffers
                 clearInterval(listenTimer);
               }
             }
@@ -890,15 +923,11 @@ module.exports = function (config) {
       if (send_seq % 1000 === 0) {
         debug('requesting ', send_seq);
       }
-      if (!recovering) {
+      if (!recovering && !pending) {
         tandemCommand(COMMANDS.LOG_ENTRY_SEQ_REQ, [send_seq++], function (err) {
           if(err) {
-            if(err.message === 'pending') {
-              sendFrequency = backoff(err,sendFrequency,callback);
-            }else{
-              clearInterval(sendTimer);
-              callback(err,null);
-            }
+            clearInterval(sendTimer);
+            callback(err,null);
           }
         });
       }
@@ -933,6 +962,7 @@ module.exports = function (config) {
     var listenTimer = setInterval(function () {
       while (cfg.deviceComms.hasAvailablePacket()) {
         var processPacket = function (pkt) {
+          console.log("receiving ",pkt.payload['header_log_seq_no']);
           if (pkt.valid &&
             pkt.descriptor === RESPONSES.LOG_ENTRY_TE.value &&
             pkt.payload['header_log_seq_no'] <= receive_seq) {
@@ -947,6 +977,14 @@ module.exports = function (config) {
                   }
                 });
               } else{
+                if(recovering) {
+                  //out-of-order, re-request
+                  tandemCommand(COMMANDS.LOG_ENTRY_SEQ_REQ, [receive_seq], function (err) {
+                    if(err) {
+                      callback(err,null);
+                    }
+                  });
+                }
                 console.log('Out of order: ',receive_seq, ' ', pkt.payload['header_log_seq_no'] );
               }// drop out-of-order packets on the floor; they will be re-requested.
             }
@@ -987,15 +1025,11 @@ module.exports = function (config) {
       if (send_seq % 1000 === 0) {
         console.log('requesting', send_seq);
       }
-      if (!recovering) {
+      if (!recovering && !pending) {
         tandemCommand(COMMANDS.LOG_ENTRY_SEQ_REQ, [send_seq--], function (err) {
           if(err) {
-            if(err.message === 'pending') {
-              sendFrequency = backoff(err,sendFrequency,callback);
-            }else{
-              clearInterval(sendTimer);
-              callback(err,null);
-            }
+            clearInterval(sendTimer);
+            callback(err,null);
           }
         });
       }
@@ -1006,11 +1040,12 @@ module.exports = function (config) {
   };
 
   var tandemCommandResponse = function (command, args, callback) {
-    listenForPacket(callback);
+
     tandemCommand(command, args, function (err) {
       if(err) {
         callback(err,null);
       }
+      listenForPacket(command,args,callback);
     });
   };
 
@@ -1135,29 +1170,18 @@ module.exports = function (config) {
       debug('end_seq after finding newest record: ', result.payload.header_log_seq_no);
       maxIndex = result.payload.header_log_seq_no;
       data.end_seq = result.payload.header_log_seq_no;
-      tandemLogRequester(start_seq, start_seq, progress, getOldestEvent);
 
-    }
-
-    function getOldestEvent(err, result) {
-
-      if (err) {
-        debug('error retrieving record ', result);
-        callback(err, null);
+      if(__DEBUG__) {
+        debug('oldest event seq: ', start_seq);
+        debug('oldest record deviceTime: ', result.payload.deviceTime);
       }
-      else {
-        if(__DEBUG__) {
-          debug('oldest event seq: ', start_seq);
-          debug('oldest record deviceTime: ', result.payload.deviceTime);
-        }
-        minIndex = start_seq;
-        currentIndex = (minIndex + maxIndex) / 2 | 0;
-        tandemLogRequester(currentIndex, currentIndex, progress, binarySearch);
-      }
+      minIndex = start_seq;
+      currentIndex = (minIndex + maxIndex) / 2 | 0;
+      tandemLogRequester(currentIndex, currentIndex, progress, binarySearch);
     }
 
     function binarySearch(err, result) {
-
+      console.log("binary search result: ",result);
       if (err) {
         debug('error retrieving record during binary search ', result);
         callback(err, null);
@@ -1193,6 +1217,7 @@ module.exports = function (config) {
             debug('Execution time for binary search: ' + time);
           }
           progress(10);
+          cfg.deviceComms.flush(); // making sure we flush the buffers
           tandemFetchEventRange(progress, data, callback);
         }
       }
@@ -1211,6 +1236,9 @@ module.exports = function (config) {
           start_seq = result.payload['start_seq']; // limit to 3000 for debugging
           debug('end_seq before looking for newest event: ',end_seq);
           newestEventRequester(end_seq, start_seq, progress, getNewestEvent);
+        }
+        else{
+          console.log('Invalid log size:', result);
         }
       }
     });

--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -918,7 +918,7 @@ module.exports = function (config) {
             callback(err,null);
           }
         });
-        if (send_seq < end) {
+        if ((send_seq < end) && !recovering) {
           send_seq++;
         }
       }
@@ -990,6 +990,7 @@ module.exports = function (config) {
 
               if (receive_seq < end_seq) {
                 debug('We did not find any events');
+                clearInterval(sendTimer);
                 clearInterval(listenTimer);
               }
             }
@@ -1004,15 +1005,15 @@ module.exports = function (config) {
         console.log('requesting', send_seq);
       }
       if (!recovering && !pending) {
-        tandemCommand(COMMANDS.LOG_ENTRY_SEQ_REQ, [send_seq--], function (err) {
+        tandemCommand(COMMANDS.LOG_ENTRY_SEQ_REQ, [send_seq], function (err) {
           if(err) {
             clearInterval(sendTimer);
             callback(err,null);
           }
         });
-      }
-      if (send_seq < end_seq) { // we've gone back far enough
-        clearInterval(sendTimer);
+        if ((send_seq > end) && !recovering) {
+          send_seq--;
+        }
       }
     }, SEND_FREQ); // if we spin too quickly on this, packets don't get sent when window doesn't have focus
   };

--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -859,7 +859,7 @@ module.exports = function (config) {
             if (receive_seq != pkt.payload['header_log_seq_no']) {
               if (!recovering) {
                 recovering = true;
-                debug('recovering ', receive_seq);
+                debug('recovering ', receive_seq, '(received ',pkt.payload['header_log_seq_no'], ')');
               }
 
               send_seq = receive_seq + 1;
@@ -930,6 +930,8 @@ module.exports = function (config) {
     var end_seq = end;
     var receive_seq = start;
     var recovering = false;
+    var percentage = 0;
+    var prevPercentage = 0;
 
     // this contains only the log events that we consider to define
     // a set of events that can truly be considered "pump data"
@@ -972,6 +974,13 @@ module.exports = function (config) {
               }
               receive_seq = pkt.payload['header_log_seq_no'] - 1;
               recovering = false;
+
+              percentage = ((start-receive_seq)/(start-end) * 5);
+              if(percentage > (prevPercentage+1)) {
+                // only update progress to UI if there's an increase of at least 1 percent
+                prevPercentage = percentage;
+                progress(percentage);
+              }
 
               if (headerIdFilter.indexOf(pkt.payload.header_id) === -1 || pkt.payload.name  === undefined) {
                 if(__DEBUG__) {

--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -751,7 +751,7 @@ module.exports = function (config) {
   var tandemPacketHandler = function (buffer) {
     // first, discard bytes that can't start a packet
     var discardCount = 0;
-    while (buffer.len() > discardCount && buffer.get(0) != SYNC_BYTE) {
+    while ((buffer.len() > discardCount) && (buffer.contains(SYNC_BYTE) === false)) {
       ++discardCount;
     }
     if (discardCount) {
@@ -785,6 +785,8 @@ module.exports = function (config) {
         if (pkt.valid) {
           clearInterval(listenTimer);
           return callback(null, pkt);
+        }else{
+          console.log('Packet not valid');
         }
       }
     }, 1); // spin on this one quickly
@@ -824,7 +826,6 @@ module.exports = function (config) {
     var send_seq = start;
     var receive_seq = start;
     var recovering = false;
-    var delay = [];
     var percentage = 0;
     var prevPercentage = 0;
     var sendFrequency = SEND_INC;
@@ -845,6 +846,8 @@ module.exports = function (config) {
                     callback(err,null);
                   }
                 });
+              } else{
+                console.log('Out of order: ',receive_seq, ' ', pkt.payload['header_log_seq_no'] );
               } // drop out-of-order packets on the floor; they will be re-requested.
             }
             else {
@@ -880,7 +883,6 @@ module.exports = function (config) {
           }
         };
         processPacket(cfg.deviceComms.nextPacket());
-        delay.forEach(processPacket);
       }
     }, 1);
 
@@ -944,7 +946,9 @@ module.exports = function (config) {
                     callback(err,null);
                   }
                 });
-              } // drop out-of-order packets on the floor; they will be re-requested.
+              } else{
+                console.log('Out of order: ',receive_seq, ' ', pkt.payload['header_log_seq_no'] );
+              }// drop out-of-order packets on the floor; they will be re-requested.
             }
             else {
               if (recovering) {

--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -598,8 +598,8 @@ module.exports = function (config) {
   };
 
   var pending = false;    //if serial send is pending, we have to wait before we send again
-  var SEND_INC = 5;  // amount to increment interval by if serial send pending
-  var SEND_INC_MAX = 100; // maximum time between sending packets
+  var SEND_FREQ = 5;  // time between sending serial packets
+  var SEND_WAIT = 300; // time to wait when serial send is pending
 
   var BASE_TIME = Date.UTC(2008, 0, 1, 0, 0, 0).valueOf(); /* new Date(2008, 0, 1, 0, 0, 0).valueOf(); */
   var addTimestamp = function (o, rawTime) {
@@ -752,8 +752,10 @@ module.exports = function (config) {
   var tandemPacketHandler = function (buffer) {
     // first, discard bytes that can't start a packet
     while ((buffer.len() > 0) && (buffer.get(0) !== SYNC_BYTE)) {
+      //console.log("Discarding ", buffer.get(0));
       buffer.discard(1);
     }
+    //console.log("Received ", buffer.bytes());
 
     if (buffer.len() < 9) { // all complete packets must be at least this long
       return null; // not enough there yet
@@ -765,6 +767,7 @@ module.exports = function (config) {
       // remove the now-processed packet
       buffer.discard(packet.packet_len);
     }
+    //console.log("Packet: ", packet);
     if (packet.valid) {
       return packet;
     }
@@ -807,6 +810,7 @@ module.exports = function (config) {
       payload = new Uint8Array(payload_len);
       struct.pack(payload, 0, format, args);
     }
+    //console.log("requesting ", args);
 
     var commandPacket = buildPacket(command, payload_len, payload);
     cfg.deviceComms.writeSerial(commandPacket, function(err) {
@@ -817,7 +821,7 @@ module.exports = function (config) {
           callback();
           setTimeout(function() {
             pending = false;
-          },SEND_INC_MAX);
+          },SEND_WAIT);
         } else if(err.name === 'system_error') {
           pending = true;
           callback();
@@ -845,10 +849,9 @@ module.exports = function (config) {
     var recovering = false;
     var percentage = 0;
     var prevPercentage = 0;
-    var sendFrequency = SEND_INC;
 
     var listenTimer = setInterval(function () {
-      if (cfg.deviceComms.hasAvailablePacket()) {
+      while (cfg.deviceComms.hasAvailablePacket()) {
         var processPacket = function (pkt) {
           if (pkt.valid &&
             pkt.descriptor === RESPONSES.LOG_ENTRY_TE.value &&
@@ -856,25 +859,16 @@ module.exports = function (config) {
             if (receive_seq != pkt.payload['header_log_seq_no']) {
               if (!recovering) {
                 recovering = true;
-                send_seq = receive_seq + 1;
                 debug('recovering ', receive_seq);
-                tandemCommand(COMMANDS.LOG_ENTRY_SEQ_REQ, [receive_seq], function (err) {
-                  if(err) {
-                    callback(err,null);
-                  }
-                });
-              } else{
-                if(recovering) {
-                  //out-of-order, re-request
-                  tandemCommand(COMMANDS.LOG_ENTRY_SEQ_REQ, [receive_seq], function (err) {
-                    if(err) {
-                      callback(err,null);
-                    }
-                  });
-                }
-                console.log('Out of order: ',receive_seq, ' ', pkt.payload['header_log_seq_no'] );
               }
-            }
+
+              send_seq = receive_seq + 1;
+              tandemCommand(COMMANDS.LOG_ENTRY_SEQ_REQ, [receive_seq], function (err) {
+                if(err) {
+                  callback(err,null);
+                }
+              });
+            }            
             else {
               if (recovering) {
                 debug('recovered ', receive_seq, pkt);
@@ -911,7 +905,7 @@ module.exports = function (config) {
         };
         processPacket(cfg.deviceComms.nextPacket());
       }
-    }, 5);
+    }, 1);
 
     var sendTimer = setInterval(function () {
       if (send_seq % 1000 === 0) {
@@ -924,11 +918,11 @@ module.exports = function (config) {
             callback(err,null);
           }
         });
+        if (send_seq < end) {
+          send_seq++;
+        }
       }
-      if (send_seq < end) {
-        send_seq++;
-      }
-    }, sendFrequency); // if we spin too quickly on this, packets don't get sent when window doesn't have focus
+    }, SEND_FREQ); // if we spin too quickly on this, packets don't get sent when window doesn't have focus
   };
 
   var newestEventRequester = function (start, end, progress, callback) {
@@ -936,7 +930,6 @@ module.exports = function (config) {
     var end_seq = end;
     var receive_seq = start;
     var recovering = false;
-    var sendFrequency = SEND_INC;
 
     // this contains only the log events that we consider to define
     // a set of events that can truly be considered "pump data"
@@ -954,32 +947,24 @@ module.exports = function (config) {
     ];
 
     var listenTimer = setInterval(function () {
-      if (cfg.deviceComms.hasAvailablePacket()) {
+      while (cfg.deviceComms.hasAvailablePacket()) {
         var processPacket = function (pkt) {
+          //console.log("receiving ",pkt.payload['header_log_seq_no']);
           if (pkt.valid &&
             pkt.descriptor === RESPONSES.LOG_ENTRY_TE.value &&
             pkt.payload['header_log_seq_no'] <= receive_seq) {
             if (receive_seq != pkt.payload['header_log_seq_no']) {
               if (!recovering) {
                 recovering = true;
-                send_seq = receive_seq - 1;
                 debug('recovering ', receive_seq);
-                tandemCommand(COMMANDS.LOG_ENTRY_SEQ_REQ, [receive_seq], function (err) {
-                  if(err) {
-                    callback(err,null);
-                  }
-                });
-              } else{
-                if(recovering) {
-                  //out-of-order, re-request
-                  tandemCommand(COMMANDS.LOG_ENTRY_SEQ_REQ, [receive_seq], function (err) {
-                    if(err) {
-                      callback(err,null);
-                    }
-                  });
-                }
-                console.log('Out of order: ',receive_seq, ' ', pkt.payload['header_log_seq_no'] );
               }
+
+              send_seq = receive_seq - 1;
+              tandemCommand(COMMANDS.LOG_ENTRY_SEQ_REQ, [receive_seq], function (err) {
+                if(err) {
+                  callback(err,null);
+                }
+              });
             }
             else {
               if (recovering) {
@@ -1012,7 +997,7 @@ module.exports = function (config) {
         };
         processPacket(cfg.deviceComms.nextPacket());
       }
-    }, 5);
+    }, 1);
 
     var sendTimer = setInterval(function () {
       if (send_seq % 1000 === 0) {
@@ -1029,7 +1014,7 @@ module.exports = function (config) {
       if (send_seq < end_seq) { // we've gone back far enough
         clearInterval(sendTimer);
       }
-    }, sendFrequency); // if we spin too quickly on this, packets don't get sent when window doesn't have focus
+    }, SEND_FREQ); // if we spin too quickly on this, packets don't get sent when window doesn't have focus
   };
 
   var tandemCommandResponse = function (command, args, callback) {
@@ -1174,6 +1159,7 @@ module.exports = function (config) {
     }
 
     function binarySearch(err, result) {
+      //console.log("binary search result: ",result);
       if (err) {
         debug('error retrieving record during binary search ', result);
         callback(err, null);

--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -986,7 +986,7 @@ module.exports = function (config) {
                       }
                     });
                   }
-                ,RETRY_TIMEOUT);
+                },RETRY_TIMEOUT);
               });
             }
             else {

--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -599,7 +599,7 @@ module.exports = function (config) {
 
   var pending = false;    //if serial send is pending, we have to wait before we send again
   var SEND_FREQ = 5;  // time between sending serial packets
-  var SEND_WAIT = 300; // time to wait when serial send is pending
+  var SEND_WAIT = 800; // time to wait when serial send is pending
 
   var BASE_TIME = Date.UTC(2008, 0, 1, 0, 0, 0).valueOf(); /* new Date(2008, 0, 1, 0, 0, 0).valueOf(); */
   var addTimestamp = function (o, rawTime) {
@@ -848,6 +848,9 @@ module.exports = function (config) {
     var retryRecoverTimer;
 
     var listenTimer = setInterval(function () {
+      if(pending) {
+        debug('pending');
+      }
       while (cfg.deviceComms.hasAvailablePacket() && !pending) {
         var processPacket = function (pkt) {
           if (pkt.valid &&
@@ -910,7 +913,7 @@ module.exports = function (config) {
         };
         processPacket(cfg.deviceComms.nextPacket());
       }
-    }, 1);
+    }, 5);
 
     var sendTimer = setInterval(function () {
       if (send_seq % 1000 === 0) {
@@ -936,6 +939,7 @@ module.exports = function (config) {
     var receive_seq = start;
     var recovering = false;
     var percentage_seq = 0;
+    var retryRecoverTimer;
 
     // this contains only the log events that we consider to define
     // a set of events that can truly be considered "pump data"
@@ -953,6 +957,9 @@ module.exports = function (config) {
     ];
 
     var listenTimer = setInterval(function () {
+      if(pending) {
+        debug('pending');
+      }
       while (cfg.deviceComms.hasAvailablePacket() && !pending) {
         var processPacket = function (pkt) {
           if (pkt.valid &&
@@ -969,6 +976,16 @@ module.exports = function (config) {
                 if(err) {
                   callback(err,null);
                 }
+                retryRecoverTimer = setTimeout(function() {
+                  if(recovering) {
+                    debug('Retrying to recover..',receive_seq);
+                    tandemCommand(COMMANDS.LOG_ENTRY_SEQ_REQ, [receive_seq], function (err) {
+                      if(err) {
+                        callback(err,null);
+                      }
+                    });
+                  }
+                },1000);
               });
             }
             else {
@@ -1009,7 +1026,7 @@ module.exports = function (config) {
         };
         processPacket(cfg.deviceComms.nextPacket());
       }
-    }, 1);
+    }, 5);
 
     var sendTimer = setInterval(function () {
       if (send_seq % 1000 === 0) {

--- a/lib/serialDevice.js
+++ b/lib/serialDevice.js
@@ -362,6 +362,9 @@ module.exports = function(config) {
       sendcheck({ bytesSent: 0, error: 'timeout' });
     }, 500);
     var sendcheck = function(info) {
+      if (chrome.runtime.lastError !== undefined) {
+        console.log('Error during send: ', chrome.runtime.lastError);
+      }
       clearTimeout(timerId);
       // debug('Sent ', info.bytesSent,' bytes');
 

--- a/lib/serialDevice.js
+++ b/lib/serialDevice.js
@@ -34,8 +34,8 @@ var moduleCounter = 1;
 
 var SEND_ERRORS = {
   'disconnected' : 'Disconnected. Reconnect the device.',
-  'pending' : 'pending', // this should be handled, not displayed
-  'timeout' : 'The send timed out.',
+  'pending' : 'Serial send is still pending.',
+  'timeout' : 'The serial send timed out.',
   'system_error' : 'A system error occurred. Reconnect the device.'
 };
 
@@ -364,19 +364,15 @@ module.exports = function(config) {
     var sendcheck = function(info) {
       clearTimeout(timerId);
       // debug('Sent ', info.bytesSent,' bytes');
-      addlog(' xmit ');
-      for (var i in bufView) {
-        addlog(('00' + bufView[i].toString(16)).substr(-2) + ' ');
-      }
-      addlog('\n');
-      logdump();
 
       if (l != info.bytesSent) {
         debug('Only ' + info.bytesSent + ' bytes sent out of ' + l);
       }
       if (info.error) {
         debug('Serial send returned ' + info.error);
-        callback(new Error(SEND_ERRORS[info.error]),null);
+        var error = new Error(SEND_ERRORS[info.error]);
+        error.name = info.error;
+        callback(error,null);
       }
       callback(null, info);
     };

--- a/lib/serialDevice.js
+++ b/lib/serialDevice.js
@@ -83,6 +83,9 @@ module.exports = function(config) {
     // bytes() -- returns entire buffer as a Uint8Array
     bytes : function() {
       return new Uint8Array(buffer);
+    },
+    contains : function(n) {
+      return (buffer.indexOf(n) !== -1) ? true : false;
     }
   };
 

--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -392,7 +392,7 @@ appActions._hideUnavailableDevices = function() {
   }
   else if (this.app.state._os === 'win') {
     uploads = _.reject(uploads, function(d) {
-      return d.key === 'tandem';
+      return;
     });
   }
   this.app.setState({uploads: uploads});

--- a/manifest.json
+++ b/manifest.json
@@ -71,8 +71,8 @@
           "vendorId": 1155,
           "productId": 22336,
           "bitrate": 921600,
-          "sendTimeout": 100,
-          "receiveTimeout": 100
+          "sendTimeout": 50,
+          "receiveTimeout": 50
         },
         {
           "deviceName": "OneTouchUltra2 w/FTDI cable",

--- a/manifest.json
+++ b/manifest.json
@@ -71,8 +71,8 @@
           "vendorId": 1155,
           "productId": 22336,
           "bitrate": 921600,
-          "sendTimeout": 5000,
-          "receiveTimeout": 5000
+          "sendTimeout": 100,
+          "receiveTimeout": 100
         },
         {
           "deviceName": "OneTouchUltra2 w/FTDI cable",

--- a/test/ui/testAppActions.js
+++ b/test/ui/testAppActions.js
@@ -559,11 +559,10 @@ describe('appActions', function() {
         app.setState({_os: 'win'});
       });
 
-      it('excludes only Tandem', function() {
+      it('excludes nothing', function() {
         expect(app.state.uploads.length).to.equal(10);
         appActions._hideUnavailableDevices();
-        expect(app.state.uploads.length).to.equal(9);
-        expect(_.findWhere(app.state.uploads, {key: 'tandem'})).to.not.be.ok;
+        expect(app.state.uploads.length).to.equal(10);
       });
     });
 


### PR DESCRIPTION
Addresses the following issues:

- Found an issue where it is assumed that a synchronization byte will always be at the beginning of the buffer, which is not always true. Fixed by discarding bytes correctly.
- On a "serial timeout" or "serial pending" error, we now wait SEND_INC_MAX ms before sending again (replaces backoff algorithm)
- Found an issue where sometimes if you send a request to the Tandem device, it just responds with a burst of 1s and 0s. This was fixed by retrying after a timeout, in which case it replies with the expected packet.
- On a "system_error" error, we now disconnect and reconnect automatically and continue where we left off.
- While recovering from a previous error, out-of-order packets were not re-requested. This was fixed by always re-requesting out-of-order packets.
- During a recovery sequence, we were still requesting other packets, which made things slower. We now only request the packet we are trying to actually recover.
- Binary search was using the wrong requester function.
- We now increase the progress bar while searching for the newest event. This is useful for devices that haven't been used in a while.

