### PR TITLE
Tandem settings history

### DIFF
--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -1233,6 +1233,8 @@ module.exports = function (config) {
             debug('Execution time for binary search: ' + time);
           }
           progress(10);
+          data.start_seq = 0;
+          console.log("TODO: change this back!");
           tandemFetchEventRange(progress, data, callback);
         }
       }
@@ -1301,9 +1303,9 @@ module.exports = function (config) {
       .with_conversionOffset(0)
       .done();
 
-    settings = postsettings;
     postrecords.push(postsettings);
 
+    var postSettingsHistory = [];
     var records = filterLogEntries([
       PUMP_LOG_RECORDS.LID_IDP,         //profile added or deleted
       PUMP_LOG_RECORDS.LID_IDP_MSG2,
@@ -1327,6 +1329,8 @@ module.exports = function (config) {
         var scheduleName = _.find(data.profiles, {idp: record.idp}).name;
         console.log("scheduleName", scheduleName);
 
+        //TODO: set values to undefined instead of 0 when segment is deleted
+        console.log(basalSchedules);
         basalSchedules[scheduleName][record.segment_index] = {rate: record.basal_rate, start: record.start_time};
         carbSchedules[scheduleName][record.segment_index] = {amount: record.carb_ratio, start: record.start_time};
         sensitivitySchedules[scheduleName][record.segment_index] = {amount: record.isf, start: record.start_time};
@@ -1337,9 +1341,37 @@ module.exports = function (config) {
           .with_insulinSensitivities(sensitivitySchedules)
           .with_bgTargets(targetSchedules)
           .done();
-        postrecords.push(settingsEntry);
+        postSettingsHistory.push(settingsEntry);
+      }
+      else if (record.header_id === PUMP_LOG_RECORDS.LID_IDP.value ){
+        console.log("LID_IDP:", record.idp, record.operation, record.source_idp, record.name_start);
+        if(record.operation === 'new' || record.operation === 'rename') {
+          var nameChange = {
+            type: 'pumpSettings',
+            subType: 'name-change',
+            name: record.name_start,
+            idp: record.idp
+          };
+          cfg.tzoUtil.fillInUTCInfo(nameChange, record.jsDate);
+          postSettingsHistory.push(nameChange);
+        }
+        else if (record.operation === 'activate') {
+          var activate = {
+            type: 'pumpSettings',
+            subType: 'activate',
+            name: record.name_start,
+            idp: record.idp
+          };
+          cfg.tzoUtil.fillInUTCInfo(activate, record.jsDate);
+          postSettingsHistory.push(activate);
+        }
+      }
+      else if (record.header_id === PUMP_LOG_RECORDS.LID_IDP_MSG2.value ){
+        console.log("LID_ID_MSG2:", record.idp, record.name_end);
       }
     });
+
+    postrecords = postrecords.concat(postSettingsHistory);
 
     /*
     var last = null;

--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -433,6 +433,8 @@ module.exports = function (config) {
             debug('unhandled operation in profile event', rec);
             rec.operation = 'unknown';
         }
+
+        rec.name_start = rec.name_start.replace(/\0/g, ''); //remove null characters
       }
     },
     LID_IDP_BOLUS: {
@@ -1285,9 +1287,13 @@ module.exports = function (config) {
         targetSchedule.push({ target: tdep['TargetBG'], start: tdep['startTime'] });
       });
       basalSchedules[scheduleName] = schedule;
+      basalSchedules[scheduleName].idp = profile.idp; //need idp in case schedule is renamed
       carbSchedules[scheduleName] = carbSchedule;
+      carbSchedules[scheduleName].idp = profile.idp;
       sensitivitySchedules[scheduleName] = sensitivitySchedule;
+      sensitivitySchedules[scheduleName].idp = profile.idp;
       targetSchedules[scheduleName] = targetSchedule;
+      targetSchedules[scheduleName].idp = profile.idp;
     });
 
     var postsettings = cfg.builder.makePumpSettingsAllObjects()

--- a/lib/drivers/tandemTslimDriver.js
+++ b/lib/drivers/tandemTslimDriver.js
@@ -1297,13 +1297,47 @@ module.exports = function (config) {
       .with_conversionOffset(0)
       .done();
 
+    settings = postsettings;
     postrecords.push(postsettings);
 
-    var records = filterLogEntries([PUMP_LOG_RECORDS.LID_IDP, PUMP_LOG_RECORDS.LID_IDP_BOLUS,
-      PUMP_LOG_RECORDS.LID_IDP_LIST, PUMP_LOG_RECORDS.LID_IDP_MSG2, PUMP_LOG_RECORDS.LID_IDP_TD_SEG,
-      PUMP_LOG_RECORDS.LID_PARAM_GLOBAL_SETTINGS], data.log_records);
+    var records = filterLogEntries([
+      PUMP_LOG_RECORDS.LID_IDP,         //profile added or deleted
+      PUMP_LOG_RECORDS.LID_IDP_MSG2,
+      PUMP_LOG_RECORDS.LID_IDP_LIST,    // a new segment is added, deleted, or activated. List id of all available profiles, active at index 0
+      PUMP_LOG_RECORDS.LID_IDP_TD_SEG],  // time dependent parameter changed
+      data.log_records);
 
-    records = filterLogEntries([PUMP_LOG_RECORDS.LID_IDP_TD_SEG], data.log_records);
+    records = _.sortBy(records, function(rec) { return rec.index; }).reverse();
+
+    records.forEach(function (record) {
+      console.log("Settings change:",record);
+      var settingsEntry = cfg.builder.makePumpSettingsAllObjects()
+        .with_activeSchedule(activeName)
+        .with_units({ carb: 'grams', bg: 'mg/dL' })
+        .with_deviceTime(record.deviceTime) //time of settings change
+        .set('index', record.index);
+      cfg.tzoUtil.fillInUTCInfo(settingsEntry, record.jsDate);
+
+
+      if (record.header_id === PUMP_LOG_RECORDS.LID_IDP_TD_SEG.value) {
+        var scheduleName = _.find(data.profiles, {idp: record.idp}).name;
+        console.log("scheduleName", scheduleName);
+
+        basalSchedules[scheduleName][record.segment_index] = {rate: record.basal_rate, start: record.start_time};
+        carbSchedules[scheduleName][record.segment_index] = {amount: record.carb_ratio, start: record.start_time};
+        sensitivitySchedules[scheduleName][record.segment_index] = {amount: record.isf, start: record.start_time};
+        targetSchedules[scheduleName][record.segment_index] = {target: record.target_bg, start: record.start_time};
+
+        settingsEntry.with_basalSchedules(basalSchedules)
+          .with_carbRatios(carbSchedules)
+          .with_insulinSensitivities(sensitivitySchedules)
+          .with_bgTargets(targetSchedules)
+          .done();
+        postrecords.push(settingsEntry);
+      }
+    });
+
+    /*
     var last = null;
     records = _.sortByOrder(records, ['idp','segment_index','index'], [true, true, false]); //TODO: this needs to change for lodash 3.10
 
@@ -1342,6 +1376,7 @@ module.exports = function (config) {
       }
       last = record;
     });
+    */
 
     return postrecords;
   };
@@ -1777,11 +1812,8 @@ module.exports = function (config) {
       }
 
       if (!_.isEmpty(data.log_records)) {
+        postrecords = buildTimeChangeRecords(data, postrecords); //cfg.tzoUtil gets built here
         postrecords = buildSettingsRecords(data, postrecords);
-        if (!_.isEmpty(postrecords)) {
-          settings = postrecords[0];
-        }
-        postrecords = buildTimeChangeRecords(data, postrecords);
         postrecords = buildBolusRecords(data, postrecords);
 
         postrecords = buildBasalRecords(data, postrecords);

--- a/lib/drivers/tandemTslimDriver.js
+++ b/lib/drivers/tandemTslimDriver.js
@@ -581,7 +581,7 @@ module.exports = function (config) {
     fields: ['startTime', 'basalRate', 'carbRatio', 'TargetBG', 'ISF', 'status'],
     postprocess: function (rec) {
       rec.startTime = rec.startTime * sundial.MIN_TO_MSEC;
-      rec.basalRate = rec.basalRate * 0.001;
+      rec.basalRate = (rec.basalRate * 0.001).toFixedNumber(SIGNIFICANT_DIGITS);
       rec.carbRatio = rec.carbRatio * 0.001;
       // TODO: status
       return rec;
@@ -1273,7 +1273,7 @@ module.exports = function (config) {
       var sensitivitySchedule = [];
       var targetSchedule = [];
       profile.tdeps.forEach(function (tdep) {
-        schedule.push({ rate: Math.fround(tdep['basalRate']), start: tdep['startTime'] });
+        schedule.push({ rate: tdep['basalRate'], start: tdep['startTime'] });
         carbSchedule.push({ amount: Math.fround(tdep['carbRatio']), start: tdep['startTime'] });
         sensitivitySchedule.push({ amount: tdep['ISF'], 'start': tdep['startTime'] });
         targetSchedule.push({ target: tdep['TargetBG'], start: tdep['startTime'] });

--- a/lib/tandem/tandemSimulator.js
+++ b/lib/tandem/tandemSimulator.js
@@ -49,6 +49,8 @@ exports.make = function(config){
   var currStatus = null;
   var currTimestamp = null;
   var currTempBasal = null;
+  var scheduleNames = [];
+  var activeSchedule = {};
 
   function setCurrBasal(basal) {
     currBasal = basal;
@@ -60,6 +62,27 @@ exports.make = function(config){
 
   function setCurrTempBasal(tempBasal) {
     currTempBasal = tempBasal;
+  }
+
+  function setScheduleName(idp, name) {
+    if(scheduleNames[idp] !== undefined) {
+      //update schedule name
+      scheduleNames[idp].previous = scheduleNames[idp].name;
+      scheduleNames[idp].name = name;
+      console.log("updating schedule name", scheduleNames[idp]);
+    } else {
+      // set new schedule name
+      scheduleNames[idp] = {};
+      scheduleNames[idp].name = name;
+      console.log("new schedule name:", scheduleNames[idp]);
+    }
+  }
+
+  function setActiveSchedule(idp, name) {
+    activeSchedule = {
+      idp : idp,
+      name : name
+    };
   }
 
   function ensureTimestamp(e){
@@ -215,8 +238,39 @@ exports.make = function(config){
       // (and tideline is able to render them)
       // then start simulating them again for upload
 
-      //TODO: batch records with the same time
-      simpleSimulate(event);
+      //TODO: batch records with the same time?
+
+
+
+      if(event.subType === 'name-change') {
+        console.log("schedule name change");
+        setScheduleName(event.idp,event.name);
+      }
+      else if (event.subType === 'activate') {
+        console.log("active schedule change");
+        setActiveSchedule(event.idp,event.name);
+      } else{
+        //regular settings Object
+        console.log("event before:", event.activeSchedule);
+        if (activeSchedule) {
+          event.activeSchedule = activeSchedule.name;
+        }
+        scheduleNames.forEach(function (schedule) {
+          if(schedule.previous !== undefined) {
+            //renaming schedules
+            event.basalSchedules[schedule.name] = event.basalSchedules[schedule.previous];
+            delete event.basalSchedules[schedule.previous];
+            event.carbRatios[schedule.name] = event.carbRatios[schedule.previous];
+            delete event.carbRatios[schedule.previous];
+            event.insulinSensitivities[schedule.name] = event.insulinSensitivities[schedule.previous];
+            delete event.insulinSensitivities[schedule.previous];
+            event.bgTargets[schedule.name] = event.bgTargets[schedule.previous];
+            delete event.bgTargets[schedule.previous];
+          }
+        });
+        console.log("event after:", event.activeSchedule, event);
+        simpleSimulate(event);
+      }
     },
     smbg: function(event) {
       simpleSimulate(event);

--- a/lib/tandem/tandemSimulator.js
+++ b/lib/tandem/tandemSimulator.js
@@ -65,17 +65,14 @@ exports.make = function(config){
   }
 
   function setScheduleName(idp, name) {
-    if(scheduleNames[idp] !== undefined) {
-      //update schedule name
-      scheduleNames[idp].previous = scheduleNames[idp].name;
-      scheduleNames[idp].name = name;
-      console.log("updating schedule name", scheduleNames[idp]);
+    var match = _.find(scheduleNames, {idp:idp});
+    if(match){
+        var index = _.indexOf(scheduleNames, match);
+        scheduleNames.splice(index, 1, {idp:idp,name:name});
     } else {
-      // set new schedule name
-      scheduleNames[idp] = {};
-      scheduleNames[idp].name = name;
-      console.log("new schedule name:", scheduleNames[idp]);
+        scheduleNames.push({idp:idp,name:name});
     }
+    console.log("scheduleNames:",scheduleNames);
   }
 
   function setActiveSchedule(idp, name) {
@@ -234,16 +231,11 @@ exports.make = function(config){
       simpleSimulate(event);
     },
     pumpSettings: function(event) {
-      // TODO: once pumpSettings are a corrected
-      // (and tideline is able to render them)
-      // then start simulating them again for upload
 
-      //TODO: batch records with the same time?
-
-
+      //TODO: batch records with the same time
 
       if(event.subType === 'name-change') {
-        console.log("schedule name change");
+        console.log("schedule name change to ", event.name);
         setScheduleName(event.idp,event.name);
       }
       else if (event.subType === 'activate') {
@@ -251,24 +243,33 @@ exports.make = function(config){
         setActiveSchedule(event.idp,event.name);
       } else{
         //regular settings Object
-        console.log("event before:", event.activeSchedule);
         if (activeSchedule) {
           event.activeSchedule = activeSchedule.name;
         }
         scheduleNames.forEach(function (schedule) {
-          if(schedule.previous !== undefined) {
+
+          var match = null;
+          // searching for old schedule name
+          _.forEach(event.basalSchedules, function(n, key) {
+            if (n.idp === schedule.idp) {
+              match = key;
+            }
+          });
+
+          if (match && match !== schedule.name) {
+            console.log("renaming", match ,"to",schedule.name);
             //renaming schedules
-            event.basalSchedules[schedule.name] = event.basalSchedules[schedule.previous];
-            delete event.basalSchedules[schedule.previous];
-            event.carbRatios[schedule.name] = event.carbRatios[schedule.previous];
-            delete event.carbRatios[schedule.previous];
-            event.insulinSensitivities[schedule.name] = event.insulinSensitivities[schedule.previous];
-            delete event.insulinSensitivities[schedule.previous];
-            event.bgTargets[schedule.name] = event.bgTargets[schedule.previous];
-            delete event.bgTargets[schedule.previous];
+            event.basalSchedules[schedule.name] = event.basalSchedules[match];
+            delete event.basalSchedules[match];
+            event.carbRatios[schedule.name] = event.carbRatios[match];
+            delete event.carbRatios[match];
+            event.insulinSensitivities[schedule.name] = event.insulinSensitivities[match];
+            delete event.insulinSensitivities[match];
+            event.bgTargets[schedule.name] = event.bgTargets[match];
+            delete event.bgTargets[match];
+            console.log("basalSchedules after:", JSON.stringify(event.basalSchedules));
           }
         });
-        console.log("event after:", event.activeSchedule, event);
         simpleSimulate(event);
       }
     },

--- a/lib/tandem/tandemSimulator.js
+++ b/lib/tandem/tandemSimulator.js
@@ -103,9 +103,11 @@ exports.make = function(config){
       if (currBasal != null) {
         if (currBasal.deliveryType !== 'scheduled') {
           if (currBasal.deliveryType === 'temp') {
+            /*
             if (currBasal.isAssigned('suppressed')) {
               //TODO: handle suppressed
-            }
+            }*/
+            currBasal.duration = 0;
             currBasal = currBasal.done();
           }
           else {
@@ -172,6 +174,8 @@ exports.make = function(config){
       // TODO: once pumpSettings are a corrected
       // (and tideline is able to render them)
       // then start simulating them again for upload
+
+      //TODO: batch records with the same time
       simpleSimulate(event);
     },
     smbg: function(event) {


### PR DESCRIPTION
**WIP**: Do not merge.

We may not be able to get this working until we upload all records during the first upload, and subsequently use diff uploads. The reason is that if a schedule's name change, we have to look to the previous "new schedule" or "rename schedule" record to determine what the name was. If we only have the most recent 90 days' worth of data, we don't have enough information to do this.

We need to take into account:
- [ ] a profile/schedule being added or deleted
- [x] a profile/schedule being renamed
- [ ] a segment in a profile being added or deleted
- [x] parameters in a segment being changed
- [x] active schedule changes