### PR TITLE
Removed the 'Choose file' button, and added a (x) on Insulet uploads.

### DIFF
--- a/lib/components/Upload.jsx
+++ b/lib/components/Upload.jsx
@@ -118,6 +118,11 @@ var Upload = React.createClass({
       return null;
     }
 
+    // don't show the 'choose file' button if a file has already been selected.
+    if (this.isBlockModeFileChosen()) {
+      return null;
+    }
+
     return (
       <div className="Upload-inputWrapper">
         <input className="Upload-fileinput" ref="file" type="file" onChange={this.onBlockModeInputChange}/>
@@ -211,9 +216,13 @@ var Upload = React.createClass({
       return <div className="Upload-status Upload-status--success">{this.props.text.UPLOAD_COMPLETE}</div>;
     }
     if (this.isBlockModeFileChosen()) {
-      return <div className="Upload-status Upload-status--uploading"><p>{this.props.upload.file.name}</p></div>;
+      return (
+          <div className="Upload-status Upload-status--filename">
+            <p>{this.props.upload.file.name}</p>
+            <i className="icon-delete" onClick={this.clearBlockModeFile}></i>
+          </div>
+      );
     }
-
     return null;
   },
   renderReset: function() {
@@ -347,15 +356,19 @@ var Upload = React.createClass({
     this.props.onUpload(options);
   },
 
+  clearBlockModeFile: function() {
+    this.setState({
+      blockModeFileNotChosen: true
+    });
+  },
+
   handleBlockModeUpload: function() {
     var options = {
       filename: this.props.upload.file.name,
       filedata: this.props.upload.file.data
     };
     this.props.onUpload(options);
-    this.setState({
-      blockModeFileNotChosen: true
-    });
+    this.clearBlockModeFile();
   },
 
   handleReset: function(e) {

--- a/styles/components/Upload.less
+++ b/styles/components/Upload.less
@@ -63,6 +63,10 @@
   width: 100%;
 }
 
+.Upload-status--filename i:hover {
+  color: @purple-light;
+}
+
 .Upload-status--error {
   padding-right: 5px;
   color: @red;

--- a/styles/components/Upload.less
+++ b/styles/components/Upload.less
@@ -59,6 +59,10 @@
   }
 }
 
+.Upload-status--filename {
+  width: 100%;
+}
+
 .Upload-status--error {
   padding-right: 5px;
   color: @red;


### PR DESCRIPTION
I believe this patch fixes https://trello.com/c/P0TpowaC
I've added some simple conditionals and styling to hide the 'choose file' button
once an ibf file has been selected in the uploader, as well as adding a 'delete'
icon button next to the file name.  That button removes the file from the list and
causes the choose and upload buttons to return to their default state by virtue of
toggling the 'isBlockModeFileChosen' state flag on the Upload component.

I have *not* tested that the proper file is uploaded to the server, but the current
upload behavior should be the same as that of clicking the 'choose file' button
multiple times.

Here's a screenshot of the change:
![image](https://cloud.githubusercontent.com/assets/257712/11769137/1054f44c-a195-11e5-81b3-3ab23818899e.png)
