### PR TITLE
Refactoring when closest is found and returning

### DIFF
--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -1242,6 +1242,22 @@ module.exports = function (config) {
     }
 
     function binarySearch(err, result) {
+
+      var foundClosest = function() {
+        debug('90 day, closest record: ', result.payload.deviceTime);
+        debug('start_seq: ', currentIndex);
+
+        data.start_seq = currentIndex;
+        if(__DEBUG__) {
+          var end_exec = Date.now();
+          var time = end_exec - start_exec;
+          debug('Execution time for binary search: ' + time);
+        }
+        progress(10);
+        cfg.deviceComms.flush(); // making sure we flush the buffers
+        tandemFetchEventRange(progress, data, callback);
+      };
+
       if (err) {
         debug('error retrieving record during binary search ', result);
         callback(err, null);
@@ -1258,8 +1274,7 @@ module.exports = function (config) {
             maxIndex = currentIndex - 1;
           }
           else {
-            data.start_seq = currentIndex;
-            tandemFetchEventRange(progress, data, callback);
+            return foundClosest();
           }
           currentIndex = Math.floor( (minIndex + maxIndex) / 2 );
           if (currentIndex < start_seq) {
@@ -1267,19 +1282,7 @@ module.exports = function (config) {
           }
           tandemCommandResponse(COMMANDS.LOG_ENTRY_SEQ_REQ, [currentIndex], binarySearch);
         } else {
-
-          debug('90 day, closest record: ', result.payload.deviceTime);
-          debug('start_seq: ', currentIndex);
-
-          data.start_seq = currentIndex;
-          if(__DEBUG__) {
-            var end_exec = Date.now();
-            var time = end_exec - start_exec;
-            debug('Execution time for binary search: ' + time);
-          }
-          progress(10);
-          cfg.deviceComms.flush(); // making sure we flush the buffers
-          tandemFetchEventRange(progress, data, callback);
+          return foundClosest();
         }
       }
     }

--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -1216,8 +1216,8 @@ module.exports = function (config) {
     var minIndex;
     var maxIndex;
     var currentIndex;
-    var currentElement;
-    var searchElement;
+    var currentTimestamp;
+    var timestampToFind;
 
     function getNewestEvent(err, result) {
 
@@ -1226,7 +1226,7 @@ module.exports = function (config) {
         callback(err, null);
       }
 
-      searchElement = result.payload.rawTimestamp - 90 * 24 * 60 * 60 * 1000;
+      timestampToFind = result.payload.rawTimestamp - 90 * 24 * 60 * 60 * 1000;
 
       debug('newest record deviceTime: ', result.payload.deviceTime);
       debug('end_seq after finding newest record: ', result.payload.header_log_seq_no);
@@ -1248,7 +1248,7 @@ module.exports = function (config) {
         debug('start_seq: ', currentIndex);
 
         data.start_seq = currentIndex;
-        if(__DEBUG__) {
+        if (__DEBUG__) {
           var end_exec = Date.now();
           var time = end_exec - start_exec;
           debug('Execution time for binary search: ' + time);
@@ -1265,12 +1265,12 @@ module.exports = function (config) {
       else {
         if (minIndex <= maxIndex) {
 
-          currentElement = result.payload.rawTimestamp;
+          currentTimestamp = result.payload.rawTimestamp;
 
-          if (currentElement < searchElement) {
+          if (currentTimestamp < timestampToFind) {
             minIndex = currentIndex + 1;
           }
-          else if (currentElement > searchElement) {
+          else if (currentTimestamp > timestampToFind) {
             maxIndex = currentIndex - 1;
           }
           else {
@@ -1281,7 +1281,8 @@ module.exports = function (config) {
             currentIndex = start_seq;
           }
           tandemCommandResponse(COMMANDS.LOG_ENTRY_SEQ_REQ, [currentIndex], binarySearch);
-        } else {
+        }
+        else {
           return foundClosest();
         }
       }


### PR DESCRIPTION
This is a potential fix for the EF long upload issue. It looks like the bug happens when the exact timestamp is found by the binary search, and would then run different code (and essentially continue to run the binary search).

The same code `foundClosest()` is now run when the exact timestamp is found or the binary search ends.