### PR TITLE
Add support for non-US formatted CareLink CSV files

### DIFF
--- a/lib/carelink/getCareLinkFormatInfo.js
+++ b/lib/carelink/getCareLinkFormatInfo.js
@@ -1,0 +1,49 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2016, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+var _ = require('lodash');
+var moment = require('moment'); // Moment is already a dependency of sundial
+var POSSIBLE_DATE_FORMATS = ['MM/DD/YY HH:mm:ss', 'DD/MM/YY HH:mm:ss']; // The first element is the default
+
+// We take a Moment as an argument because it's unambiguous.
+module.exports = function (rows, /* moment */ dataDownloadMoment) {
+  var dataExportFormat = 0;
+
+  var dataExportedOnString;
+  for (var i = 0; i < rows.length; ++i) {
+    if (rows[i][0].search('Data Exported on') != -1) {
+      dataExportedOnString = rows[i][1];
+      break;
+    }
+  }
+
+  // Now try and figure out what the date format should be, since CareLink doesn't tell us explicitly
+  // Start from the second element, because the first will be the default if we don't match anyway.
+  for (var j = 1; j < POSSIBLE_DATE_FORMATS.length; j++) {
+    var dataExportMoment = moment(dataExportedOnString, POSSIBLE_DATE_FORMATS[j]);
+    if (dataExportMoment.diff(dataDownloadMoment, 'days') === 0) {
+      dataExportFormat = j;
+      break;
+    }
+  }
+
+  return {
+    getDataExportFormat: function () {
+      return POSSIBLE_DATE_FORMATS[dataExportFormat];
+    }
+  };
+};

--- a/lib/carelink/pumpSettings.js
+++ b/lib/carelink/pumpSettings.js
@@ -31,16 +31,16 @@ var TIMESTAMP = 'Timestamp';
 var RV_KEYS = {
   AMOUNT_HIGH: 'AMOUNT_HIGH',
   AMOUNT_LOW: 'AMOUNT_LOW',
-  BG_TARGET_RANGE_PATTERN_DATUM: 'BG_TARGET_RANGE_PATTERN_DATUM_ID',
+  BG_TARGET_RANGE_PATTERN_DATUM: 'BG_TARGET_RANGE_PATTERN_DATUM',
   BG_UNITS: 'BG_UNITS',
-  CARB_RATIO_PATTERN_DATUM: 'CARB_RATIO_PATTERN_DATUM_ID',
+  CARB_RATIO_PATTERN_DATUM: 'CARB_RATIO_PATTERN_DATUM',
   CARB_UNITS: 'CARB_UNITS',
-  INSULIN_SENSITIVITY_PATTERN_DATUM: 'INSULIN_SENSITIVITY_PATTERN_DATUM_ID',
-  NEW_CONFIG_DATUM: 'NEW_CONFIG_DATUM_ID',
+  INSULIN_SENSITIVITY_PATTERN_DATUM: 'INSULIN_SENSITIVITY_PATTERN_DATUM',
+  NEW_CONFIG_DATUM: 'NEW_CONFIG_DATUM',
   NUM_PROFILES: 'NUM_PROFILES',
-  OLD_CONFIG_DATUM: 'OLD_CONFIG_DATUM_ID',
+  OLD_CONFIG_DATUM: 'OLD_CONFIG_DATUM',
   OLD_PATTERN_NAME: 'OLD_PATTERN_NAME',
-  PATTERN_DATUM: 'PATTERN_DATUM_ID',
+  PATTERN_DATUM: 'PATTERN_DATUM',
   PATTERN_NAME: 'PATTERN_NAME',
   PROFILE_INDEX: 'PROFILE_INDEX',
   RATE: 'RATE',
@@ -51,7 +51,18 @@ var RV_KEYS = {
   SIZE: 'SIZE',
   START_TIME: 'START_TIME',
   TARGET_INDEX: 'INDEX',
-  UNITS: 'UNITS'
+  UNITS: 'UNITS',
+  getKeyValue: function(data, key){
+    return (typeof data[RAW_VALUES][key] !== 'undefined') ?
+      data[RAW_VALUES][key] : data[RAW_VALUES][key+'_ID'];
+  },
+  patternDatumFieldFn: function(n){
+    return (typeof n[RAW_VALUES][RV_KEYS.PATTERN_DATUM] !== 'undefined') ?
+      n[RAW_VALUES][RV_KEYS.PATTERN_DATUM] : n[RAW_VALUES][RV_KEYS.PATTERN_DATUM+'_ID'];
+  },
+  getRawValue: function(data) {
+    return data;
+  }
 };
 
 function makeEntryParser() {
@@ -60,7 +71,7 @@ function makeEntryParser() {
       /** basal **/
       ChangeBasalProfile: {
         index: parsing.asNumber([RAW_VALUES, RV_KEYS.PROFILE_INDEX]),
-        patternDatum: parsing.asNumber([RAW_VALUES, RV_KEYS.PATTERN_DATUM]),
+        patternDatum: parsing.map(RV_KEYS.patternDatumFieldFn, parsing.asNumber(RV_KEYS.getRawValue)),
         payload: {
           rate: parsing.asNumber([RAW_VALUES, RV_KEYS.RATE]),
           start: parsing.asNumber([RAW_VALUES, RV_KEYS.START_TIME])
@@ -68,7 +79,7 @@ function makeEntryParser() {
       },
       ChangeBasalProfilePre: {
         index: parsing.asNumber([RAW_VALUES, RV_KEYS.PROFILE_INDEX]),
-        patternDatum: parsing.asNumber([RAW_VALUES, RV_KEYS.PATTERN_DATUM]),
+        patternDatum: parsing.map(RV_KEYS.patternDatumFieldFn, parsing.asNumber(RV_KEYS.getRawValue)),
         payload: {
           rate: parsing.asNumber([RAW_VALUES, RV_KEYS.RATE]),
           start: parsing.asNumber([RAW_VALUES, RV_KEYS.START_TIME])
@@ -76,7 +87,7 @@ function makeEntryParser() {
       },
       CurrentBasalProfile: {
         index: parsing.asNumber([RAW_VALUES, RV_KEYS.PROFILE_INDEX]),
-        patternDatum: parsing.asNumber([RAW_VALUES, RV_KEYS.PATTERN_DATUM]),
+        patternDatum: parsing.map(RV_KEYS.patternDatumFieldFn, parsing.asNumber(RV_KEYS.getRawValue)),
         payload: {
           rate: parsing.asNumber([RAW_VALUES, RV_KEYS.RATE]),
           start: parsing.asNumber([RAW_VALUES, RV_KEYS.START_TIME])
@@ -86,7 +97,7 @@ function makeEntryParser() {
       /** bgTarget **/
       ChangeBGTargetRange: {
         index: parsing.asNumber([RAW_VALUES, RV_KEYS.TARGET_INDEX]),
-        patternDatum: parsing.asNumber([RAW_VALUES, RV_KEYS.PATTERN_DATUM]),
+        patternDatum: parsing.map(RV_KEYS.patternDatumFieldFn, parsing.asNumber(RV_KEYS.getRawValue)),
         payload: {
           low: parsing.map(parsing.asNumber([RAW_VALUES, RV_KEYS.AMOUNT_LOW]), bgConversionFn),
           high: parsing.map(parsing.asNumber([RAW_VALUES, RV_KEYS.AMOUNT_HIGH]), bgConversionFn),
@@ -95,7 +106,7 @@ function makeEntryParser() {
       },
       CurrentBGTargetRange: {
         index: parsing.asNumber([RAW_VALUES, RV_KEYS.TARGET_INDEX]),
-        patternDatum: parsing.asNumber([RAW_VALUES, RV_KEYS.PATTERN_DATUM]),
+        patternDatum: parsing.map(RV_KEYS.patternDatumFieldFn, parsing.asNumber(RV_KEYS.getRawValue)),
         payload: {
           low: parsing.map(parsing.asNumber([RAW_VALUES, RV_KEYS.AMOUNT_LOW]), bgConversionFn),
           high: parsing.map(parsing.asNumber([RAW_VALUES, RV_KEYS.AMOUNT_HIGH]), bgConversionFn),
@@ -106,7 +117,7 @@ function makeEntryParser() {
       /** carbRatio **/
       ChangeCarbRatio: {
         index: parsing.asNumber([RAW_VALUES, RV_KEYS.RATIO_INDEX]),
-        patternDatum: parsing.asNumber([RAW_VALUES, RV_KEYS.PATTERN_DATUM]),
+        patternDatum: parsing.map(RV_KEYS.patternDatumFieldFn, parsing.asNumber(RV_KEYS.getRawValue)),
         payload: {
           amount: parsing.asNumber([RAW_VALUES, RV_KEYS.RATIO_AMOUNT]),
           start: parsing.asNumber([RAW_VALUES, RV_KEYS.START_TIME])
@@ -114,7 +125,7 @@ function makeEntryParser() {
       },
       CurrentCarbRatio: {
         index: parsing.asNumber([RAW_VALUES, RV_KEYS.RATIO_INDEX]),
-        patternDatum: parsing.asNumber([RAW_VALUES, RV_KEYS.PATTERN_DATUM]),
+        patternDatum: parsing.map(RV_KEYS.patternDatumFieldFn, parsing.asNumber(RV_KEYS.getRawValue)),
         payload: {
           amount: parsing.asNumber([RAW_VALUES, RV_KEYS.RATIO_AMOUNT]),
           start: parsing.asNumber([RAW_VALUES, RV_KEYS.START_TIME])
@@ -124,7 +135,7 @@ function makeEntryParser() {
       /** insulinSensitivity **/
       ChangeInsulinSensitivity: {
         index: parsing.asNumber([RAW_VALUES, RV_KEYS.SENSITIVITY_INDEX]),
-        patternDatum: parsing.asNumber([RAW_VALUES, RV_KEYS.PATTERN_DATUM]),
+        patternDatum: parsing.map(RV_KEYS.patternDatumFieldFn, parsing.asNumber(RV_KEYS.getRawValue)),
         payload: {
           amount: parsing.map(parsing.asNumber([RAW_VALUES, RV_KEYS.SENSITIVITY_AMOUNT]), bgConversionFn),
           start: parsing.asNumber([RAW_VALUES, RV_KEYS.START_TIME])
@@ -132,7 +143,7 @@ function makeEntryParser() {
       },
       CurrentInsulinSensitivity: {
         index: parsing.asNumber([RAW_VALUES, RV_KEYS.SENSITIVITY_INDEX]),
-        patternDatum: parsing.asNumber([RAW_VALUES, RV_KEYS.PATTERN_DATUM]),
+        patternDatum: parsing.map(RV_KEYS.patternDatumFieldFn, parsing.asNumber(RV_KEYS.getRawValue)),
         payload: {
           amount: parsing.map(parsing.asNumber([RAW_VALUES, RV_KEYS.SENSITIVITY_AMOUNT]), bgConversionFn),
           start: parsing.asNumber([RAW_VALUES, RV_KEYS.START_TIME])
@@ -195,19 +206,19 @@ function applyEntries(data, range, lookup) {
 function buildWizardChange(data, range, id){
   var configDatum = findDatum(data, range, id);
 
-  var bgTargetDatum = findDatum(data, range, configDatum[RAW_VALUES][RV_KEYS.BG_TARGET_RANGE_PATTERN_DATUM]);
-  var carbRatioDatum = findDatum(data, range, configDatum[RAW_VALUES][RV_KEYS.CARB_RATIO_PATTERN_DATUM]);
-  var insSensDatum = findDatum(data, range, configDatum[RAW_VALUES][RV_KEYS.INSULIN_SENSITIVITY_PATTERN_DATUM]);
+  var bgTargetDatum = findDatum(data, range, RV_KEYS.getKeyValue(configDatum,RV_KEYS.BG_TARGET_RANGE_PATTERN_DATUM));
+  var carbRatioDatum = findDatum(data, range, RV_KEYS.getKeyValue(configDatum,RV_KEYS.CARB_RATIO_PATTERN_DATUM));
+  var insSensDatum = findDatum(data, range, RV_KEYS.getKeyValue(configDatum,RV_KEYS.INSULIN_SENSITIVITY_PATTERN_DATUM));
 
   var retVal = {
-    bgTarget: new Array(parseInt(bgTargetDatum[RAW_VALUES][RV_KEYS.SIZE])),
-    carbRatio: new Array(parseInt(carbRatioDatum[RAW_VALUES][RV_KEYS.SIZE])),
-    insulinSensitivity: new Array(parseInt(insSensDatum[RAW_VALUES][RV_KEYS.SIZE])),
+    bgTarget: new Array(parseInt(RV_KEYS.getKeyValue(bgTargetDatum,RV_KEYS.SIZE))),
+    carbRatio: new Array(parseInt(RV_KEYS.getKeyValue(carbRatioDatum,RV_KEYS.SIZE))),
+    insulinSensitivity: new Array(parseInt(RV_KEYS.getKeyValue(insSensDatum,RV_KEYS.SIZE))),
     units: {
-      carb: configDatum[RAW_VALUES][RV_KEYS.CARB_UNITS]
+      carb: RV_KEYS.getKeyValue(configDatum,RV_KEYS.CARB_UNITS)
     }
   };
-  var normalizedBg = common.normalizeBgUnits(configDatum[RAW_VALUES][RV_KEYS.BG_UNITS]);
+  var normalizedBg = common.normalizeBgUnits(RV_KEYS.getKeyValue(configDatum,RV_KEYS.BG_UNITS));
   if (normalizedBg != null) {
     retVal.units.bg = normalizedBg;
   }
@@ -282,11 +293,11 @@ module.exports = function (opts) {
             var prevSettings = _.assign(
               _.cloneDeep(currSettings),
               commonParser(findSettingsChangeBefore(i)),
-              { activeSchedule: datum[RAW_VALUES][RV_KEYS.OLD_PATTERN_NAME] }
+              { activeSchedule: RV_KEYS.getKeyValue(datum,RV_KEYS.OLD_PATTERN_NAME) }
             );
             delete prevSettings.annotations;
 
-            if (datum[RAW_VALUES][RV_KEYS.PATTERN_NAME] !== currSettings.activeSchedule) {
+            if (RV_KEYS.getKeyValue(datum,RV_KEYS.PATTERN_NAME) !== currSettings.activeSchedule) {
               annotate.annotateEvent(prevSettings, 'carelink/settings/activeSchedule-mismatch');
             }
 
@@ -313,10 +324,10 @@ module.exports = function (opts) {
               ++preIndex;
             }
 
-            var scheduleName = data[i][RAW_VALUES][RV_KEYS.PATTERN_NAME];
-            var newSchedule = new Array(parseInt(data[i][RAW_VALUES][RV_KEYS.NUM_PROFILES]));
-            var oldSchedule = preIndex === range.end ? [] : 
-              new Array(parseInt(data[preIndex][RAW_VALUES][RV_KEYS.NUM_PROFILES]));
+            var scheduleName = RV_KEYS.getKeyValue(data[i],RV_KEYS.PATTERN_NAME);
+            var newSchedule = new Array(parseInt(RV_KEYS.getKeyValue(data[i],RV_KEYS.NUM_PROFILES)));
+            var oldSchedule = preIndex === range.end ? [] :
+              new Array(parseInt(RV_KEYS.getKeyValue(data[preIndex],RV_KEYS.NUM_PROFILES)));
 
             var lookup = {};
             lookup[data[i][RAW_ID]] = newSchedule;
@@ -359,8 +370,8 @@ module.exports = function (opts) {
           (function(){
             var range = findTimestampGrouping(data, i);
 
-            var newConfig = buildWizardChange(data, range, datum[RAW_VALUES][RV_KEYS.NEW_CONFIG_DATUM]);
-            var oldConfig = buildWizardChange(data, range, datum[RAW_VALUES][RV_KEYS.OLD_CONFIG_DATUM]);
+            var newConfig = buildWizardChange(data, range, RV_KEYS.getKeyValue(datum,RV_KEYS.NEW_CONFIG_DATUM));
+            var oldConfig = buildWizardChange(data, range, RV_KEYS.getKeyValue(datum,RV_KEYS.OLD_CONFIG_DATUM));
 
             // We walk settings backwards, so all of these events indicate a change to
             // *become* our "current" settings, rather than a change *away from* our "current" settings.
@@ -407,32 +418,32 @@ module.exports = function (opts) {
             for (var j = range.start; j < range.end; ++j) {
               switch (data[j]['Raw-Type']) {
                 case 'CurrentActiveBasalProfilePattern':
-                  settings.activeSchedule = data[j][RAW_VALUES][RV_KEYS.PATTERN_NAME];
+                  settings.activeSchedule = RV_KEYS.getKeyValue(data[j],RV_KEYS.PATTERN_NAME);
                   break;
                 case 'CurrentBasalProfilePattern':
-                  var patternName = data[j][RAW_VALUES][RV_KEYS.PATTERN_NAME];
-                  var basalEntries = new Array(parseInt(data[j][RAW_VALUES][RV_KEYS.NUM_PROFILES], 10));
+                  var patternName = RV_KEYS.getKeyValue(data[j],RV_KEYS.PATTERN_NAME);
+                  var basalEntries = new Array(parseInt(RV_KEYS.getKeyValue(data[j],RV_KEYS.NUM_PROFILES), 10));
                   lookup[data[j][RAW_ID]]  = settings.basalSchedules[patternName] = basalEntries;
                   break;
                 case 'CurrentBGTargetRangePattern':
-                  var bgTargetEntries = new Array(parseInt(data[j][RAW_VALUES][RV_KEYS.SIZE], 10));
+                  var bgTargetEntries = new Array(parseInt(RV_KEYS.getKeyValue(data[j],RV_KEYS.SIZE), 10));
                   lookup[data[j][RAW_ID]] = settings.bgTarget = bgTargetEntries;
                   break;
                 case 'CurrentBolusWizardBGUnits':
-                  var normalized = common.normalizeBgUnits(data[j][RAW_VALUES][RV_KEYS.UNITS]);
+                  var normalized = common.normalizeBgUnits(RV_KEYS.getKeyValue(data[j],RV_KEYS.UNITS));
                   if (normalized != null) {
                     settings.units.bg = normalized;
                   }
                   break;
                 case 'CurrentBolusWizardCarbUnits':
-                  settings.units.carb = data[j][RAW_VALUES][RV_KEYS.UNITS];
+                  settings.units.carb = RV_KEYS.getKeyValue(data[j],RV_KEYS.UNITS);
                   break;
                 case 'CurrentCarbRatioPattern':
-                  var carbRatioEntries = new Array(parseInt(data[j][RAW_VALUES][RV_KEYS.SIZE], 10));
+                  var carbRatioEntries = new Array(parseInt(RV_KEYS.getKeyValue(data[j],RV_KEYS.SIZE), 10));
                   lookup[data[j][RAW_ID]] = settings.carbRatio = carbRatioEntries;
                   break;
                 case 'CurrentInsulinSensitivityPattern':
-                  var insulinSensitivityEntries = new Array(parseInt(data[j][RAW_VALUES][RV_KEYS.SIZE], 10));
+                  var insulinSensitivityEntries = new Array(parseInt(RV_KEYS.getKeyValue(data[j],RV_KEYS.SIZE), 10));
                   lookup[data[j][RAW_ID]] = settings.insulinSensitivity = insulinSensitivityEntries;
                   break;
               }

--- a/lib/drivers/carelinkDriver.js
+++ b/lib/drivers/carelinkDriver.js
@@ -21,6 +21,8 @@ var util = require('util');
 
 var csv = require('babyparse');
 var sundial = require('sundial');
+var moment = require('moment');
+var fs = require('fs');
 
 var TZOUtil = require('../TimezoneOffsetUtil');
 
@@ -30,7 +32,7 @@ var indexDevice = require('../carelink/indexDevice');
 var removeOverlaps = require('../carelink/removeOverlapping');
 var getDeviceInfo = require('../carelink/getDeviceInfo');
 var timeChangeProcessor = require('../carelink/timeChange')();
-var CARELINK_TS_FORMAT = 'MM/DD/YY HH:mm:ss';
+var getCareLinkFormatInfo = require('../carelink/getCareLinkFormatInfo');
 
 function convertRawValues(e) {
   var RAW_VALUES = e['Raw-Values'];
@@ -179,12 +181,25 @@ module.exports = function(simulatorMaker, api) {
 
         var endOfPreamble = cfg.fileData.indexOf('Index');
         // Setup the preamble to have everything up to the header line
-        payload.preamble = csv.parse(cfg.fileData.substr(0, endOfPreamble), {});
+        payload.preamble = csv.parse(cfg.fileData.substr(0, endOfPreamble), {
+            newline: '\n'
+        });
         cfg.deviceInfo = getDeviceInfo(payload.preamble.data, /Pump/);
+
+        // Find out what the date format in the CareLink CSV is.
+        var fileTime = Date.now();
+        if (cfg.filename !== undefined) {
+          var stats = fs.statSync(cfg.filename);
+          fileTime = new Date(stats.mtime);
+        }
+        cfg.careLinkFormatInfo = getCareLinkFormatInfo(payload.preamble.data, moment(fileTime));
+        debug('CareLink date format is', cfg.careLinkFormatInfo.getDataExportFormat());
+
         // Store the rest of the data
         var parsed = csv.parse(cfg.fileData.substr(endOfPreamble), {
           header: true,
-          dynamicTyping: true
+          dynamicTyping: true,
+          newline: '\n'
         });
         payload.colLabels = parsed.meta;
         var rows = [];
@@ -193,7 +208,7 @@ module.exports = function(simulatorMaker, api) {
         for (var i = parsed.data.length - 1; i >= 0; --i) {
           var datum = parsed.data[i];
           convertRawValues(datum);
-          datum.jsDate = sundial.parseFromFormat(datum['Timestamp'], CARELINK_TS_FORMAT);
+          datum.jsDate = sundial.parseFromFormat(datum['Timestamp'], cfg.careLinkFormatInfo.getDataExportFormat());
           datum.deviceTime = sundial.formatDeviceTime(datum.jsDate);
           datum.csvIndex = datum['Index'];
           if (!_.isEmpty(datum[RAW_VALUES])) {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "blueimp-md5": "1.1.0",
     "commander": "2.7.1",
     "lodash": "3.6.0",
+    "moment": "2.9.0",
     "node-uuid": "1.4.3",
     "react": "0.12.0",
     "react-select": "0.4.6",

--- a/test/carelink/testDriver.js
+++ b/test/carelink/testDriver.js
@@ -35,7 +35,7 @@ function spiderTests(baseDir) {
           var input = fs.readFileSync(path + '/input.csv', {encoding: 'utf8'});
           var output = JSON.parse(fs.readFileSync(path + '/output.json'));
 
-          var drvr = carelinkDriver({ filename: '/input.csv', fileData: input, timezone: 'Pacific/Honolulu' });
+          var drvr = carelinkDriver({ filename: path + '/input.csv', fileData: input, timezone: 'Pacific/Honolulu' });
 
           async.waterfall(
             [
@@ -71,7 +71,7 @@ function spiderTests(baseDir) {
           var input = fs.readFileSync(path + '/old.csv', {encoding: 'utf8'});
           var output = JSON.parse(fs.readFileSync(path + '/output.json'));
 
-          var drvr = carelinkDriver({ filename: '/old.csv', fileData: input, timezone: 'Pacific/Honolulu' });
+          var drvr = carelinkDriver({ filename: path + '/old.csv', fileData: input, timezone: 'Pacific/Honolulu' });
 
           async.waterfall(
             [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,7 +47,10 @@ var config = {
   ],
   // to fix the 'broken by design' issue with npm link-ing modules
   resolve: { fallback: path.join(__dirname, 'node_modules') },
-  resolveLoader: { fallback: path.join(__dirname, 'node_modules') }
+  resolveLoader: { fallback: path.join(__dirname, 'node_modules') },
+  node: {
+    fs: 'empty'
+  }
 };
 
 module.exports = config;


### PR DESCRIPTION
Explicitly set newline for Baby Parse - it didn't always get it right with big files.
Add support for non-US formatted files (date format and RAW_VALUE key names).

I realise I will have to add extra tests for this, just wanted to make sure you're happy with the way this change is implemented.
