### PR TITLE
Changing error message for no records available

### DIFF
--- a/lib/drivers/dexcomDriver.js
+++ b/lib/drivers/dexcomDriver.js
@@ -710,7 +710,7 @@ module.exports = function (config) {
       if((range.lo === 0xFFFFFFFF) && (range.hi === 0xFFFFFFFF)) {
         // in both G4 and G5 0xFFFFFFFF is returned for the first and last index
         // when there are no records in the partition
-        return callback(new Error('No records available'));
+        return callback(new Error('We found no data on this Dexcom receiver.'));
       }
       var pages = [];
       for (var pg = range.hi; pg >= range.lo; --pg) {


### PR DESCRIPTION
One-liner to update error message when there are no records on the Dexcom receiver. Pinging @jebeck for review and merge. As v0.242.0 is currently a RC, I'm ok with this going out in the next release.