### PR TITLE
Update message seen when usb cable bad

### DIFF
--- a/lib/state/appActions.js
+++ b/lib/state/appActions.js
@@ -65,7 +65,7 @@ appActions.errorStages = {
   STAGE_METADATA_UPLOAD : { code: 'E_METADATA_UPLOAD' , friendlyMessage: 'Error uploading upload metadata'},
   STAGE_DEVICE_UPLOAD : { code: 'E_DEVICE_UPLOAD' , friendlyMessage: 'Error uploading device data' },
   STAGE_DEVICE_DETECT : { code: 'E_DEVICE_DETECT' , friendlyMessage: 'Hmm, we couldn\'t detect your device' },
-  STAGE_DRIVER : { code: 'E_DRIVER' , friendlyMessage: 'You may need to install the ', driverName: 'device driver' },
+  STAGE_DRIVER : { code: 'E_DRIVER' , friendlyMessage: 'There might be a problem with your cable or you may need to install the ', driverName: 'device driver' },
   STAGE_CARELINK_UPLOAD : { code: 'E_CARELINK_UPLOAD' , friendlyMessage: 'Error uploading CareLink data' },
   STAGE_CARELINK_FETCH : { code: 'E_CARELINK_FETCH' , friendlyMessage: 'Error fetching CareLink data' }
 };


### PR DESCRIPTION
When I tried to upload my data, I had a cable that apparently only provides power and does not transfer signal.  After a bunch of troubles, I found the entry on http://support.tidepool.org/article/13-upload-your-dexcom-g4 about trying another USB cable and that fixed the problem.  Having that as an option in the error message would've likely been a nicer experience.

I would've preferred to add the comment at the end of the message, but it appears like the error handling is forcing the link to the device driver to be at the end of the message.  I'm not necessarily in love with the wording or anything here, if you think it's suitable great.  If not, feel free to do something else that is more meaningful and just close this PR.