### PR TITLE
unbork the node CLI tools for uploading

### DIFF
--- a/lib/carelink/cli/csv_loader.js
+++ b/lib/carelink/cli/csv_loader.js
@@ -49,10 +49,12 @@ function processCarelink(driverMgr){
  * login to the platform
  */
 function login(un, pw, config, cb){
-  api.init({
+  api.create({
     apiUrl: config.API_URL,
-    uploadUrl: config.UPLOAD_URL
-  }, function(){
+    uploadUrl: config.UPLOAD_URL,
+    version: 'uploader node CLI tool - CareLink'
+  });
+  api.init(function() {
     api.user.login({ username: un, password:pw}, cb);
   });
 }

--- a/lib/components/VersionCheckError.js
+++ b/lib/components/VersionCheckError.js
@@ -19,6 +19,7 @@ import cx from 'classnames';
 import React, { Component, PropTypes } from 'react';
 
 import * as errorUtils from '../redux/utils/errors';
+import errorText from '../redux/constants/errors';
 
 export default class VersionCheckError extends Component {
   static propTypes = {

--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -29,7 +29,7 @@ var uuid = require('node-uuid');
 
 var isChromeApp = (typeof chrome !== 'undefined');
 var bows = require('../bows');
-var errorText = require('../redux/utils/errors').errorText;
+var errorText = require('../redux/constants/errors');
 var log = isChromeApp ? bows('Api') : console.log;
 var builder = require('../objectBuilder')();
 var localStore = require('./localStore');

--- a/lib/insulet/cli/ibf_loader.js
+++ b/lib/insulet/cli/ibf_loader.js
@@ -70,7 +70,7 @@ function login(un, pw, config, cb){
   api.create({
     apiUrl: config.API_URL,
     uploadUrl: config.UPLOAD_URL,
-    version: 'uploader node CLI tool - CareLink'
+    version: 'uploader node CLI tool - Insulet'
   });
   api.init(function() {
     api.user.login({ username: un, password:pw}, cb);

--- a/lib/insulet/cli/ibf_loader.js
+++ b/lib/insulet/cli/ibf_loader.js
@@ -67,10 +67,12 @@ function processInsulet(driverMgr){
  * login to the platform
  */
 function login(un, pw, config, cb){
-  api.init({
+  api.create({
     apiUrl: config.API_URL,
-    uploadUrl: config.UPLOAD_URL
-  }, function(){
+    uploadUrl: config.UPLOAD_URL,
+    version: 'uploader node CLI tool - CareLink'
+  });
+  api.init(function() {
     api.user.login({ username: un, password:pw}, cb);
   });
 }

--- a/lib/redux/actions/async.js
+++ b/lib/redux/actions/async.js
@@ -26,7 +26,7 @@ import sundial from 'sundial';
 import * as actionTypes from '../constants/actionTypes';
 import * as actionSources from '../constants/actionSources';
 import { pages, paths, steps, urls } from '../constants/otherConstants';
-import { errorText } from '../utils/errors';
+import errorText from '../constants/errors';
 
 import * as syncActions from './sync';
 import * as actionUtils from './utils';

--- a/lib/redux/actions/sync.js
+++ b/lib/redux/actions/sync.js
@@ -24,7 +24,8 @@ import * as actionSources from '../constants/actionSources';
 import * as metrics from '../constants/metrics';
 import { pages, paths, steps } from '../constants/otherConstants';
 
-import { addInfoToError, errorText, getAppInitErrorMessage, getLoginErrorMessage, getLogoutErrorMessage, UnsupportedError } from '../utils/errors';
+import { addInfoToError, getAppInitErrorMessage, getLoginErrorMessage, getLogoutErrorMessage, UnsupportedError } from '../utils/errors';
+import errorText from '../constants/errors';
 
 import * as actionUtils from './utils';
 

--- a/lib/redux/actions/utils.js
+++ b/lib/redux/actions/utils.js
@@ -22,7 +22,7 @@ import stacktrace from 'stack-trace';
 
 import sundial from 'sundial';
 
-import { errorText } from '../utils/errors';
+import errorText from '../constants/errors';
 import * as syncActions from './sync';
 
 export function getDeviceTargetsByUser(targetsByUser) {

--- a/lib/redux/constants/errors.js
+++ b/lib/redux/constants/errors.js
@@ -1,0 +1,34 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2016, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+// NB: this module is ES5 because the CLI tools run in node
+// and these error constants are a dependency through lib/core/api.js
+
+module.exports = {
+  E_CARELINK_CREDS: 'Check your CareLink username and password',
+  E_CARELINK_UPLOAD: 'Error processing & uploading CareLink data',
+  E_DEVICE_UPLOAD: 'Something went wrong during device upload',
+  E_FETCH_CARELINK: 'Something went wrong trying to fetch CareLink data',
+  E_FILE_EXT: 'Please choose a file ending in ',
+  E_HID_CONNECTION: 'Hmm, your device doesn\'t appear to be connected',
+  E_INIT: 'Error during app initialization',
+  E_OFFLINE: 'Not connected to the Internet!',
+  E_READ_FILE: 'Error reading file ',
+  E_SERIAL_CONNECTION: 'Hmm, we couldn\'t detect your device',
+  E_SERVER_ERR: 'Sorry, the Tidepool servers appear to be down',
+  E_UPLOAD_IN_PROGRESS: 'Sorry, an upload is already in progress'
+};

--- a/lib/redux/utils/errors.js
+++ b/lib/redux/utils/errors.js
@@ -17,20 +17,7 @@
 
 import _ from 'lodash';
 
-export const errorText = {
-  E_CARELINK_CREDS: 'Check your CareLink username and password',
-  E_CARELINK_UPLOAD: 'Error processing & uploading CareLink data',
-  E_DEVICE_UPLOAD: 'Something went wrong during device upload',
-  E_FETCH_CARELINK: 'Something went wrong trying to fetch CareLink data',
-  E_FILE_EXT: 'Please choose a file ending in ',
-  E_HID_CONNECTION: 'Hmm, your device doesn\'t appear to be connected',
-  E_INIT: 'Error during app initialization',
-  E_OFFLINE: 'Not connected to the Internet!',
-  E_READ_FILE: 'Error reading file ',
-  E_SERIAL_CONNECTION: 'Hmm, we couldn\'t detect your device',
-  E_SERVER_ERR: 'Sorry, the Tidepool servers appear to be down',
-  E_UPLOAD_IN_PROGRESS: 'Sorry, an upload is already in progress'
-};
+import errorText from '../constants/errors';
 
 const errorProps = {
   code: 'Code',

--- a/test/browser/redux/actions/async.test.js
+++ b/test/browser/redux/actions/async.test.js
@@ -26,7 +26,8 @@ import * as actionSources from '../../../../lib/redux/constants/actionSources';
 import * as actionTypes from '../../../../lib/redux/constants/actionTypes';
 import * as metrics from '../../../../lib/redux/constants/metrics';
 import { pages, steps, urls } from '../../../../lib/redux/constants/otherConstants';
-import { errorText, UnsupportedError } from '../../../../lib/redux/utils/errors';
+import { UnsupportedError } from '../../../../lib/redux/utils/errors';
+import errorText from '../../../../lib/redux/constants/errors';
 
 import * as asyncActions from '../../../../lib/redux/actions/async';
 import { getLoginErrorMessage, getLogoutErrorMessage } from '../../../../lib/redux/utils/errors';

--- a/test/browser/redux/actions/sync.test.js
+++ b/test/browser/redux/actions/sync.test.js
@@ -26,7 +26,8 @@ import * as metrics from '../../../../lib/redux/constants/metrics';
 import { steps } from '../../../../lib/redux/constants/otherConstants';
 
 import * as syncActions from '../../../../lib/redux/actions/sync';
-import { errorText, UnsupportedError } from '../../../../lib/redux/utils/errors';
+import { UnsupportedError } from '../../../../lib/redux/utils/errors';
+import errorText from '../../../../lib/redux/constants/errors';
 
 describe('Synchronous Actions', () => {
   describe('addTargetDevice', () => {


### PR DESCRIPTION
I borked the CLI tools again due to ES6 deps on the CLIs' `require` path /o\

Probably no one should merge this until I figure out how to add a couple of tests to make sure I don't keep borking the tools. Should be pretty easy.