### PR TITLE
replace async.timesSeries with for loop + async.until

### DIFF
--- a/lib/drivers/bayerContourNext.js
+++ b/lib/drivers/bayerContourNext.js
@@ -478,18 +478,41 @@ module.exports = function (config) {
         }, 20);
       }
 
-      async.timesSeries(data.nrecs, getOneRecordWithProgress, function(err, result) {
+      var numRecs = parseInt(data.nrecs, 10);
+      var bgmReadings = [];
+
+      for (var i = 0; i < numRecs; ++i) {
+        getOneRecordWithProgress(i, function(err, rec) {
+          if (err) {
+            debug('fetchData failed on record', i);
+            debug(err);
+            return cb(err);
+          }
+          debug('fetchData', rec);
+          bgmReadings.push(rec);
+        });
+      }
+
+      function allRecordsGathered() {
+        return bgmReadings.length === numRecs;
+      }
+
+      function waiting(cb) {
+        // poll every 1/2 second to see if record-gathering is finished
+        setTimeout(cb, 500);
+      }
+
+      async.until(allRecordsGathered, waiting, function(err) {
         if (err) {
           debug('fetchData failed');
           debug(err);
-          debug(result);
-        } else {
-          debug('fetchData', result);
+          return cb(err);
         }
+        debug('fetchData', bgmReadings);
         data.fetchData = true;
-        data.bgmReadings = result;
+        data.bgmReadings = bgmReadings;
         progress(100);
-        cb(err, data);
+        cb(null, data);
       });
     },
 

--- a/lib/drivers/oneTouchMiniDriver.js
+++ b/lib/drivers/oneTouchMiniDriver.js
@@ -527,6 +527,10 @@ module.exports = function (config) {
         }, 20);
       }
 
+      // TODO: the implementation of async.timesSeries has changed!
+      // when we come back to this driver, it is likely this will need to change
+      // see Bayer driver's fetchData for an example of replacing async.timesSeries
+      // with a for loop + async.until
       async.timesSeries(data.nrecs, getOneRecordWithProgress, function(err, result) {
         if (err) {
           debug('fetchData failed');


### PR DESCRIPTION
The regression that caused only one data point to upload for Bayer meters was due to a change in the implementation of `async.timesSeries`, a dependency that was updated as part of the redux work.

This PR replaces the use of `async.timesSeries` with a for loop and `async.until`.