### PR TITLE
just parse the string into an integer and all is well

### DIFF
--- a/lib/drivers/bayerContourNext.js
+++ b/lib/drivers/bayerContourNext.js
@@ -478,7 +478,7 @@ module.exports = function (config) {
         }, 20);
       }
 
-      async.timesSeries(data.nrecs, getOneRecordWithProgress, function(err, result) {
+      async.timesSeries(parseInt(data.nrecs, 10), getOneRecordWithProgress, function(err, result) {
         if (err) {
           debug('fetchData failed');
           debug(err);


### PR DESCRIPTION
Necessary because `timesSeries` method in new version of `async` won't coerce a _string_ as a first arg to an int!