### PR TITLE
set uploadTargetUser properly 

### DIFF
--- a/lib/components/UserDropdown.js
+++ b/lib/components/UserDropdown.js
@@ -66,9 +66,9 @@ var UserDropdown = React.createClass({
   render: function() {
     // we're already doing a check to see if we want to render in App.js
     // but this is an extra measure of protection against trying to render
-    // when we don't have the groups to do so
+    // when we don't have the potential target users to do so
     if (_.isEmpty(this.props.targetUsersForUpload) ||
-        this.props.targetUsersForUpload.length <= 1) {
+        this.props.targetUsersForUpload.length < 1) {
       return null;
     }
 

--- a/lib/containers/App.js
+++ b/lib/containers/App.js
@@ -302,8 +302,17 @@ export default connect(
       );
     }
     function shouldShowUserSelectionDropdown(state) {
-      return !_.isEmpty(state.targetUsersForUpload) &&
-        state.targetUsersForUpload.length > 1;
+      if (!_.isEmpty(state.targetUsersForUpload)) {
+        // if there's only one potential target for upload but it's *not* the loggedInUser
+        if (state.targetUsersForUpload.length === 1 &&
+          !_.includes(state.targetUsersForUpload, state.loggedInUser)) {
+          return true;
+        }
+        if (state.targetUsersForUpload.length > 1) {
+          return true;
+        }
+      }
+      return false;
     }
     return {
       // plain state

--- a/lib/redux/reducers/users.js
+++ b/lib/redux/reducers/users.js
@@ -222,11 +222,14 @@ export function uploadTargetUser(state = null, action) {
     case actionTypes.LOGIN_SUCCESS:
     case actionTypes.SET_USER_INFO_FROM_TOKEN:
       const { user, profile, memberships } = action.payload;
+      const uploadMemberships = _.filter(memberships, (mship) => {
+        return !_.isEmpty(_.get(mship, ['profile', 'patient']));
+      });
       if (!_.isEmpty(profile.patient)) {
         return user.userid;
       }
-      else if (memberships.length === 1) {
-        return memberships[0].userid;
+      else if (uploadMemberships.length === 1) {
+        return uploadMemberships[0].userid;
       }
       else {
         return null;

--- a/test/browser/redux/reducers/users.test.js
+++ b/test/browser/redux/reducers/users.test.js
@@ -451,11 +451,14 @@ describe('users', () => {
 
     it('should handle LOGIN_SUCCESS [loggedInUser is not PWD, can upload to only one]', () => {
       const profile = {a: 1};
-      const memberships = [{userid: 'd4e5f6'}];
+      const memberships = [
+        {userid: 'a1b2c3'},
+        {userid: 'd4e5f6', profile: {patient: {diagnosisDate: '1999-01-01'}}}
+      ];
       expect(users.uploadTargetUser(undefined, {
         type: actionTypes.LOGIN_SUCCESS,
         payload: { user, profile, memberships }
-      })).to.equal(memberships[0].userid);
+      })).to.equal(memberships[1].userid);
     });
 
     it('should handle LOGIN_SUCCESS [loggedInUser is not PWD, can upload to > 1]', () => {
@@ -491,11 +494,14 @@ describe('users', () => {
 
     it('should handle SET_USER_INFO_FROM_TOKEN [loggedInUser is not PWD, can upload to only one]', () => {
       const profile = {a: 1};
-      const memberships = [{userid: 'd4e5f6'}];
+      const memberships = [
+        {userid: 'a1b2c3'},
+        {userid: 'd4e5f6', profile: {patient: {diagnosisDate: '1999-01-01'}}}
+      ];
       expect(users.uploadTargetUser(undefined, {
         type: actionTypes.SET_USER_INFO_FROM_TOKEN,
         payload: { user, profile, memberships }
-      })).to.equal(memberships[0].userid);
+      })).to.equal(memberships[1].userid);
     });
 
     it('should handle SET_USER_INFO_FROM_TOKEN [loggedInUser is not PWD, can upload to > 1]', () => {


### PR DESCRIPTION
There was a bug in the first production release (v0.251.0) of the redux migration. It involved not setting an `uploadTargetUser` in the case of non-PWD `loggedInUser` with upload access to exactly one other account.

This fixes the problem and updates the tests.

In the course of comparing against prod (i.e., v0.242.0) to understand the problem, I discovered another inconsistency (showing vs. not a user dropdown with only one user in the same case). That will be fixed here too.

Ping @GordyD @krystophv 