### PR TITLE
pass the correct built object to the annotation utility

### DIFF
--- a/lib/drivers/abbottPrecisionXtra.js
+++ b/lib/drivers/abbottPrecisionXtra.js
@@ -479,7 +479,7 @@ module.exports = function (config) {
           .done();
         if (datum.annotations) {
           _.each(datum.annotations, function(ann) {
-            annotate.annotateEvent(smbg, ann);
+            annotate.annotateEvent(bloodKetone, ann);
           });
         }
         dataToPost.push(bloodKetone);


### PR DESCRIPTION
This is in response to a bug reported by Jaeb. What's a bit odd about it is the fact that the reported error "Cannot read property `annotations` of undefined" and reported situation (meter only has one ketone reading stored) should only turn up when there's a _ketone_ reading with an annotation, and the only time that _ketone_ readings get annotated is when the value is `HI`, which I would have assumed is very very rare in the wild.

Also, since we don't have a way to produce a `HI` on a test device, we may not be able to confirm this fix directly.