### PR TITLE
hot reload doAppInit fix

### DIFF
--- a/lib/redux/actions/async.js
+++ b/lib/redux/actions/async.js
@@ -41,6 +41,12 @@ let daysForCareLink = null;
 
 export function doAppInit(opts, servicesToInit) {
   return (dispatch, getState) => {
+    // when we are developing with hot reload, we get into trouble if we try to initialize the app
+    // when it's already been initialized, so we check the working.initializingApp flag first
+    if (getState().working.initializingApp === false) {
+      console.log('App already initialized! Skipping initialization.');
+      return;
+    }
     services = servicesToInit;
     versionInfo.semver = opts.version;
     versionInfo.name = opts.namedVersion;

--- a/test/browser/redux/actions/async.test.js
+++ b/test/browser/redux/actions/async.test.js
@@ -55,6 +55,18 @@ describe('Asynchronous Actions', () => {
     asyncActions.__ResetDependency__('services');
   });
 
+  describe('doAppInit [hot reload, app already initialized]', () => {
+    it('should dispatch no actions!', (done) => {
+      const expectedActions = [];
+      const store = mockStore({working: {initializingApp: false}}, expectedActions, done.fail);
+      store.dispatch(asyncActions.doAppInit({}, {}));
+      // somewhat hacky solution to testing for no actions
+      // discussed here: https://github.com/arnaudbenard/redux-mock-store/issues/17
+      // happy to live with the hack since this is only for hot-reloading anyway
+      setTimeout(() => done(), 1000);
+    });
+  });
+
   describe('doAppInit [no session token in local storage]', () => {
     it('should dispatch SET_VERSION, INIT_APP_REQUEST, SET_OS, HIDE_UNAVAILABLE_DEVICES, SET_FORGOT_PASSWORD_URL, SET_SIGNUP_URL, SET_PAGE, INIT_APP_SUCCESS, VERSION_CHECK_REQUEST, VERSION_CHECK_SUCCESS actions', (done) => {
       const config = {
@@ -126,7 +138,7 @@ describe('Asynchronous Actions', () => {
       asyncActions.__Rewire__('versionInfo', {
         semver: config.version
       });
-      const store = mockStore({}, expectedActions, done);
+      const store = mockStore({working: {initializingApp: true}}, expectedActions, done);
       store.dispatch(asyncActions.doAppInit(config, servicesToInit));
     });
   });
@@ -223,7 +235,8 @@ describe('Asynchronous Actions', () => {
         semver: config.version
       });
       const state = {
-        uploadTargetUser: pwd.user.userid
+        uploadTargetUser: pwd.user.userid,
+        working: {initializingApp: true}
       };
       const store = mockStore(state, expectedActions, done);
       store.dispatch(asyncActions.doAppInit(config, servicesToInit));
@@ -277,7 +290,7 @@ describe('Asynchronous Actions', () => {
       asyncActions.__Rewire__('versionInfo', {
         semver: config.version
       });
-      const store = mockStore({}, expectedActions, done);
+      const store = mockStore({working: {initializingApp: true}}, expectedActions, done);
       store.dispatch(asyncActions.doAppInit(config, servicesToInit));
     });
   });


### PR DESCRIPTION
Take a look at this @krystophv and let me know if (a) it works for you locally and (b) it makes sense to you.

@GordyD and I considered two approaches, with the other possible approach being to look at the `working.initializingApp` flag in `App.js` itself and only call the `doAppInit` in the constructor if the flag is `true` but since we already have test instrumentation around the async actions (thunks), it seemed better to put the logic in the `doAppInit` thunk itself (although the test did turn out to be hacky 😕).