### PR TITLE
fix misleading 'Using the default environment' message

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ if (process.env.DEBUG_ERROR === 'true') {
   console.log();
 }
 
-if ((!process.env.API_URL || !process.env.UPLOAD_URL || !process.env.BLIP_URL)) {
+if ((!process.env.API_URL && !process.env.UPLOAD_URL && !process.env.BLIP_URL)) {
   console.log('Using the default environment, which is now production.');
 } else {
   console.log('***** NOT using the default environment *****');


### PR DESCRIPTION
The logic to determine whether to show you the "Using the default environment, which is now production" message would show you the message even if you had one or more - just not _all_ - variables set in your local environment. Now the message will only display if you have _none_ of the variables set, which is how it should be when building for production.

@gniezen please review and update your #251 accordingly.

CC @darinkrauss 