### PR TITLE
Animas zero-rate basal marked as suspended due to alarm

### DIFF
--- a/lib/animas/animasSimulator.js
+++ b/lib/animas/animasSimulator.js
@@ -196,6 +196,7 @@ exports.make = function(config){
     bolus: function(event) {
       delete event.syncCounter; //wizard events already synced up
       delete event.requiredAmount;
+      delete event.jsDate;
       simpleSimulate(event);
       setCurrBolus(event);
     },

--- a/lib/animas/animasSimulator.js
+++ b/lib/animas/animasSimulator.js
@@ -123,7 +123,6 @@ exports.make = function(config){
           };
 
           ensureTimestamp(status);
-          dataservicesEvents.push(status);
           setCurrStatus(status);
           setLastAlarm(null); //reset alarm as not to re-use for other zero-rate basals
           setCurrBasal(basal);
@@ -176,23 +175,14 @@ exports.make = function(config){
           else {
             // basal is non-zero, but status still suspended
             // is this a suspend event we created from an alarm?
-            // If so, we should create a corresponding resume event
+            // If so, we should submit a joined suspend/resume event
             if(currStatus.reason.suspended === 'automatic') {
-              var status = {
-                time: event.time,
-                deviceTime: event.deviceTime,
-                timezoneOffset: event.timezoneOffset,
-                conversionOffset: event.conversionOffset,
-                deviceId: event.deviceId,
-                type: 'deviceEvent',
-                subType: 'status',
-                status: 'resumed',
-                reason: {resumed: 'automatic'}
-              };
 
-              ensureTimestamp(status);
-              dataservicesEvents.push(status);
-              setCurrStatus(status);
+              currStatus.duration = currBasal.duration;
+              currStatus.reason.resumed = 'automatic';
+
+              dataservicesEvents.push(currStatus);
+              setCurrStatus(null);
             }
           }
         }

--- a/lib/animas/animasSimulator.js
+++ b/lib/animas/animasSimulator.js
@@ -91,7 +91,7 @@ exports.make = function(config){
   }
 
   function markIfBasalSuspendedByAlarm(alarm,basal) {
-    if ((basal !== null) && (alarm != null) &&
+    if ((basal != null) && (alarm != null) &&
         (basal.rate === 0) && (basal.deliveryType !== 'suspend')) {
 
       // Animas does not generate suspend/resume events for alarms,
@@ -99,7 +99,6 @@ exports.make = function(config){
       // If so, we mark the basal as suspended and generate a new suspend event.
 
       var duration = Date.parse(basal.time) - Date.parse(alarm.time);
-      console.log(alarm, basal);
       var twoHours = (120 * sundial.MIN_TO_MSEC);
       if(duration < twoHours) {
 

--- a/lib/animas/animasSimulator.js
+++ b/lib/animas/animasSimulator.js
@@ -181,6 +181,7 @@ exports.make = function(config){
 
               currStatus.duration = currBasal.duration;
               currStatus.reason.resumed = 'automatic';
+              annotate.annotateEvent(currStatus, 'animas/status/fabricated-from-alarm');
 
               dataservicesEvents.push(currStatus);
               setCurrStatus(null);

--- a/lib/animas/animasSimulator.js
+++ b/lib/animas/animasSimulator.js
@@ -108,6 +108,7 @@ exports.make = function(config){
 
           //this basal is suspended
           basal.deliveryType = 'suspend';
+          annotate.annotateEvent(basal, 'animas/basal/marked-suspended-from-alarm');
 
           var status = {
             time: basal.time,

--- a/lib/animas/animasSimulator.js
+++ b/lib/animas/animasSimulator.js
@@ -90,7 +90,7 @@ exports.make = function(config){
     events.push(e);
   }
 
-  function checkIfBasalSuspendedByAlarm(alarm,basal) {
+  function markIfBasalSuspendedByAlarm(alarm,basal) {
     if ((basal !== null) && (alarm != null) &&
         (basal.rate === 0) && (basal.deliveryType !== 'suspend')) {
 
@@ -136,7 +136,7 @@ exports.make = function(config){
   return {
     alarm: function(event) {
       setLastAlarm(event);
-      checkIfBasalSuspendedByAlarm(event,currBasal);
+      markIfBasalSuspendedByAlarm(event,currBasal);
       simpleSimulate(event);
     },
     basal: function(event){
@@ -191,7 +191,7 @@ exports.make = function(config){
       }
 
       setCurrBasal(event);
-      checkIfBasalSuspendedByAlarm(lastAlarm,event);
+      markIfBasalSuspendedByAlarm(lastAlarm,event);
 
     },
     bolus: function(event) {

--- a/lib/animas/animasSimulator.js
+++ b/lib/animas/animasSimulator.js
@@ -285,6 +285,7 @@ exports.make = function(config){
       return orderedEvents;
     },
     getDataServicesEvents: function() {
+      dataservicesEvents.forEach(function(e){ delete e.index; });
       return dataservicesEvents;
     }
   };

--- a/lib/animas/animasSimulator.js
+++ b/lib/animas/animasSimulator.js
@@ -187,7 +187,7 @@ exports.make = function(config){
                 type: 'deviceEvent',
                 subType: 'status',
                 status: 'resumed',
-                reason: {suspended: 'automatic'}
+                reason: {resumed: 'automatic'}
               };
 
               ensureTimestamp(status);

--- a/lib/animas/animasSimulator.js
+++ b/lib/animas/animasSimulator.js
@@ -41,6 +41,7 @@ exports.make = function(config){
   var currStatus = null;
   var currTimestamp = null;
   var currSMBG = null;
+  var lastAlarm = null;
 
   function setCurrBasal(basal) {
     currBasal = basal;
@@ -56,6 +57,10 @@ exports.make = function(config){
 
   function setCurrSMBG(smbg) {
     currSMBG = smbg;
+  }
+
+  function setLastAlarm(alarm) {
+    lastAlarm = alarm;
   }
 
   function ensureTimestamp(e){
@@ -85,9 +90,53 @@ exports.make = function(config){
     events.push(e);
   }
 
+  function checkIfBasalSuspendedByAlarm(alarm,basal) {
+    if ((basal !== null) && (alarm != null) &&
+        (basal.rate === 0) && (basal.deliveryType !== 'suspend')) {
+
+      // Animas does not generate suspend/resume events for alarms,
+      // so we check if an alarm occurred recently or at the same time.
+      // If so, we mark the basal as suspended and generate a new suspend event.
+
+      var duration = Date.parse(basal.time) - Date.parse(alarm.time);
+      console.log(alarm, basal);
+      var twoHours = (120 * sundial.MIN_TO_MSEC);
+      if(duration < twoHours) {
+
+        var type = alarm.alarmType;
+        if(type === 'occlusion' || type === 'auto_off' || type === 'no_insulin' || type === 'no_power') {
+
+          //this basal is suspended
+          basal.deliveryType = 'suspend';
+
+          var status = {
+            time: basal.time,
+            deviceTime: basal.deviceTime,
+            timezoneOffset: basal.timezoneOffset,
+            conversionOffset: basal.conversionOffset,
+            deviceId: basal.deviceId,
+            type: 'deviceEvent',
+            subType: 'status',
+            status: 'suspended',
+            reason: {suspended: 'automatic'},
+            payload: {cause: type}
+          };
+
+          ensureTimestamp(status);
+          dataservicesEvents.push(status);
+          setCurrStatus(status);
+          setLastAlarm(null); //reset alarm as not to re-use for other zero-rate basals
+          setCurrBasal(basal);
+        }
+      }
+    }
+  }
+
 
   return {
     alarm: function(event) {
+      setLastAlarm(event);
+      checkIfBasalSuspendedByAlarm(event,currBasal);
       simpleSimulate(event);
     },
     basal: function(event){
@@ -119,13 +168,38 @@ exports.make = function(config){
       }
 
       if(currStatus !== null) {
-        if(currStatus.status === 'suspended' && event.rate === 0) {
-          //this basal is suspended
-          event.deliveryType = 'suspend';
+        if(currStatus.status === 'suspended') {
+          if (event.rate === 0) {
+            //this basal is suspended
+            event.deliveryType = 'suspend';
+          }
+          else {
+            // basal is non-zero, but status still suspended
+            // is this a suspend event we created from an alarm?
+            // If so, we should create a corresponding resume event
+            if(currStatus.reason.suspended === 'automatic') {
+              var status = {
+                time: event.time,
+                deviceTime: event.deviceTime,
+                timezoneOffset: event.timezoneOffset,
+                conversionOffset: event.conversionOffset,
+                deviceId: event.deviceId,
+                type: 'deviceEvent',
+                subType: 'status',
+                status: 'resumed',
+                reason: {suspended: 'automatic'}
+              };
+
+              ensureTimestamp(status);
+              dataservicesEvents.push(status);
+              setCurrStatus(status);
+            }
+          }
         }
       }
 
       setCurrBasal(event);
+      checkIfBasalSuspendedByAlarm(lastAlarm,event);
 
     },
     bolus: function(event) {

--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -1592,10 +1592,10 @@ module.exports = function (config) {
 
       animasDeviceId = data.settings.modelNumber + '-' + data.settings.serialNumber;
       cfg.builder.setDefaults({ deviceId: animasDeviceId});
-      var settings = [];
-      settings.time = new Date().toISOString(); //TODO: UTC bootstrapping
+      // most recent record is the final suspend event before uploading
+      var mostRecent = sundial.applyTimezone(data.suspendResumeRecords[0].suspendJsDate, cfg.timezone).toISOString();
       var changes = [];
-      var tzoUtil = new TZOUtil(cfg.timezone, settings.time, changes);
+      var tzoUtil = new TZOUtil(cfg.timezone, mostRecent, changes);
       cfg.tzoUtil = tzoUtil;
 
       var postrecords = [];
@@ -1612,7 +1612,7 @@ module.exports = function (config) {
       if (!_.isEmpty(data.postrecords)) {
         settings = data.postrecords[0];
       }*/
-      simulator = animasSimulator.make({settings: settings});
+      simulator = animasSimulator.make({settings: data.settings});
 
       var deviceEvent = null;
       for(var d in data.primeRewindRecords) {

--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -1157,12 +1157,16 @@ module.exports = function (config) {
           t.setSeconds(t.getSeconds() + 30);
           t = t.toISOString();
 
+          var dt = new Date(bolusdatum.deviceTime);
+          dt.setSeconds(dt.getSeconds() + 30);
+          dt = dt.toISOString();
+
           var bgRecord = cfg.builder.makeSMBG()
             .with_subType('manual')
             .with_value(bg)
             .with_units(wizarddatum.configuration.units)
             .set('index',wizarddatum.index)
-            .with_deviceTime(sundial.formatDeviceTime(t))
+            .with_deviceTime(sundial.formatDeviceTime(dt))
             .with_time(t)
             .with_timezoneOffset(bolusdatum.timezoneOffset)
             .with_conversionOffset(bolusdatum.conversionOffset)

--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -1114,8 +1114,9 @@ module.exports = function (config) {
 
       bolus = bolus.with_deviceTime(bolusdatum.deviceTime)
           .set('index', bolusdatum.index)
-          .set('syncCounter', bolusdatum.sync_counter)
-          .set('requiredAmount', bolusdatum.requiredAmount);
+          .set('syncCounter', bolusdatum.sync_counter) // need these for wizard records
+          .set('requiredAmount', bolusdatum.requiredAmount)
+          .set('jsDate', bolusdatum.jsDate);
 
       cfg.tzoUtil.fillInUTCInfo(bolus, bolusdatum.jsDate);
       bolus = bolus.done();
@@ -1153,24 +1154,16 @@ module.exports = function (config) {
 
           // Animas uses 1-minute resolution, so we add 30 seconds to manual
           // value to ensure it's always after any potential duplicate linked values
-          var t = new Date(bolusdatum.time);
-          t.setSeconds(t.getSeconds() + 30);
-          t = t.toISOString();
-
-          var dt = new Date(bolusdatum.deviceTime);
-          dt.setSeconds(dt.getSeconds() + 30);
-          dt = dt.toISOString();
+          var jsDate = bolusdatum.jsDate;
+          jsDate.setSeconds(jsDate.getSeconds() + 30);
 
           var bgRecord = cfg.builder.makeSMBG()
             .with_subType('manual')
             .with_value(bg)
             .with_units(wizarddatum.configuration.units)
             .set('index',wizarddatum.index)
-            .with_deviceTime(sundial.formatDeviceTime(dt))
-            .with_time(t)
-            .with_timezoneOffset(bolusdatum.timezoneOffset)
-            .with_conversionOffset(bolusdatum.conversionOffset)
-            .with_clockDriftOffset(bolusdatum.clockDriftOffset);
+            .with_deviceTime(bolusdatum.deviceTime);
+          cfg.tzoUtil.fillInUTCInfo(bgRecord, jsDate);
           bgRecord.done();
           postrecords.push(bgRecord);
         }

--- a/test/node/animas/testAnimasSimulator.js
+++ b/test/node/animas/testAnimasSimulator.js
@@ -576,6 +576,7 @@ describe('animasSimulator.js', function() {
         payload: {cause: 'auto_off'},
         duration: 3600000
       };
+      expectedSuspendResume.annotations = [{code: 'animas/status/fabricated-from-alarm'}];
 
       simulator.alarm(alarm);
       simulator.basal(basal1);

--- a/test/node/animas/testAnimasSimulator.js
+++ b/test/node/animas/testAnimasSimulator.js
@@ -532,4 +532,72 @@ describe('animasSimulator.js', function() {
       ]);
     });
   });
+
+  describe('event interplay', function() {
+    it('basal is suspended by alarm', function() {
+
+      var alarm = {
+        time: '2014-09-25T01:00:00.000Z',
+        deviceTime: '2014-09-25T01:00:00',
+        timezoneOffset: 0,
+        conversionOffset: 0,
+        deviceId: 'animas12345',
+        type: 'deviceEvent',
+        subType: 'alarm',
+        alarmType: 'auto_off'
+      };
+
+      var basal1 = builder.makeScheduledBasal()
+        .with_time('2014-09-25T02:00:00.000Z')
+        .with_deviceTime('2014-09-25T02:00:00')
+        .with_timezoneOffset(0)
+        .with_conversionOffset(0)
+        .with_rate(0);
+      basal1.deviceId = 'animas12345';
+
+      var basal2 = builder.makeScheduledBasal()
+        .with_time('2014-09-25T03:00:00.000Z')
+        .with_deviceTime('2014-09-25T03:00:00')
+        .with_timezoneOffset(0)
+        .with_conversionOffset(0)
+        .with_rate(1.2);
+      basal2.deviceId = 'animas12345';
+
+      var expectedSuspend = {
+        time: '2014-09-25T02:00:01.000Z',
+        deviceTime: '2014-09-25T02:00:01',
+        timezoneOffset: 0,
+        conversionOffset: 0,
+        deviceId: 'animas12345',
+        type: 'deviceEvent',
+        subType: 'status',
+        status: 'suspended',
+        reason: {suspended: 'automatic'},
+        payload: {cause: 'auto_off'}
+      };
+      var expectedResume = builder.makeDeviceEventResume()
+        .with_time('2014-09-25T03:00:01.000Z')
+        .with_deviceTime('2014-09-25T03:00:01')
+        .with_timezoneOffset(0)
+        .with_conversionOffset(0)
+        .with_status('resumed')
+        .with_reason({resumed: 'automatic'})
+        .done();
+      expectedResume.deviceId = 'animas12345';
+
+      simulator.alarm(alarm);
+      simulator.basal(basal1);
+      simulator.basal(basal2);
+
+      var expectedBasal = _.cloneDeep(basal1);
+      expectedBasal = expectedBasal.done();
+      expectedBasal.deliveryType ='suspend';
+
+      expect(simulator.getDataServicesEvents()).deep.equals([
+        expectedSuspend,
+        expectedBasal,
+        expectedResume
+      ]);
+    });
+  });
 });

--- a/test/node/animas/testAnimasSimulator.js
+++ b/test/node/animas/testAnimasSimulator.js
@@ -563,7 +563,7 @@ describe('animasSimulator.js', function() {
         .with_rate(1.2);
       basal2.deviceId = 'animas12345';
 
-      var expectedSuspend = {
+      var expectedSuspendResume = {
         time: '2014-09-25T02:00:01.000Z',
         deviceTime: '2014-09-25T02:00:01',
         timezoneOffset: 0,
@@ -572,18 +572,10 @@ describe('animasSimulator.js', function() {
         type: 'deviceEvent',
         subType: 'status',
         status: 'suspended',
-        reason: {suspended: 'automatic'},
-        payload: {cause: 'auto_off'}
+        reason: {suspended: 'automatic', resumed: 'automatic'},
+        payload: {cause: 'auto_off'},
+        duration: 3600000
       };
-      var expectedResume = builder.makeDeviceEventResume()
-        .with_time('2014-09-25T03:00:01.000Z')
-        .with_deviceTime('2014-09-25T03:00:01')
-        .with_timezoneOffset(0)
-        .with_conversionOffset(0)
-        .with_status('resumed')
-        .with_reason({resumed: 'automatic'})
-        .done();
-      expectedResume.deviceId = 'animas12345';
 
       simulator.alarm(alarm);
       simulator.basal(basal1);
@@ -594,9 +586,8 @@ describe('animasSimulator.js', function() {
       expectedBasal.deliveryType ='suspend';
 
       expect(simulator.getDataServicesEvents()).deep.equals([
-        expectedSuspend,
         expectedBasal,
-        expectedResume
+        expectedSuspendResume,
       ]);
     });
   });

--- a/test/node/animas/testAnimasSimulator.js
+++ b/test/node/animas/testAnimasSimulator.js
@@ -295,6 +295,9 @@ describe('animasSimulator.js', function() {
 
         var expectedResume = _.cloneDeep(resume);
         expectedResume.annotations = [{code: 'animas/out-of-sequence'}];
+        delete expectedResume.index;
+        delete suspend.index;
+        delete resume.index;
 
         expect(simulator.getDataServicesEvents()).deep.equals([suspend, expectedResume.done(), suspend2]);
       });
@@ -436,6 +439,8 @@ describe('animasSimulator.js', function() {
       simulator.basal(basal1);
       simulator.basal(basal2);
       simulator.basal(basal3);
+      delete expectedFirstBasal.index;
+      delete expectedSecondBasal.index;
       expect(simulator.getDataServicesEvents()).deep.equals([expectedFirstBasal, expectedSecondBasal]);
     });
 


### PR DESCRIPTION
If we have a zero-rate basal that is not already marked as suspended, we look back two hours to see if we have any recent alarms that could have caused the zero-rate basal. If so, we mark it as suspended and remove the alarm (so that we don't mark any other zero-rate basals with the same alarm).

We then also generate a suspend event (at the time the basal rate changed to zero) and a resume event (when the basal rate changes again).

@jebeck please review when you get a chance and test with your data to see if it works as expected. 