### PR TITLE
Adding support for Animas Vibe

### DIFF
--- a/lib/core/device.js
+++ b/lib/core/device.js
@@ -34,7 +34,7 @@ var insuletOmniPod = require('../drivers/insuletDriver');
 var oneTouchUltra2 = require('../drivers/oneTouchUltra2');
 var abbottFreeStyleLite = require('../drivers/abbottFreeStyleLite');
 var bayerContourNext = require('../drivers/bayerContourNext');
-var animasPing = require('../drivers/animasDriver');
+var animasDriver = require('../drivers/animasDriver');
 
 var device = {
   log: require('../bows')('Device')
@@ -53,7 +53,7 @@ device._deviceDrivers = {
   'BayerContourNextUsb': bayerContourNext,
   'BayerContourUsb': bayerContourNext,
   'BayerContourNextLink': bayerContourNext,
-  'AnimasPing': animasPing
+  'Animas': animasDriver
 };
 
 device._deviceComms = {
@@ -68,7 +68,7 @@ device._deviceComms = {
   'BayerContourNextUsb': hidDevice,
   'BayerContourUsb': hidDevice,
   'BayerContourNextLink': hidDevice,
-  'AnimasPing': serialDevice
+  'Animas': serialDevice
 };
 
 device._silentComms = {};

--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -958,9 +958,13 @@ module.exports = function (config) {
   };
 
   var decodeDate = function(encoded) {
-    var startYear = 2007; // OneTouch Ping starts in year 2007 as 0
-    if(modelNumber === 'IR1295') {
-      startYear = 2008;   // Animas Vibe starts in 2008
+    var startYear = null;
+    if (modelNumber === 'IR1285') {   // OneTouch Ping starts in year 2007 as 0
+      startYear = 2007;
+    } else if (modelNumber === 'IR1295') {
+      startYear = 2008; // Animas Vibe starts in 2008
+    } else {
+      throw new Error('Unknown device model number');
     }
     var year = (encoded.monthYear & 0x0f) + startYear;
     var month = (encoded.monthYear >> 4); // January = 0

--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -142,6 +142,8 @@ module.exports = function (config) {
   var primaryAddress = null;
   var connectionAddress = null; // 11000000b primary devices sets bit 0 (LSB), bit 1-7 is connection address
 
+  var modelNumber = null;
+
   var bytes2hex = function(bytes) {
     var message = '';
     for(var i in bytes) {
@@ -841,6 +843,7 @@ module.exports = function (config) {
           month: String.fromCharCode(struct.extractByte(result,14)), // hex month: 1=January .. C=December
           year: String.fromCharCode(struct.extractByte(result,15)) //hex year
         };
+        modelNumber = data.modelNumber;
         cb(null, data);
       }
     });
@@ -955,8 +958,11 @@ module.exports = function (config) {
   };
 
   var decodeDate = function(encoded) {
-    var year = (encoded.monthYear & 0x0f) + 2007; // OneTouch Ping starts in year 2007 as 0
-    // TODO: Animas Vibe starts in 2008
+    var startYear = 2007; // OneTouch Ping starts in year 2007 as 0
+    if(modelNumber === 'IR1295') {
+      startYear = 2008;   // Animas Vibe starts in 2008
+    }
+    var year = (encoded.monthYear & 0x0f) + startYear;
     var month = (encoded.monthYear >> 4); // January = 0
     var date = sundial.buildTimestamp({year:year,month:month+1,day:encoded.day,hours:encoded.hour,minutes:encoded.minute,seconds:0});
     return date;

--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -1570,14 +1570,20 @@ module.exports = function (config) {
         },
         */
         bgRecords: function(callback){
-          readAllRecords(RECORD_TYPES.BLOOD_GLUCOSE.value, requestBG(), 80, function(err, data) {
-            if(err) {
-              return callback(err,null);
-            }
-            else{
-              return callback(null,data);
-            }
-          });
+          if(modelNumber === 'IR1285') {
+            readAllRecords(RECORD_TYPES.BLOOD_GLUCOSE.value, requestBG(), 80, function(err, data) {
+              if(err) {
+                return callback(err,null);
+              }
+              else{
+                return callback(null,data);
+              }
+            });
+          }
+          else {
+            // TODO: handle CGM calibration records
+            return callback(null,[]);
+          }
         }
       },
       function(err, results){

--- a/lib/redux/reducers/devices.js
+++ b/lib/redux/reducers/devices.js
@@ -90,12 +90,12 @@ const devices = {
     source: {type: 'device', driverId: 'BayerContourNextLink'},
     enabled: {mac: true, win: true}
   },
-  animasping: {
+  animas: {
     instructions: 'Suspend pump; align with IR port',
-    key: 'animasping',
-    name: 'Animas OneTouch Ping',
+    key: 'animas',
+    name: 'Animas',
     showDriverLink: {mac: true, win: true},
-    source: {type: 'device', driverId: 'AnimasPing'},
+    source: {type: 'device', driverId: 'Animas'},
     enabled: {mac: true, win: true}
   }
 };

--- a/lib/redux/reducers/devices.js
+++ b/lib/redux/reducers/devices.js
@@ -91,7 +91,7 @@ const devices = {
     enabled: {mac: true, win: true}
   },
   animas: {
-    instructions: 'Suspend pump; align with IR port',
+    instructions: 'Suspend and align back of pump with IR dongle front',
     key: 'animas',
     name: 'Animas',
     showDriverLink: {mac: true, win: true},

--- a/manifest.json
+++ b/manifest.json
@@ -134,8 +134,8 @@
           "productId": 24578
         },
         {
-          "deviceName": "Animas OneTouch Ping",
-          "driverId": "AnimasPing",
+          "deviceName": "Animas",
+          "driverId": "Animas",
           "mode": "serial",
           "bitrate": 9600,
           "ctsFlowControl": true,


### PR DESCRIPTION
- Checks pump model number to determine start year (2007 vs 2008)
- ignores CGM calibration records on Vibe (for now)

Known issue: Vibe screen timeout must be set to 60 seconds. Will be address by another PR.