### PR TITLE
Non IBF file upload state fix

### DIFF
--- a/lib/components/Upload.js
+++ b/lib/components/Upload.js
@@ -181,7 +181,7 @@ export default class Upload extends Component {
           disabled={disabled}
           ref="file"
           type="file"
-          accept={upload.source.extension}
+          accept={_.get(upload, 'source.extension')}
           onChange={this.onBlockModeInputChange}/>
       </div>
     );

--- a/lib/components/Upload.js
+++ b/lib/components/Upload.js
@@ -181,6 +181,7 @@ export default class Upload extends Component {
           disabled={disabled}
           ref="file"
           type="file"
+          accept={upload.source.extension}
           onChange={this.onBlockModeInputChange}/>
       </div>
     );

--- a/lib/redux/reducers/uploads.js
+++ b/lib/redux/reducers/uploads.js
@@ -122,7 +122,7 @@ export function uploadsByUser(state = {}, action) {
         });
       });
       if (uploadTargetUser && uploadTargetDevice) {
-        let devicesForCurrentUser = _.get(state, [uploadTargetUser], {});
+        let devicesForCurrentUser = _.get(state, uploadTargetUser, {});
         _.forOwn(devicesForCurrentUser, (upload, key) => {
           newState = update(
             newState,

--- a/lib/redux/reducers/uploads.js
+++ b/lib/redux/reducers/uploads.js
@@ -112,6 +112,7 @@ export function uploadsByUser(state = {}, action) {
     case actionTypes.READ_FILE_ABORTED: {
       const err = action.payload;
       let uploadTargetUser, uploadTargetDevice;
+      let newState = state;
       _.forOwn(state, (uploads, userId) => {
         _.forOwn(uploads, (upload, deviceKey) => {
           if (upload.choosingFile === true) {
@@ -121,16 +122,33 @@ export function uploadsByUser(state = {}, action) {
         });
       });
       if (uploadTargetUser && uploadTargetDevice) {
-        return update(
-          state,
-          {[uploadTargetUser]: {[uploadTargetDevice]: {
-            choosingFile: {$set: false},
-            completed: {$set: true},
-            error: {$set: err},
-            failed: {$set: true}
-          }}}
-        );
+        let devicesForCurrentUser = _.get(state, [uploadTargetUser], {});
+        _.forOwn(devicesForCurrentUser, (upload, key) => {
+          newState = update(
+            newState,
+            {[uploadTargetUser]: {[key]: {$apply: (upload) => {
+              if (key === uploadTargetDevice) {
+                return update(
+                  upload,
+                  {
+                    choosingFile: {$set: false},
+                    completed: {$set: true},
+                    error: {$set: err},
+                    failed: {$set: true}
+                  }
+                );
+              }
+              else {
+                return update(
+                  upload,
+                  {disabled: {$set: false}}
+                );
+              }
+            }}}}
+          );
+        });
       }
+      return newState;
     }
     case actionTypes.READ_FILE_FAILURE: {
       const err = action.payload;

--- a/test/browser/redux/reducers/uploads.test.js
+++ b/test/browser/redux/reducers/uploads.test.js
@@ -204,7 +204,10 @@ describe('uploads', () => {
     it('should handle READ_FILE_ABORTED', () => {
       const err = new Error('Wrong file ext!');
       let initialState = {
-        [userId]: {[deviceKey]: {choosingFile: true, history: []}}
+        [userId]: {
+          a_pump: {disabled: true, history: [1,2]},
+          [deviceKey]: {choosingFile: true, history: []}
+        }
       };
       let result = uploads.uploadsByUser(initialState, {
         type: actionTypes.READ_FILE_ABORTED,
@@ -212,13 +215,19 @@ describe('uploads', () => {
         payload: err
       });
       expect(result).to.deep.equal({
-        [userId]: {[deviceKey]: {
-          choosingFile: false,
-          completed: true,
-          error: err,
-          failed: true,
-          history: []
-        }}
+        [userId]: {
+          a_pump: {
+            disabled: false,
+            history: [1,2]
+          },
+          [deviceKey]: {
+            choosingFile: false,
+            completed: true,
+            error: err,
+            failed: true,
+            history: []
+          }
+        }
       });
       // tests to be sure not *mutating* state object but rather returning new!
       expect(initialState === result).to.be.false;


### PR DESCRIPTION
In handling the `READ_FILE_ABORTED` action, the uploads reducer fails to reset the rest of the download states' `disabled` property that gets set in the `CHOOSING_FILE` handler. This uses the same sort of logic from the `CHOOSING_FILE` handler to undo what it does in order to restore upload functionality for the rest of the download options. 

I also added the accept property to the file upload element in order to encourage (though it's not a failsafe sort of thing) users to select an actual `.ibf` file by having other files either not displayed or disabled in the file selector.