### PR TITLE
Parsing timestamp correctly in Bayer driver

### DIFF
--- a/lib/drivers/bayerContourNext.js
+++ b/lib/drivers/bayerContourNext.js
@@ -438,7 +438,7 @@ module.exports = function (config) {
 
   var processReadings = function(readings) {
     _.each(readings, function(reading, index) {
-      var dateTime = sundial.parseFromFormat(reading.timestamp, 'YYYYMMDD HHmm');
+      var dateTime = sundial.parseFromFormat(reading.timestamp, 'YYYYMMDDHHmm');
       readings[index].displayTime = sundial.formatDeviceTime(new Date(dateTime).toISOString());
       var utcInfo = cfg.tzoUtil.lookup(dateTime);
       readings[index].displayUtc = utcInfo.time;


### PR DESCRIPTION
We've had two reports of an `invalid time value` error when trying to upload Bayer devices.

Only thing that I can notice so far is that while the timestamp looks like `timestamp : 201508271729` we’re parsing it as `'YYYYMMDD HHmm'` (with a space). Not sure if this may be the cause of the problem, so I've updated the parse string.

@jh-bate / @darinkrauss, can one of you review this one-liner?