### PR TITLE
Reworking Animas device comms to prevent screen timeouts

### DIFF
--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -46,6 +46,8 @@ module.exports = function (config) {
   var EOM_BYTE = 0xC1;
   var ADDRESS_CONNECT = 0xFF; //used to establish connection
 
+  var RETRIES = 10;
+
   var CMDS = {
     CONNECT: { value: 0x93, name: 'CONNECT'},
     DISCONNECT: { value: 0x53, name: 'DISCONNECT'},
@@ -577,7 +579,7 @@ module.exports = function (config) {
   var listenForPacket = function (timeout, commandpacket, callback) {
     var abortTimer = setTimeout(function () {
       clearInterval(listenTimer);
-      debug('TIMEOUT:', commandpacket);
+      debug('TIMEOUT:', commandpacket.packet);
       callback(new Error('Timeout error'), null);
     }, timeout);
 
@@ -674,13 +676,12 @@ module.exports = function (config) {
               cb(err, null);
             } else {
               if(result.payload && result.payload[0] === 0x44 && result.payload[1] === 0x49) {
-                var payload = result.payload;
                 //TODO: double-check extra checksum
-                sendAck(true, function (err, result){
+                sendAck(true, function (err, ackResult){
                   if(err) {
                     return cb(err, null);
                   }
-                  return cb(null,payload);
+                  return cb(null,result);
                 });
               }else{
                 cb(new Error('Pump not sending data. Please retry.'), null);
@@ -689,13 +690,12 @@ module.exports = function (config) {
           });
         } else {
           if(result.payload && result.payload[0] === 0x44 && result.payload[1] === 0x49) {
-            var payload = result.payload;
             //TODO: double-check extra checksum
-            sendAck(true, function (err, result){
+            sendAck(true, function (err, ackResult){
               if(err) {
                 return cb(err, null);
               }
-              return cb(null,payload);
+              return cb(null,result);
             });
           } else {
             return cb(new Error('Unknown packet'), null);
@@ -716,17 +716,15 @@ module.exports = function (config) {
             }
             incrementReceivedCounter();
             if(result.payload && result.payload[0] === 0x44 && result.payload[1] === 0x49) {
-              var payload = result.payload;
               //TODO: double-check extra checksum
-              sendAck(true, function (err, result){
+              sendAck(true, function (err, ackResult){
                 if(err) {
                   return cb(err, null);
                 }
-                return cb(null,payload);
+                return cb(null,result);
               });
             }else {
-              async.retry(5, retry, function(err, result) {
-                console.log("RESULT1:", result);
+              async.retry(RETRIES, retry, function(err, result) {
                 if (err) {
                   cb(err, null);
                 } else {
@@ -739,8 +737,7 @@ module.exports = function (config) {
         else {
           //it's possible that we're receiving diagnostic echo messages,
           //so retry command
-          async.retry(5, retry, function(err, result) {
-            console.log("RESULT2:", result);
+          async.retry(RETRIES, retry, function(err, result) {
             if (err) {
               cb(err, null);
             } else {
@@ -833,12 +830,12 @@ module.exports = function (config) {
       if (err) {
         cb(err, null);
       } else {
-        var model = struct.extractString(result,10,2);
+        var model = struct.extractString(result.payload,10,2);
         var data = {
           modelNumber : MODELS[parseInt(model,10)],
-          serialNumber: struct.extractString(result,12,2).concat('-',struct.extractString(result,4,6),model),
-          month: String.fromCharCode(struct.extractByte(result,14)), // hex month: 1=January .. C=December
-          year: String.fromCharCode(struct.extractByte(result,15)) //hex year
+          serialNumber: struct.extractString(result.payload,12,2).concat('-',struct.extractString(result.payload,4,6),model),
+          month: String.fromCharCode(struct.extractByte(result.payload,14)), // hex month: 1=January .. C=December
+          year: String.fromCharCode(struct.extractByte(result.payload,15)) //hex year
         };
         modelNumber = data.modelNumber;
         cb(null, data);
@@ -854,8 +851,8 @@ module.exports = function (config) {
           cb(err, null);
         } else {
           var data = {
-            insulinSensitivity : struct.extractShort(result,10),
-            bgTarget: struct.extractShort(result,8)
+            insulinSensitivity : struct.extractShort(result.payload,10),
+            bgTarget: struct.extractShort(result.payload,8)
           };
           cb(null, data);
         }
@@ -869,8 +866,8 @@ module.exports = function (config) {
         cb(err, null);
       } else {
         var data = {
-          numRecords : struct.extractShort(result,2),
-          recordSize: struct.extractShort(result,4)
+          numRecords : struct.extractShort(result.payload,2),
+          recordSize: struct.extractShort(result.payload,4)
         };
         cb(null,data);
       }
@@ -972,17 +969,23 @@ module.exports = function (config) {
   var getRecords = function(request,numRecords,cb) {
 
     var cmd = readDataPages(request.recordType,0,numRecords);
+    var firstPass = true;
+    var records = [];
 
-    animasCommandResponse(cmd, true, function (err, result) {
+    animasCommandResponseAck(cmd, function (err, result) {
       if (err) {
         cb(err, null);
       } else {
 
-        async.timesSeries(numRecords+1, function(n, next){
+        // sometimes, the same record is retruned twice, so we have to continue
+        // reading records until we know we're at the last one
+        var datum = {index:-1};
+        async.whilst(function () { return datum.index+1 < numRecords; }, function(next){
+          console.log('Retrieving', datum.index+1,'of',numRecords);
 
           var parsePayload = function(result) {
             var payload = result.payload;
-            var datum = request.parser(payload);
+            datum = request.parser(payload);
             console.log('Datum:', datum);
 
             if(struct.extractInt(payload,4) === 0) {// empty date
@@ -997,57 +1000,63 @@ module.exports = function (config) {
               if(err) {
                 return cb(err, null);
               }
-              return next(err,datum);
+              records.push(datum);
+              return next(err,records);
             });
           };
 
-          sendAck(true, function (err, result){
-            if(err) {
-              return cb(err, null);
-            } else {
-              incrementReceivedCounter();
-              if(result.payload) {
-                parsePayload(result);
-              }
-              else if(result.ack) {
-
-                console.log('Waiting..');
-                var waitTimer = setTimeout(function () {
-                  console.log('and retrying..', result);
-                  animasCommandResponse(cmd, true, function (err, result) {
-                    if(err) {
-                      return cb(err, null);
-                    }
-                    if(result.payload) {
-                      parsePayload(result);
-                    }
-                    else {
-                      incrementSentCounter();
-                      sendAck(true, function (err, result){
-                        if(err) {
-                          return cb(err, null);
-                        }
-                        incrementReceivedCounter();
-                        if(result.payload) {
-                          parsePayload(result);
-                        }else if(result.ack){
-                          return cb(new Error('Pump not responding as expected. Please retry.'), null);
-                        }else{
-                          cb(new Error('Unknown packet received'), null);
-                        }
-                      });
-                    }
-                  });
-                }, 1000);
-              }
-            }
-          });
-
-        }, function(obj, result) {
-          _.remove(result, function (item) { return item.empty;});
-          if (result[result.length-1].jsDate === null) {
-            result.pop(); //remove null element
+          // on the first pass, we may already have a payload
+          if(firstPass && result) {
+            parsePayload(result);
           }
+          else {
+            sendAck(true, function (err, result){
+              if(err) {
+                return cb(err, null);
+              } else {
+                incrementReceivedCounter();
+                if(result.payload) {
+                  parsePayload(result);
+                }
+                else if(result.ack) {
+
+                  console.log('Waiting..');
+                  var waitTimer = setTimeout(function () {
+                    console.log('and retrying..', result);
+                    animasCommandResponse(cmd, true, function (err, result) {
+                      if(err) {
+                        return cb(err, null);
+                      }
+                      if(result.payload) {
+                        parsePayload(result);
+                      }
+                      else {
+                        incrementSentCounter();
+                        sendAck(true, function (err, result){
+                          if(err) {
+                            return cb(err, null);
+                          }
+                          incrementReceivedCounter();
+                          if(result.payload) {
+                            parsePayload(result);
+                          }else if(result.ack){
+                            return cb(new Error('Pump not responding as expected. Please retry.'), null);
+                          }else{
+                            cb(new Error('Unknown packet received'), null);
+                          }
+                        });
+                      }
+                    });
+                  }, 1000);
+                }
+              }
+            });
+          }
+          firstPass = false;
+
+        }, function(err, result) {
+          // remove empty and invalid records
+          _.remove(result, function (item) { return item.empty || item.jsDate === null;});
           cb(null,result);
         });
       }
@@ -1491,6 +1500,7 @@ module.exports = function (config) {
                       callback(null,ordered);
                     }
                     else{
+                      debug('Result:', result);
                       callback(new Error('Some data went missing. Please retry.'),null);
                     }
                   }

--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -54,6 +54,7 @@ module.exports = function (config) {
     HANDSHAKE: {value: 0xBF, name: 'HANDSHAKE'},
     UA: {value: 0x73, name: 'Unnumbered Acknowledge'},
     RI: {value: 0x5249, name: 'RI message (Read)'},
+    DI: {value: 0x4449, name: 'DI message (RI response)'},
     ACK: {value: 0x11, name: 'Acknowledge'}
   };
 
@@ -675,7 +676,7 @@ module.exports = function (config) {
             if (err) {
               cb(err, null);
             } else {
-              if(result.payload && result.payload[0] === 0x44 && result.payload[1] === 0x49) {
+              if(result.payload && result.payload.slice(0,2) === CMDS.DI.value) {
                 //TODO: double-check extra checksum
                 sendAck(true, function (err, ackResult){
                   if(err) {
@@ -689,7 +690,7 @@ module.exports = function (config) {
             }
           });
         } else {
-          if(result.payload && result.payload[0] === 0x44 && result.payload[1] === 0x49) {
+          if(result.payload && result.payload.slice(0,2) === CMDS.DI.value) {
             //TODO: double-check extra checksum
             sendAck(true, function (err, ackResult){
               if(err) {
@@ -715,7 +716,7 @@ module.exports = function (config) {
               return cb(err, null);
             }
             incrementReceivedCounter();
-            if(result.payload && result.payload[0] === 0x44 && result.payload[1] === 0x49) {
+            if(result.payload && result.payload.slice(0,2) === CMDS.DI.value) {
               //TODO: double-check extra checksum
               sendAck(true, function (err, ackResult){
                 if(err) {

--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -865,6 +865,9 @@ module.exports = function (config) {
       if (err) {
         cb(err, null);
       } else {
+        if(result.payload.length !== 6) {
+          return cb(new Error('Invalid packet sent by pump'),null);
+        }
         var data = {
           numRecords : struct.extractShort(result.payload,2),
           recordSize: struct.extractShort(result.payload,4)
@@ -977,8 +980,8 @@ module.exports = function (config) {
         cb(err, null);
       } else {
 
-        // sometimes, the same record is retruned twice, so we have to continue
-        // reading records until we know we're at the last one
+        // sometimes, the same record is returned twice, so we have to check
+        // the record index until we know we're at the last one
         var datum = {index:-1};
         async.whilst(function () { return datum.index+1 < numRecords; }, function(next){
           console.log('Retrieving', datum.index+1,'of',numRecords);

--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -54,7 +54,7 @@ module.exports = function (config) {
     HANDSHAKE: {value: 0xBF, name: 'HANDSHAKE'},
     UA: {value: 0x73, name: 'Unnumbered Acknowledge'},
     RI: {value: 0x5249, name: 'RI message (Read)'},
-    DI: {value: 0x4449, name: 'DI message (RI response)'},
+    DI: {value: [0x44,0x49], name: 'DI message (RI response)'},
     ACK: {value: 0x11, name: 'Acknowledge'}
   };
 
@@ -676,7 +676,7 @@ module.exports = function (config) {
             if (err) {
               cb(err, null);
             } else {
-              if(result.payload && result.payload.slice(0,2) === CMDS.DI.value) {
+              if(result.payload && (result.payload.slice(0,2).toString() === CMDS.DI.value.toString())) {
                 //TODO: double-check extra checksum
                 sendAck(true, function (err, ackResult){
                   if(err) {
@@ -690,7 +690,7 @@ module.exports = function (config) {
             }
           });
         } else {
-          if(result.payload && result.payload.slice(0,2) === CMDS.DI.value) {
+          if(result.payload && (result.payload.slice(0,2).toString() === CMDS.DI.value.toString())) {
             //TODO: double-check extra checksum
             sendAck(true, function (err, ackResult){
               if(err) {
@@ -716,7 +716,7 @@ module.exports = function (config) {
               return cb(err, null);
             }
             incrementReceivedCounter();
-            if(result.payload && result.payload.slice(0,2) === CMDS.DI.value) {
+            if(result.payload && (result.payload.slice(0,2).toString() === CMDS.DI.value.toString())) {
               //TODO: double-check extra checksum
               sendAck(true, function (err, ackResult){
                 if(err) {

--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -1030,7 +1030,7 @@ module.exports = function (config) {
                 if(result.payload) {
                   parsePayload(result);
                 }
-                else if(result.ack) {
+                else {
 
                   console.log('Waiting..');
                   var waitTimer = setTimeout(function () {

--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -577,7 +577,7 @@ module.exports = function (config) {
   var listenForPacket = function (timeout, commandpacket, callback) {
     var abortTimer = setTimeout(function () {
       clearInterval(listenTimer);
-      debug('TIMEOUT');
+      debug('TIMEOUT:', commandpacket);
       callback(new Error('Timeout error'), null);
     }, timeout);
 
@@ -660,6 +660,50 @@ module.exports = function (config) {
   var animasCommandResponseAck = function (cmd, cb) {
     // This is for Information packets, where one ACK is received after the command is sent,
     // and an ACK is sent in response. When the payload is received, another ACK is sent.
+
+    var retry = function (cb, results) {
+      console.log('Sending ack and then command again..');
+      incrementReceivedCounter();
+      sendAck(true, function (err, result){
+        if(err) {
+          return cb(err, null);
+        }
+        if(result.ack) {
+          animasCommandResponse(cmd, true, function (err, result) {
+            if (err) {
+              cb(err, null);
+            } else {
+              if(result.payload && result.payload[0] === 0x44 && result.payload[1] === 0x49) {
+                var payload = result.payload;
+                //TODO: double-check extra checksum
+                sendAck(true, function (err, result){
+                  if(err) {
+                    return cb(err, null);
+                  }
+                  return cb(null,payload);
+                });
+              }else{
+                cb(new Error('Pump not sending data. Please retry.'), null);
+              }
+            }
+          });
+        } else {
+          if(result.payload && result.payload[0] === 0x44 && result.payload[1] === 0x49) {
+            var payload = result.payload;
+            //TODO: double-check extra checksum
+            sendAck(true, function (err, result){
+              if(err) {
+                return cb(err, null);
+              }
+              return cb(null,payload);
+            });
+          } else {
+            return cb(new Error('Unknown packet'), null);
+          }
+        };
+      });
+    };
+
     animasCommandResponse(cmd, true, function (err, result) {
       if (err) {
         cb(err, null);
@@ -671,7 +715,7 @@ module.exports = function (config) {
               return cb(err, null);
             }
             incrementReceivedCounter();
-            if(result.payload) {
+            if(result.payload && result.payload[0] === 0x44 && result.payload[1] === 0x49) {
               var payload = result.payload;
               //TODO: double-check extra checksum
               sendAck(true, function (err, result){
@@ -680,49 +724,28 @@ module.exports = function (config) {
                 }
                 return cb(null,payload);
               });
-            }else if(result.ack){
-              //Retry
-              debug('Not retrying, as we can crash the pump...');
-              cb(new Error('Pump not sending data. Please retry.'), null);
-            }else{
-              cb(new Error('Unknown packet received'), null);
+            }else {
+              async.retry(5, retry, function(err, result) {
+                console.log("RESULT1:", result);
+                if (err) {
+                  cb(err, null);
+                } else {
+                  cb(null,result);
+                }
+              });
             }
           });
         }
         else {
-          console.log('Sending another ack..');
-          incrementReceivedCounter();
-          sendAck(true, function (err, result){
-            //incrementSentCounter();
-            if(err) {
-              return cb(err, null);
+          //it's possible that we're receiving diagnostic echo messages,
+          //so retry command
+          async.retry(5, retry, function(err, result) {
+            console.log("RESULT2:", result);
+            if (err) {
+              cb(err, null);
+            } else {
+              cb(null,result);
             }
-            if(result.ack) {
-              //incrementReceivedCounter();
-              sendAck(true, function (err, result){
-                incrementReceivedCounter();
-                if(result.payload) {
-                  var payload = result.payload;
-                  //TODO: double-check extra checksum
-                  sendAck(true, function (err, result){
-                    incrementReceivedCounter();
-                    if(err) {
-                      return cb(err, null);
-                    }
-                    return cb(null,payload);
-                  });
-                }
-                else{
-                  debug('Too many acks');
-                  cb(new Error('Pump not sending data. Please retry.'), null);
-                }
-              });
-            }
-            else {
-              debug('Expecting pump to respond with ack, got something else instead');
-              cb(new Error('Pump not sending acknowledgement. Please retry.'), null);
-            }
-
           });
         }
       }
@@ -731,10 +754,8 @@ module.exports = function (config) {
 
   var discoverDevice = function(cb) {
     debug('discovering animas device');
-    primaryAddress = [(Math.floor(Math.random() * 30) + 1),0x00,0x00,0x00]; // use random primary address
-    connectionAddress = (Math.floor(Math.random() * 30) + 1) | 0x01; // use random primary address with LSB as 1
-    debug('Primary address: ', bytes2hex(primaryAddress));
-    debug('Connection address: ', connectionAddress.toString(16).toUpperCase());
+    primaryAddress = [0x01,0x00,0x00,0x00];
+    connectionAddress = 0x03; // use connection address with LSB as 1
 
     var i = 0;
     var handshakeInterval = setInterval(function() {
@@ -754,7 +775,7 @@ module.exports = function (config) {
         }
       });
 
-    }, 1000);
+    }, 200); // discovery timeout is 100ms, we wait a bit longer
 
   };
 
@@ -781,16 +802,16 @@ module.exports = function (config) {
   };
 
   var resetConnection = function(obj, cb) {
-    debug('reset connection to animas');
     cfg.deviceComms.setPaused(false);
 
+    debug('reset connection to animas');
     var cmd = {
       packet: buildPacket(
-        connectionAddress, CMDS.DISCONNECT.value, []
+        connectionAddress, CMDS.CONNECT.value, []
       ),
       parser: function (packet) {
         if (packet.command == CMDS.UA.value) {
-          var data = {connected : false};
+          var data = {wasReset: true};
           return data;
         }
         return false;
@@ -798,34 +819,10 @@ module.exports = function (config) {
     };
 
     animasCommandResponse(cmd, false, function (err, result) {
-
-        discoverDevice(function(discoverErr, discoverResult) {
-          if(discoverErr) {
-            console.log('Retrying discover sequence..');
-
-            discoverDevice(function(discoverErr, discoverResult) {
-              if(discoverErr) {
-                return cb(discoverErr, null);
-              }else{
-                getConnection(discoverResult, function(connectErr, obj) {
-                  if(connectErr) {
-                    cb(connectErr, null);
-                  }else{
-                    cb(null, obj);
-                  }
-                });
-              }
-            });
-          }else{
-            getConnection(discoverResult, function(connectErr, obj) {
-              if(connectErr) {
-                cb(connectErr, null);
-              }else{
-                cb(null, obj);
-              }
-            });
-          }
-        });
+      if(err) {
+        return cb(err,null);
+      }
+      return cb(null, result);
     });
   };
 
@@ -981,24 +978,27 @@ module.exports = function (config) {
         cb(err, null);
       } else {
 
-        async.timesSeries(numRecords, function(n, next){
+        async.timesSeries(numRecords+1, function(n, next){
 
           var parsePayload = function(result) {
             var payload = result.payload;
-            if(struct.extractInt(payload,4) === 0) {// empty date
-              return next('stop',null);
-            }else{
-              var datum = request.parser(payload);
-              console.log('Datum:', datum);
+            var datum = request.parser(payload);
+            console.log('Datum:', datum);
 
-              //TODO: double-check extra checksum
-              sendAck(true, function (err, result){
-                if(err) {
-                  return cb(err, null);
-                }
-                return next(err,datum);
-              });
+            if(struct.extractInt(payload,4) === 0) {// empty date
+              datum.empty = true;
             }
+            else{
+              datum.empty = false;
+            }
+
+            //TODO: double-check extra checksum
+            sendAck(true, function (err, result){
+              if(err) {
+                return cb(err, null);
+              }
+              return next(err,datum);
+            });
           };
 
           sendAck(true, function (err, result){
@@ -1044,7 +1044,8 @@ module.exports = function (config) {
           });
 
         }, function(obj, result) {
-          if(obj == 'stop') {
+          _.remove(result, function (item) { return item.empty;});
+          if (result[result.length-1].jsDate === null) {
             result.pop(); //remove null element
           }
           cb(null,result);

--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -1454,6 +1454,61 @@ module.exports = function (config) {
         return records;
       };
 
+      var readRecords = function (recordType, request, percentage, numResult, callback) {
+
+        debug('Number of',_getName(RECORD_TYPES, recordType),'records:',numResult);
+        var numRecords = numResult.numRecords;
+
+        if (recordType === RECORD_TYPES.BASAL_PROGRAM.value) {
+          debug('Reading basal schedules');
+          // TODO: read basal schedules when set to 4 instead of just 1
+          // pump does not respond in the same way as with other records :(
+          numRecords = 1;
+        }
+
+        getRecords(request, numRecords, percentage, progress, function(err, result){
+          if(err) {
+            debug('Resetting and trying again..');
+            resetConnection(true, function(connectErr, obj) {
+              if(connectErr) {
+                // give up
+                return callback(connectErr, null);
+              }else{
+                counters.received = 0;
+                counters.sent = 0;
+                getRecords(request, numRecords, percentage, progress, function(errRetry, resultRetry){
+                  if(errRetry) {
+                    //give up
+                    return callback(errRetry, null);
+                  }
+                  else{
+                    progress(percentage);
+                    var ordered = dedupAndCheckOrder(resultRetry);
+                    if (ordered) {
+                      callback(null,ordered);
+                    }
+                    else{
+                      callback(new Error('Some data went missing. Please try again.'),null);
+                    }
+                  }
+                });
+              }
+            });
+          }
+          else {
+            progress(percentage);
+            var ordered = dedupAndCheckOrder(result);
+            if (ordered) {
+              callback(null,ordered);
+            }
+            else{
+              debug('Result:', result);
+              callback(new Error('Some data went missing. Please retry.'),null);
+            }
+          }
+        });
+      };
+
       var readAllRecords = function (recordType, request, percentage, callback) {
         resetConnection(true, function(connectErr, obj) {
           if(connectErr) {
@@ -1463,59 +1518,22 @@ module.exports = function (config) {
             counters.sent = 0;
             getNumberOfRecords(recordType, function (err, result) {
               if(err) {
-                callback(err,null);
-              }else{
-                debug('Number of',_getName(RECORD_TYPES, recordType),'records:',result);
-                var numRecords = result.numRecords;
-
-                if (recordType === RECORD_TYPES.BASAL_PROGRAM.value) {
-                  debug('Reading basal schedules');
-                  // TODO: read basal schedules when set to 4 instead of just 1
-                  // pump does not respond in the same way as with other records :(
-                  numRecords = 1;
-                }
-
-                getRecords(request, numRecords, percentage, progress, function(err, result){
-                  if(err) {
-                    debug('Resetting and trying again..');
-                    resetConnection(true, function(connectErr, obj) {
-                      if(connectErr) {
-                        // give up
-                        return callback(connectErr, null);
-                      }else{
-                        counters.received = 0;
-                        counters.sent = 0;
-                        getRecords(request, numRecords, percentage, progress, function(errRetry, resultRetry){
-                          if(errRetry) {
-                            //give up
-                            return callback(errRetry, null);
-                          }
-                          else{
-                            progress(percentage);
-                            var ordered = dedupAndCheckOrder(resultRetry);
-                            if (ordered) {
-                              callback(null,ordered);
-                            }
-                            else{
-                              callback(new Error('Some data went missing. Please try again.'),null);
-                            }
-                          }
-                        });
+                debug('Resetting and trying again..');
+                resetConnection(true, function(connectErr, obj) {
+                  if(connectErr) {
+                    return cb(connectErr, null);
+                  }else{
+                    getNumberOfRecords(recordType, function (err2, result2) {
+                      if(err2) {
+                        return cb(err2,null);
+                      } else {
+                        readRecords(recordType, request, percentage, result2, callback);
                       }
                     });
                   }
-                  else {
-                    progress(percentage);
-                    var ordered = dedupAndCheckOrder(result);
-                    if (ordered) {
-                      callback(null,ordered);
-                    }
-                    else{
-                      debug('Result:', result);
-                      callback(new Error('Some data went missing. Please retry.'),null);
-                    }
-                  }
                 });
+              }else{
+                readRecords(recordType, request, percentage, result, callback);
               }
             });
           }

--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -969,11 +969,12 @@ module.exports = function (config) {
     return date;
   };
 
-  var getRecords = function(request,numRecords,cb) {
+  var getRecords = function(request,numRecords,percentage,progress,cb) {
 
     var cmd = readDataPages(request.recordType,0,numRecords);
     var firstPass = true;
     var records = [];
+    var prevPercentage = 0;
 
     animasCommandResponseAck(cmd, function (err, result) {
       if (err) {
@@ -985,6 +986,13 @@ module.exports = function (config) {
         var datum = {index:-1};
         async.whilst(function () { return datum.index+1 < numRecords; }, function(next){
           console.log('Retrieving', datum.index+1,'of',numRecords);
+
+          var newPercentage = (datum.index/numRecords)*10+(10-percentage);
+          if(newPercentage > (prevPercentage+1)) {
+            // only update progress to UI if there's an increase of at least 1 percent
+            prevPercentage = newPercentage;
+            progress(newPercentage);
+          }
 
           var parsePayload = function(result) {
             var payload = result.payload;
@@ -1467,7 +1475,7 @@ module.exports = function (config) {
                   numRecords = 1;
                 }
 
-                getRecords(request, numRecords, function(err, result){
+                getRecords(request, numRecords, percentage, progress, function(err, result){
                   if(err) {
                     debug('Resetting and trying again..');
                     resetConnection(true, function(connectErr, obj) {
@@ -1477,7 +1485,7 @@ module.exports = function (config) {
                       }else{
                         counters.received = 0;
                         counters.sent = 0;
-                        getRecords(request, numRecords, function(errRetry, resultRetry){
+                        getRecords(request, numRecords, percentage, progress, function(errRetry, resultRetry){
                           if(errRetry) {
                             //give up
                             return callback(errRetry, null);


### PR DESCRIPTION
With the existing device comms strategy, when reading a specific record type, we terminate the connection when the record is empty (as all subsequent records will be empty), and reconnect to read the next record type. It's not possible to just send a reset command, as the pump will continue to try to send the next empty record. Diasend reads all the records for each type, even if they're empty, and we were hoping to eliminate this inefficiency.

Unfortunately, if the disconnect command is received on the Animas Vibe, the screen goes dark, making it impossible to reconnect to the pump.

One side-effect of new Animas device comms strategy: We are downloading ​_all_​ the records (including empty ones) off the pump each time (just like Diasend does), even if you only have a single bolus record on your pump. Luckily the pump has a small memory, so this only takes 2.5 minutes on my machine.