### PR TITLE
Handling timestamps in future when current interval start is null

### DIFF
--- a/lib/TimezoneOffsetUtil.js
+++ b/lib/TimezoneOffsetUtil.js
@@ -1,15 +1,15 @@
 /*
  * == BSD2 LICENSE ==
  * Copyright (c) 2014, Tidepool Project
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the associated License, which is identical to the BSD 2-Clause
  * License as published by the Open Source Initiative at opensource.org.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the License for more details.
- * 
+ *
  * You should have received a copy of the License along with this program; if
  * not, you can obtain one from Tidepool Project at tidepool.org.
  * == BSD2 LICENSE ==
@@ -194,6 +194,9 @@ module.exports = function(timezone, mostRecent, changes) {
             // handles timestamps in the future
             // e.g., when a user set device time a month in the future
             else if (utc >= currentInterval.start && utc > currentInterval.end) {
+              return retObj;
+            }
+            else if (currentInterval.start === null && utc > currentInterval.end) {
               return retObj;
             }
           }


### PR DESCRIPTION
 We’ve got an OmniPod `Failed to look up UTC info!` error. There’s only one time change event (1 April to 15 April) and the first event is on 4 April.

@jebeck to review if the change is correct.