### PR TITLE
Fix for timeout error at with 50-60% progress bar

### DIFF
--- a/lib/drivers/bayerContourNext.js
+++ b/lib/drivers/bayerContourNext.js
@@ -322,7 +322,7 @@ module.exports = function (config) {
                 if (err) {
                   debug('Failure trying to read record', record.frame);
                   debug(err);
-                  return whilstCb(err);
+                  return whilstCb(err,null);
                 } else {
                   robj.timestamp = parseInt(r[4]);
                   robj.annotations = getAnnotations(r[3], data);

--- a/lib/drivers/bayerContourNext.js
+++ b/lib/drivers/bayerContourNext.js
@@ -392,18 +392,26 @@ module.exports = function (config) {
   };
 
   var getASTMMessage = function (timeout, retries, callback) {
+    var e = new Error('Timeout error.');
+    e.name = 'TIMEOUT';
+
     var abortTimer = setTimeout(function () {
       clearInterval(listenTimer);
       debug('TIMEOUT');
-      var e = new Error('Timeout error.');
-      e.name = 'TIMEOUT';
       return callback(e, null);
     }, timeout);
 
     var listenTimer = setInterval(function () {
       hidDevice.receive(function(raw) {
         var packet = new Uint8Array(raw);
+
+        // we need to reset the timeout
         clearTimeout(abortTimer);
+        abortTimer = setTimeout(function () {
+          clearInterval(listenTimer);
+          debug('TIMEOUT');
+          return callback(e, null);
+        }, timeout);
 
         // Only process if we get data
         if ( packet.length === 0 ) {
@@ -414,6 +422,7 @@ module.exports = function (config) {
 
         if(packetHead['HEADER'] !== MAGIC_HEADER){
           debug('Invalid packet from Contour device');
+          clearTimeout(abortTimer);
           clearInterval(listenTimer);
           return callback(new Error('Invalid USB packet received.'), null);
         }
@@ -428,6 +437,7 @@ module.exports = function (config) {
             packetHead['BYTE1'] == ASCII_CONTROL.ENQ ||
             packetTail['FRAME_TYPE'] == ASCII_CONTROL.ETX ||
             packetTail['FRAME_TYPE'] == ASCII_CONTROL.ETB ) {
+            clearTimeout(abortTimer);
             clearInterval(listenTimer);
             callback(null);
         }

--- a/lib/drivers/bayerContourNext.js
+++ b/lib/drivers/bayerContourNext.js
@@ -403,6 +403,7 @@ module.exports = function (config) {
     var listenTimer = setInterval(function () {
       hidDevice.receive(function(raw) {
         var packet = new Uint8Array(raw);
+        clearTimeout(abortTimer);
 
         // Only process if we get data
         if ( packet.length === 0 ) {
@@ -413,7 +414,6 @@ module.exports = function (config) {
 
         if(packetHead['HEADER'] !== MAGIC_HEADER){
           debug('Invalid packet from Contour device');
-          clearTimeout(abortTimer);
           clearInterval(listenTimer);
           return callback(new Error('Invalid USB packet received.'), null);
         }
@@ -428,7 +428,6 @@ module.exports = function (config) {
             packetHead['BYTE1'] == ASCII_CONTROL.ENQ ||
             packetTail['FRAME_TYPE'] == ASCII_CONTROL.ETX ||
             packetTail['FRAME_TYPE'] == ASCII_CONTROL.ETB ) {
-            clearTimeout(abortTimer);
             clearInterval(listenTimer);
             callback(null);
         }


### PR DESCRIPTION
Problem: Some clinics have reported spurious timeout errors for Bayer meters, which can be resolved by retrying multiple times. It looks like these are produced for devices with lots of records
<img width="402" alt="screen shot 2016-04-18 at 21 54 58" src="https://cloud.githubusercontent.com/assets/418233/14642563/c999c13c-0642-11e6-9bff-f302cd2fb1aa.png">

Possible cause: `abortTimer` was only cleared when the packet is successful, not when the packet is empty.  When the `listenTimer` interval timer fires multiple times, we have the unfired `abortTimer`s building up and all firing after their timeout of 5s.

Possible solution: Clearing `abortTimer` as soon as we receive a packet, but only clearing `listenTimer` when we receive a successful packet.

I haven't been able to reproduce the error myself, but it's possible to try and emulate it by changing the timeout value from 5s to 100ms. The current `master` branch will timeout, whereas this branch will succeed even with such a short timeout.

@jebeck or @darinkrauss to review?