### PR TITLE
Sending Animas through new APIs; everything else through Jellyfish

### DIFF
--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -417,7 +417,7 @@ api.upload.toPlatform = function(data, sessionInfo, progress, groupId, cb, uploa
               api.log('created dataset does not include uploadId');
               return callback(new Error(format('Dataset response does not contain uploadId.')));
             }
-            return callback();
+            return callback(null, uploadItem);
           }
           api.log('error creating dataset ', err);
           return callback(err);

--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -222,6 +222,16 @@ api.upload.accounts = function(happyCb, sadCb) {
   });
 };
 
+function getUploadFunction(uploadType) {
+  if(uploadType === 'dataservices') {
+    return tidepool.addDataToDataset;
+  }
+  else if (uploadType === 'jellyfish') {
+   return tidepool.uploadDeviceDataForUser;
+  }
+  return null;
+}
+
 function createDatasetForUser(userId, info, callback) {
 
   var happy = function(dataset) {
@@ -266,7 +276,7 @@ function finalizeDataset(datasetId, callback) {
   });
 }
 
-function addDataToDataset(data, datasetId, blockIndex, callback) {
+function addDataToDataset(data, datasetId, blockIndex, uploadType, callback) {
 
   var recCount = data.length;
   var happy = function () {
@@ -300,7 +310,9 @@ function addDataToDataset(data, datasetId, blockIndex, callback) {
 
   api.log('addDataToDataset #' + blockIndex + ': using id ', datasetId);
 
-  tidepool.addDataToDataset(datasetId, data, function(err, result) {
+
+  var uploadForUser = getUploadFunction(uploadType);
+  uploadForUser(datasetId, data, function(err, result) {
     if (err) {
       return sad(err, err);
     }
@@ -310,10 +322,14 @@ function addDataToDataset(data, datasetId, blockIndex, callback) {
 
 /*
  * process the data sending it to the platform in blocks and feed back progress to the calling function
+ * uploadType is the final argument (instead of the callback) so that existing calls to
+ * api.upload.toPlatform don't have to be modified in every driver, and will default to
+ * the jellyfish api
  */
-api.upload.toPlatform = function(data, sessionInfo, progress, groupId, cb) {
+api.upload.toPlatform = function(data, sessionInfo, progress, groupId, cb, uploadType) {
+  uploadType = uploadType || 'jellyfish'; // can either be 'jellyfish' or 'dataservices'
 
-  api.log('attempting to upload', data.length, 'device data records');
+  api.log('attempting to upload', data.length, 'device data records to', uploadType, 'api');
   var grouped = _.groupBy(data, 'type');
   for (var type in grouped) {
     api.log(grouped[type].length, 'records of type', type);
@@ -328,7 +344,10 @@ api.upload.toPlatform = function(data, sessionInfo, progress, groupId, cb) {
   var post_and_progress = function (data, callback) {
     progress(nblocks++ * 100.0 / blocks.length);
     //off to the platfrom we go
-    return addDataToDataset(data, datasetId, nblocks, callback);
+    if(uploadType === 'jellyfish') {
+      return addDataToDataset(data, groupId, nblocks, uploadType, callback);
+    }
+    return addDataToDataset(data, datasetId, nblocks, uploadType, callback);
   };
 
   var post_dataset_create = function (uploadMeta, callback) {
@@ -339,8 +358,14 @@ api.upload.toPlatform = function(data, sessionInfo, progress, groupId, cb) {
     return finalizeDataset(datasetId, callback);
   };
 
-  var decorate = function (data) {
+  var decorate = function (data, uploadItem) {
     var deviceRecords = _.map(data, function(item) {
+      if(uploadType === 'jellyfish') {
+        return _.extend({}, item, {
+          uploadId: uploadItem.uploadId,
+          guid: uuid.v4()
+        });
+      }
       return _.extend({}, item, {
         guid: uuid.v4()
       });
@@ -374,29 +399,46 @@ api.upload.toPlatform = function(data, sessionInfo, progress, groupId, cb) {
         .with_deviceModel(sessionInfo.deviceModel)
         .with_deviceSerialNumber(sessionInfo.deviceSerialNumber)
         .with_deviceId(sessionInfo.deviceId)
-        .with_payload(sessionInfo.payload)
-        .done();
+        .with_payload(sessionInfo.payload);
+
+      if(uploadType === 'jellyfish') {
+        uploadItem.with_uploadId('upid_' + md5(sessionInfo.deviceId + '_' + sessionInfo.start).slice(0, 12));
+      }
+      uploadItem = uploadItem.done();
 
       api.log('create dataset');
 
-      post_dataset_create(uploadItem, function(err, dataset){
-        if(_.isEmpty(err)){
-          api.log('created dataset');
-          datasetId = _.get(dataset, 'uploadId');
-          if(_.isEmpty(datasetId)){
-            api.log('created dataset does not include uploadId');
-            return callback(new Error(format('Dataset response does not contain uploadId.')));
+      if(uploadType === 'dataservices') {
+        post_dataset_create(uploadItem, function(err, dataset){
+          if(_.isEmpty(err)){
+            api.log('created dataset');
+            datasetId = _.get(dataset, 'uploadId');
+            if(_.isEmpty(datasetId)){
+              api.log('created dataset does not include uploadId');
+              return callback(new Error(format('Dataset response does not contain uploadId.')));
+            }
+            return callback();
           }
-          return callback();
-        }
-        api.log('error creating dataset ', err);
-        return callback(err);
-      });
+          api.log('error creating dataset ', err);
+          return callback(err);
+        });
+      }
+      else{
+        // upload metadata uploaded as usual through jellyfish
+        addDataToDataset(uploadItem, groupId, 0, uploadType, function(err) {
+          if(_.isEmpty(err)){
+            api.log('saved upload metadata');
+            return callback(null, uploadItem);
+          }
+          api.log('error saving upload metadata ', err);
+          return callback(err);
+        });
+      }
     },
-    function(callback) {
+    function(uploadItem, callback) {
       // decorate our data with the successfully posted upload metadata
       // as well as a GUID and then save to the platform
-      data = decorate(data);
+      data = decorate(data, uploadItem);
 
       for (var i = 0; i < data.length; i += BLOCKSIZE) {
         blocks.push(data.slice(i, i + BLOCKSIZE));
@@ -406,6 +448,9 @@ api.upload.toPlatform = function(data, sessionInfo, progress, groupId, cb) {
       async.mapSeries(blocks, post_and_progress, callback);
     },
     function(result, callback) {
+      if(uploadType === 'jellyfish') {
+        return callback(null, result);
+      }
       api.log('finalize dataset');
       post_dataset_finalize(function(err){
         if(_.isEmpty(err)){

--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -1965,7 +1965,7 @@ module.exports = function (config) {
             progress(100);
             return cb(null, data);
           }
-      });
+      },'dataservices');
     },
 
     disconnect: function (progress, data, cb) {


### PR DESCRIPTION
By adding an optional `uploadType` parameter to `toPlatform` we can upload using either `jellyfish` or `dataservices`.

Ping @darinkrauss for review.