### PR TITLE
Bug fix: handling temp basal without a temp_rate_start event

### DIFF
--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -1974,17 +1974,18 @@ module.exports = function (config) {
       }
 
       if (!_.isEmpty(data.log_records)) {
+        // ordering below is important for simulator, e.g.
+        // buildTempBasalRecords needs to be before buildBasalRecords
         postrecords = buildSettingsRecords(data, postrecords);
         if (!_.isEmpty(postrecords)) {
           settings = postrecords[0];
         }
         postrecords = buildTimeChangeRecords(data, postrecords);
         postrecords = buildBolusRecords(data, postrecords);
-
+        postrecords = buildTempBasalRecords(data, postrecords);
         postrecords = buildBasalRecords(data, postrecords);
         postrecords = buildNewDayRecords(data, postrecords);
         postrecords = buildBGRecords(data, postrecords);
-        postrecords = buildTempBasalRecords(data, postrecords);
         postrecords = buildCartridgeChangeRecords(data, postrecords);
         postrecords = buildSuspendRecords(data, postrecords);
         postrecords = buildResumeRecords(data, postrecords);

--- a/lib/tandem/tandemSimulator.js
+++ b/lib/tandem/tandemSimulator.js
@@ -132,17 +132,35 @@ exports.make = function(config){
           tempBasal.type = 'basal';
           delete tempBasal.subType;
           tempBasal.deliveryType = 'temp';
-          tempBasal.deviceId = event.deviceId;
-          tempBasal.previous = currBasal.previous;
-          tempBasal.suppressed = currBasal.previous;
+          tempBasal.deviceId = currBasal.deviceId;
           annotate.annotateEvent(tempBasal, 'tandem/basal/temp-without-rate-change');
           tempBasal.payload = {
             duration : tempBasal.duration,
             logIndices: tempBasal.index //to be removed after Jaeb study
           };
           delete tempBasal.index;
-          // actual temp basal duration is based on currBasal (temp_rate_end) time
-          tempBasal.duration = Date.parse(currBasal.time) - Date.parse(tempBasal.time);
+
+          var suppressed = {
+            type: 'basal',
+            deliveryType: 'scheduled'
+          };
+
+          if(tempBasal.time_left > 0) {
+            // temp basal was cancelled, so currBasal is suppressed
+            tempBasal.previous = currBasal;
+            suppressed.rate = currBasal.rate;
+            tempBasal.suppressed = suppressed;
+            tempBasal.duration = Date.parse(event.time) - Date.parse(tempBasal.time);
+          } else{
+            // temp basal completed, so previous was suppressed
+            tempBasal.previous = currBasal.previous;
+            suppressed.rate = currBasal.previous.rate;
+            tempBasal.suppressed = suppressed;
+            // actual temp basal duration is based on currBasal (temp_rate_end) time
+            tempBasal.duration = Date.parse(currBasal.time) - Date.parse(tempBasal.time);
+          }
+          delete tempBasal.time_left;
+
           events.push(tempBasal);
           setCurrTempBasal(null);
           event.previous = _.omit(tempBasal, 'previous');

--- a/lib/tandem/tandemSimulator.js
+++ b/lib/tandem/tandemSimulator.js
@@ -108,6 +108,7 @@ exports.make = function(config){
             }else{
               currBasal.payload = {duration : currTempBasal.duration};
             }
+            setCurrTempBasal(null);
           }
         }
 
@@ -123,6 +124,28 @@ exports.make = function(config){
         }
         else {
           return;
+        }
+
+        if(currTempBasal && currTempBasal.subType === 'stop') {
+          // temp basal without a basal rate change (temp_rate_start) event
+          var tempBasal = currTempBasal;
+          tempBasal.type = 'basal';
+          delete tempBasal.subType;
+          tempBasal.deliveryType = 'temp';
+          tempBasal.deviceId = event.deviceId;
+          tempBasal.previous = currBasal.previous;
+          tempBasal.suppressed = currBasal.previous;
+          annotate.annotateEvent(tempBasal, 'tandem/basal/temp-without-rate-change');
+          tempBasal.payload = {
+            duration : tempBasal.duration,
+            logIndices: tempBasal.index //to be removed after Jaeb study
+          };
+          delete tempBasal.index;
+          // actual temp basal duration is based on currBasal (temp_rate_end) time
+          tempBasal.duration = Date.parse(currBasal.time) - Date.parse(tempBasal.time);
+          events.push(tempBasal);
+          setCurrTempBasal(null);
+          event.previous = _.omit(tempBasal, 'previous');
         }
       }
 

--- a/lib/tandem/tandemSimulator.js
+++ b/lib/tandem/tandemSimulator.js
@@ -142,23 +142,14 @@ exports.make = function(config){
 
           var suppressed = {
             type: 'basal',
-            deliveryType: 'scheduled'
+            deliveryType: 'scheduled',
+            rate: currBasal.rate
           };
 
-          if(tempBasal.time_left > 0) {
-            // temp basal was cancelled, so currBasal is suppressed
-            tempBasal.previous = currBasal;
-            suppressed.rate = currBasal.rate;
-            tempBasal.suppressed = suppressed;
-            tempBasal.duration = Date.parse(event.time) - Date.parse(tempBasal.time);
-          } else{
-            // temp basal completed, so previous was suppressed
-            tempBasal.previous = currBasal.previous;
-            suppressed.rate = currBasal.previous.rate;
-            tempBasal.suppressed = suppressed;
-            // actual temp basal duration is based on currBasal (temp_rate_end) time
-            tempBasal.duration = Date.parse(currBasal.time) - Date.parse(tempBasal.time);
-          }
+          tempBasal.previous = _.omit(currBasal, 'previous');
+          tempBasal.suppressed = suppressed;
+          // actual temp basal duration is based on basal rate change event (temp_rate_end)
+          tempBasal.duration = Date.parse(event.time) - Date.parse(tempBasal.time);
           delete tempBasal.time_left;
 
           events.push(tempBasal);
@@ -216,7 +207,9 @@ exports.make = function(config){
         setCurrTempBasal(event);
       }
       else if(event.subType === 'stop') {
-        if(currTempBasal != null) {
+        // Cancelled temp basal has two 'stop's. We're interested in the first,
+        // so make sure we're not overwriting the first 'stop'
+        if(currTempBasal != null && currTempBasal.subType === 'start') {
           var tempBasal = _.clone(currTempBasal);
           tempBasal.subType = 'stop';
           tempBasal.time_left = event.time_left;

--- a/lib/tandem/tandemSimulator.js
+++ b/lib/tandem/tandemSimulator.js
@@ -128,7 +128,7 @@ exports.make = function(config){
 
         if(currTempBasal && currTempBasal.subType === 'stop') {
           // temp basal without a basal rate change (temp_rate_start) event
-          var tempBasal = currTempBasal;
+          var tempBasal = _.clone(currTempBasal);
           tempBasal.type = 'basal';
           delete tempBasal.subType;
           tempBasal.deliveryType = 'temp';
@@ -217,7 +217,7 @@ exports.make = function(config){
       }
       else if(event.subType === 'stop') {
         if(currTempBasal != null) {
-          var tempBasal = currTempBasal;
+          var tempBasal = _.clone(currTempBasal);
           tempBasal.subType = 'stop';
           tempBasal.time_left = event.time_left;
           setCurrTempBasal(tempBasal);

--- a/test/node/tandem/testTandemSimulator.js
+++ b/test/node/tandem/testTandemSimulator.js
@@ -436,87 +436,61 @@ describe('tandemSimulator.js', function() {
       ]);
     });
 
-    var suppressed = builder.makeScheduledBasal()
-      .with_time('2014-09-25T01:05:00.000Z')
-      .with_deviceTime('2014-09-25T01:05:00')
-      .with_timezoneOffset(0)
-      .with_conversionOffset(0)
-      .with_rate(1.3)
-      .with_duration(2000000)
-      .set('deviceId','tandem12345');
-    var tempBasalStart = {
-          type: 'temp-basal',
-          subType: 'start',
-          percent: 0.65,
-          duration: 1500000,
-          time: '2014-09-25T01:10:00.000Z',
-          deviceTime: '2014-09-25T01:10:00',
-          timezoneOffset: 0,
-          conversionOffset: 0,
-          index: 1
-        };
-    var tempBasalStop = {
-          type: 'temp-basal',
-          subType: 'stop',
-          time_left: 0
-        };
-
-    var expectedTempBasal = builder.makeTempBasal()
-      .with_time('2014-09-25T01:10:00.000Z')
-      .with_deviceTime('2014-09-25T01:10:00')
-      .with_timezoneOffset(0)
-      .with_conversionOffset(0)
-      .with_duration(6600000)
-      .with_previous(suppressed.done())
-      .set('suppressed',{
-                  type: 'basal',
-                  deliveryType: 'scheduled',
-                  rate: 1.3
-                })
-      .set('percent', 0.65)
-      .set('deviceId', 'tandem12345')
-      .with_payload({'logIndices':1, duration: 1500000})
-      .done();
-    expectedTempBasal.annotations = [{code: 'tandem/basal/temp-without-rate-change'}];
-
     it('temp basal without basal rate change', function() {
+      var suppressed = builder.makeScheduledBasal()
+        .with_time('2014-09-25T01:05:00.000Z')
+        .with_deviceTime('2014-09-25T01:05:00')
+        .with_timezoneOffset(0)
+        .with_conversionOffset(0)
+        .with_rate(1.3)
+        .with_duration(2000000)
+        .set('deviceId','tandem12345');
+      var tempBasalStart = {
+            type: 'temp-basal',
+            subType: 'start',
+            percent: 0.65,
+            duration: 1500000,
+            time: '2014-09-25T01:10:00.000Z',
+            deviceTime: '2014-09-25T01:10:00',
+            timezoneOffset: 0,
+            conversionOffset: 0,
+            index: 1
+          };
+      var tempBasalStop = {
+            type: 'temp-basal',
+            subType: 'stop',
+            time_left: 0
+          };
+
+      var expectedTempBasal = builder.makeTempBasal()
+        .with_time('2014-09-25T01:10:00.000Z')
+        .with_deviceTime('2014-09-25T01:10:00')
+        .with_timezoneOffset(0)
+        .with_conversionOffset(0)
+        .with_duration(6600000)
+        .with_previous(suppressed.done())
+        .set('suppressed',{
+                    type: 'basal',
+                    deliveryType: 'scheduled',
+                    rate: 1.3
+                  })
+        .set('percent', 0.65)
+        .set('deviceId', 'tandem12345')
+        .with_payload({'logIndices':1, duration: 1500000})
+        .done();
+      expectedTempBasal.annotations = [{code: 'tandem/basal/temp-without-rate-change'}];
+      
       // temp_rate_end basal rate change occurs before temp basal stop
       simulator.basal(suppressed);
       simulator.tempBasal(tempBasalStart);
-      simulator.basal(basal2);
       simulator.tempBasal(tempBasalStop);
+      simulator.basal(basal2);
       simulator.basal(basal3);
 
       expect(simulator.getEvents()).deep.equals([
         suppressed.done(),
         expectedTempBasal,
         basal2.done()
-      ]);
-    });
-
-    it('temp basal without basal rate change; cancelled early', function() {
-      // temp_rate_end basal rate change occurs after temp basal stop
-      tempBasalStop.time_left = 500000;
-      expectedTempBasal.duration = 7900000;
-
-      var basalResume = builder.makeScheduledBasal()
-        .with_time('2014-09-25T03:21:40.000Z')
-        .with_deviceTime('2014-09-25T03:21:40')
-        .with_timezoneOffset(0)
-        .with_conversionOffset(0)
-        .with_scheduleName('Alice')
-        .with_rate(0.90);
-
-      simulator.basal(suppressed);
-      simulator.tempBasal(tempBasalStart);
-      simulator.tempBasal(tempBasalStop);
-      simulator.basal(basalResume);
-      simulator.basal(basal3);
-
-      expect(simulator.getEvents()).deep.equals([
-        suppressed.done(),
-        expectedTempBasal,
-        basalResume.done()
       ]);
     });
 

--- a/test/node/tandem/testTandemSimulator.js
+++ b/test/node/tandem/testTandemSimulator.js
@@ -346,7 +346,8 @@ describe('tandemSimulator.js', function() {
       .with_timezoneOffset(0)
       .with_conversionOffset(0)
       .with_scheduleName('Alice')
-      .with_rate(0.85);
+      .with_rate(0.85)
+      .set('deviceId','tandem12345');
     var basal3 = builder.makeScheduledBasal()
       .with_time('2014-09-25T03:30:00.000Z')
       .with_deviceTime('2014-09-25T03:30:00')
@@ -432,6 +433,90 @@ describe('tandemSimulator.js', function() {
       expect(simulator.getEvents()).deep.equals([
         suppressed.done(),
         expectedTempBasal
+      ]);
+    });
+
+    var suppressed = builder.makeScheduledBasal()
+      .with_time('2014-09-25T01:05:00.000Z')
+      .with_deviceTime('2014-09-25T01:05:00')
+      .with_timezoneOffset(0)
+      .with_conversionOffset(0)
+      .with_rate(1.3)
+      .with_duration(2000000)
+      .set('deviceId','tandem12345');
+    var tempBasalStart = {
+          type: 'temp-basal',
+          subType: 'start',
+          percent: 0.65,
+          duration: 1500000,
+          time: '2014-09-25T01:10:00.000Z',
+          deviceTime: '2014-09-25T01:10:00',
+          timezoneOffset: 0,
+          conversionOffset: 0,
+          index: 1
+        };
+    var tempBasalStop = {
+          type: 'temp-basal',
+          subType: 'stop',
+          time_left: 0
+        };
+
+    var expectedTempBasal = builder.makeTempBasal()
+      .with_time('2014-09-25T01:10:00.000Z')
+      .with_deviceTime('2014-09-25T01:10:00')
+      .with_timezoneOffset(0)
+      .with_conversionOffset(0)
+      .with_duration(6600000)
+      .with_previous(suppressed.done())
+      .set('suppressed',{
+                  type: 'basal',
+                  deliveryType: 'scheduled',
+                  rate: 1.3
+                })
+      .set('percent', 0.65)
+      .set('deviceId', 'tandem12345')
+      .with_payload({'logIndices':1, duration: 1500000})
+      .done();
+    expectedTempBasal.annotations = [{code: 'tandem/basal/temp-without-rate-change'}];
+
+    it('temp basal without basal rate change', function() {
+      // temp_rate_end basal rate change occurs before temp basal stop
+      simulator.basal(suppressed);
+      simulator.tempBasal(tempBasalStart);
+      simulator.basal(basal2);
+      simulator.tempBasal(tempBasalStop);
+      simulator.basal(basal3);
+
+      expect(simulator.getEvents()).deep.equals([
+        suppressed.done(),
+        expectedTempBasal,
+        basal2.done()
+      ]);
+    });
+
+    it('temp basal without basal rate change; cancelled early', function() {
+      // temp_rate_end basal rate change occurs after temp basal stop
+      tempBasalStop.time_left = 500000;
+      expectedTempBasal.duration = 7900000;
+
+      var basalResume = builder.makeScheduledBasal()
+        .with_time('2014-09-25T03:21:40.000Z')
+        .with_deviceTime('2014-09-25T03:21:40')
+        .with_timezoneOffset(0)
+        .with_conversionOffset(0)
+        .with_scheduleName('Alice')
+        .with_rate(0.90);
+
+      simulator.basal(suppressed);
+      simulator.tempBasal(tempBasalStart);
+      simulator.tempBasal(tempBasalStop);
+      simulator.basal(basalResume);
+      simulator.basal(basal3);
+
+      expect(simulator.getEvents()).deep.equals([
+        suppressed.done(),
+        expectedTempBasal,
+        basalResume.done()
       ]);
     });
 


### PR DESCRIPTION
When a temp basal starts around the same time as an extended basal, it's possible that there's no `temp_basal_start` basal rate change event generated. We have to use the `LID_TEMP_RATE_ACTIVATED` event to determine when the temp basal started, and annotate the temp basal with `tandem/basal/temp-without-rate-change`.

More detail: https://trello.com/c/ynVaskZx

@jebeck to test and review?