### PR TITLE
Using embedded bolus GUID for wizard event

### DIFF
--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -366,7 +366,8 @@ api.upload.toPlatform = function(data, sessionInfo, progress, groupId, cb, uploa
           guid: uuid.v4()
         });
       }
-      return _.extend({}, item, {
+      return _.defaults({}, item, {
+        // only add a guid if it's not already there
         guid: uuid.v4()
       });
     });

--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -20,6 +20,7 @@ var async = require('async');
 var sundial = require('sundial');
 var annotate = require('../eventAnnotations');
 var util = require('util');
+var uuid = require('node-uuid');
 
 var crcCalculator = require('../crc.js');
 var struct = require('../struct.js')();
@@ -1292,7 +1293,9 @@ module.exports = function (config) {
           .set('index', bolusdatum.index)
           .set('syncCounter', bolusdatum.sync_counter) // need these for wizard records
           .set('requiredAmount', bolusdatum.requiredAmount)
-          .set('jsDate', bolusdatum.jsDate);
+          .set('jsDate', bolusdatum.jsDate)
+          .set('guid', uuid.v4()); // we're manually adding the guid so that we can
+                                   // embed it into a wizard record if necessary
 
       cfg.tzoUtil.fillInUTCInfo(bolus, bolusdatum.jsDate);
       bolus = bolus.done();
@@ -1371,7 +1374,7 @@ module.exports = function (config) {
             correction: correction.toFixedNumber(2),
             net: net
           })
-          .with_bolus(bolusdatum)
+          .with_bolus(bolusdatum.guid)
           .with_units(wizarddatum.configuration.units)
           .with_deviceTime(bolusdatum.deviceTime)
           .with_time(bolusdatum.time)


### PR DESCRIPTION
Jellyfish used to squash embedded bolus events down into a hash ID. As the new platform API will not be doing this, we need to move where we're generating the GUID so that we can put that it in the wizard event instead of the bolus event itself.