### PR TITLE
Hard-coding number of records (resolving Animas "Invalid packet sent by pump" issue)

### DIFF
--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -272,7 +272,7 @@ module.exports = function (config) {
   var readDataPages = function (rectype, offset, numRecords) {
 
     var payload = new Uint8Array(8);
-    var payloadlength = struct.pack(payload,0,'Ssss',CMDS.RI.value,rectype.value,offset,numRecords);
+    var payloadlength = struct.pack(payload,0,'Ssss',CMDS.RI.value,rectype,offset,numRecords);
 
     return {
       packet: buildPacket(
@@ -985,11 +985,11 @@ module.exports = function (config) {
       debug('Reading',recordsPerTime,'records at a time');
       times = Math.ceil(numRecords / recordsPerTime);
       var numRecordsWithPacking = numRecords | 0x8000; //set highest bit to request packing
-      cmd = readDataPages(request.recordType,0,numRecordsWithPacking);
+      cmd = readDataPages(request.recordType.value,0,numRecordsWithPacking);
     }
     else{
       times = numRecords;
-      cmd = readDataPages(request.recordType,0,numRecords);
+      cmd = readDataPages(request.recordType.value,0,numRecords);
     }
 
 

--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -61,15 +61,16 @@ module.exports = function (config) {
 
   var RECORD_TYPES = {
     SERIALNUMBER : {value: 8, name: 'SERIAL AND MODEL NUMBER'},
-    SETTINGS: {value: 15, name: 'MISC. SETTINGS'},
-    BOLUS: {value: 21, name: 'BOLUS HISTORY'},
-    BASAL: {value: 26, name: 'BASAL HISTORY'},
-    PRIME_REWIND: {value: 24, name: 'PRIME-REWIND HISTORY'},
-    SUSPEND_RESUME: {value: 25, name: 'SUSPEND-RESUME HISTORY'},
-    WIZARD: {value: 38, name: 'WIZARD HISTORY'},
-    ALARM: {value: 23, name: 'ALARM HISTORY'},
     BASAL_PROGRAM: {value: 11, name: 'BASAL PROGRAMS'},
-    BLOOD_GLUCOSE: {value: 40, name: 'BLOOD GLUCOSE HISTORY'}
+    SETTINGS: {value: 15, name: 'MISC. SETTINGS'},
+    BOLUS: {value: 21, name: 'BOLUS HISTORY', numRecords: 500, recordSize: 16},
+    ALARM: {value: 23, name: 'ALARM HISTORY', numRecords: 30, recordSize: 16},
+    PRIME_REWIND: {value: 24, name: 'PRIME-REWIND HISTORY', numRecords: 60, recordSize: 16},
+    SUSPEND_RESUME: {value: 25, name: 'SUSPEND-RESUME HISTORY', numRecords: 30, recordSize: 16},
+    BASAL: {value: 26, name: 'BASAL HISTORY', numRecords: 270, recordSize: 16},
+    WIZARD: {value: 38, name: 'WIZARD HISTORY', numRecords: 500, recordSize: 16},
+    BLOOD_GLUCOSE: {value: 40, name: 'BLOOD GLUCOSE HISTORY (PING)', numRecords: 1000, recordSize: 16},
+    CGM_CALIBRATION: {value: 40, name: 'CGM CALIBRATION (VIBE)', numRecords: 1022, recordSize: 8},
   };
 
   var MODELS = {
@@ -271,7 +272,7 @@ module.exports = function (config) {
   var readDataPages = function (rectype, offset, numRecords) {
 
     var payload = new Uint8Array(8);
-    var payloadlength = struct.pack(payload,0,'Ssss',CMDS.RI.value,rectype,offset,numRecords);
+    var payloadlength = struct.pack(payload,0,'Ssss',CMDS.RI.value,rectype.value,offset,numRecords);
 
     return {
       packet: buildPacket(
@@ -287,7 +288,7 @@ module.exports = function (config) {
 
   var requestPrimeRewind = function() {
     return{
-      recordType: RECORD_TYPES.PRIME_REWIND.value,
+      recordType: RECORD_TYPES.PRIME_REWIND,
       parser : function (payload) {
         var dt = decodeDate(struct.unpack(payload,4,'bbbb',['monthYear','day','hour','minute']));
         return {
@@ -303,7 +304,7 @@ module.exports = function (config) {
 
   var requestSuspendResume = function() {
     return{
-      recordType: RECORD_TYPES.SUSPEND_RESUME.value,
+      recordType: RECORD_TYPES.SUSPEND_RESUME,
       parser : function (payload) {
         var suspenddt = decodeDate(struct.unpack(payload,4,'bbbb',['monthYear','day','hour','minute']));
         var resumedt = decodeDate(struct.unpack(payload,8,'bbbb',['monthYear','day','hour','minute']));
@@ -320,7 +321,7 @@ module.exports = function (config) {
 
   var requestBolus = function() {
     return{
-      recordType: RECORD_TYPES.BOLUS.value,
+      recordType: RECORD_TYPES.BOLUS,
       parser : function (payload) {
         var dt = decodeDate(struct.unpack(payload,4,'bbbb',['monthYear','day','hour','minute']));
         return {
@@ -339,7 +340,7 @@ module.exports = function (config) {
 
   var requestBasal = function() {
     return{
-      recordType: RECORD_TYPES.BASAL.value,
+      recordType: RECORD_TYPES.BASAL,
       parser : function (payload) {
         var dt = decodeDate(struct.unpack(payload,4,'bbbb',['monthYear','day','hour','minute']));
         return {
@@ -355,7 +356,7 @@ module.exports = function (config) {
 
   var requestBasalProgram = function() {
     return{
-      recordType: RECORD_TYPES.BASAL_PROGRAM.value,
+      recordType: RECORD_TYPES.BASAL_PROGRAM,
       parser : function (payload) {
         var valid = struct.extractByte(payload,4);
 
@@ -386,7 +387,7 @@ module.exports = function (config) {
 
   var requestWizard = function() {
     return{
-      recordType: RECORD_TYPES.WIZARD.value,
+      recordType: RECORD_TYPES.WIZARD,
       parser : function (payload) {
         var wizardConfig = getWizardConfig(struct.extractByte(payload,15));
         return {
@@ -407,7 +408,7 @@ module.exports = function (config) {
 
   var requestAlarm = function() {
     return{
-      recordType: RECORD_TYPES.ALARM.value,
+      recordType: RECORD_TYPES.ALARM,
       parser : function (payload) {
         var dt = decodeDate(struct.unpack(payload,4,'bbbb',['monthYear','day','hour','minute']));
         return {
@@ -424,7 +425,7 @@ module.exports = function (config) {
   var requestBG = function() {
     //TODO: on Vibe these will be CGM calibration records
     return{
-      recordType: RECORD_TYPES.BLOOD_GLUCOSE.value,
+      recordType: RECORD_TYPES.BLOOD_GLUCOSE,
       parser : function (payload) {
         var BASE_TIME = Date.UTC(2000, 0, 1, 0, 0, 0).valueOf();
         var bytes = struct.extractBytes(payload,8,3);
@@ -881,53 +882,6 @@ module.exports = function (config) {
           cb(null, data);
         }
       });
-  };
-
-  var getNumberOfRecords = function(rectype, cb) {
-    var cmd = readDataPages(rectype,0,0);
-
-    var setData = function(result) {
-      var data = {
-        numRecords : struct.extractShort(result.payload,2),
-        recordSize: struct.extractShort(result.payload,4)
-      };
-      return data;
-    };
-
-    animasCommandResponseAck(cmd, function (err, result) {
-      if (err) {
-        cb(err, null);
-      } else {
-        if(result.payload.length !== 6) {
-          debug('Resetting and retrying to get number of records..');
-          resetConnection(true, function(connectErr, obj) {
-            if(connectErr) {
-              cb(connectErr, obj);
-            }else{
-              sendAck(true, function (err, result) {
-                if(err) {
-                  return cb(err, null);
-                }
-                else{
-                  animasCommandResponseAck(cmd, function (errRetry, resultRetry) {
-                    if (errRetry) {
-                      cb(err, null);
-                    } else {
-                      if(resultRetry.payload.length !== 6) {
-                        return cb(new Error('Invalid packet sent by pump'),null);
-                      }
-                      cb(null,setData(resultRetry));
-                    }
-                  });
-                }
-              });
-            }
-          });
-        } else {
-          cb(null,setData(result));
-        }
-      }
-    });
   };
 
   var getBolusType = function(byte) {
@@ -1566,13 +1520,13 @@ module.exports = function (config) {
         return records;
       };
 
-      var readRecords = function (recordType, request, percentage, numResult, callback) {
+      var readRecords = function (request, percentage, callback) {
 
-        debug('Number of',_getName(RECORD_TYPES, recordType),'records:',numResult);
-        var numRecords = numResult.numRecords;
-        var recordSize = numResult.recordSize;
+        var numRecords = request.recordType.numRecords;
+        var recordSize = request.recordType.recordSize;
+        debug('Number of',request.recordType.name,'records:',numRecords);
 
-        if (recordType === RECORD_TYPES.BASAL_PROGRAM.value) {
+        if (request.recordType.value === RECORD_TYPES.BASAL_PROGRAM.value) {
           debug('Reading basal schedules');
           // TODO: read basal schedules when set to 4 instead of just 1
           // pump does not respond in the same way as with other records :(
@@ -1622,40 +1576,21 @@ module.exports = function (config) {
         });
       };
 
-      var readAllRecords = function (recordType, request, percentage, callback) {
+      var readAllRecords = function (request, percentage, callback) {
         resetConnection(true, function(connectErr, obj) {
           if(connectErr) {
             cb(connectErr, obj);
           }else{
             counters.received = 0;
             counters.sent = 0;
-            getNumberOfRecords(recordType, function (err, result) {
-              if(err) {
-                debug('Resetting and trying again..');
-                resetConnection(true, function(connectErr, obj) {
-                  if(connectErr) {
-                    return cb(connectErr, null);
-                  }else{
-                    getNumberOfRecords(recordType, function (err2, result2) {
-                      if(err2) {
-                        return cb(err2,null);
-                      } else {
-                        readRecords(recordType, request, percentage, result2, callback);
-                      }
-                    });
-                  }
-                });
-              }else{
-                readRecords(recordType, request, percentage, result, callback);
-              }
-            });
+            readRecords(request, percentage, callback);
           }
         });
       };
 
       async.series({
         bolusRecords : function(callback){
-          readAllRecords(RECORD_TYPES.BOLUS.value, requestBolus(), 10, function(err, data) {
+          readAllRecords(requestBolus(), 10, function(err, data) {
             if(err) {
               return callback(err,null);
             }
@@ -1665,7 +1600,7 @@ module.exports = function (config) {
           });
         },
         basalRecords: function(callback){
-          readAllRecords(RECORD_TYPES.BASAL.value, requestBasal(), 20, function(err, data) {
+          readAllRecords(requestBasal(), 20, function(err, data) {
             if(err) {
               return callback(err,null);
             }
@@ -1675,7 +1610,7 @@ module.exports = function (config) {
           });
         },
         primeRewindRecords: function(callback){
-          readAllRecords(RECORD_TYPES.PRIME_REWIND.value, requestPrimeRewind(), 30, function(err, data) {
+          readAllRecords(requestPrimeRewind(), 30, function(err, data) {
             if(err) {
               return callback(err,null);
             }
@@ -1685,7 +1620,7 @@ module.exports = function (config) {
           });
         },
         suspendResumeRecords: function(callback){
-          readAllRecords(RECORD_TYPES.SUSPEND_RESUME.value, requestSuspendResume(), 40, function(err, data) {
+          readAllRecords(requestSuspendResume(), 40, function(err, data) {
             if(err) {
               return callback(err,null);
             }
@@ -1695,7 +1630,7 @@ module.exports = function (config) {
           });
         },
         wizardRecords: function(callback){
-          readAllRecords(RECORD_TYPES.WIZARD.value, requestWizard(), 50, function(err, data) {
+          readAllRecords(requestWizard(), 50, function(err, data) {
             if(err) {
               return callback(err,null);
             }
@@ -1705,7 +1640,7 @@ module.exports = function (config) {
           });
         },
         alarmRecords: function(callback){
-          readAllRecords(RECORD_TYPES.ALARM.value, requestAlarm(), 60, function(err, data) {
+          readAllRecords(requestAlarm(), 60, function(err, data) {
             if(err) {
               return callback(err,null);
             }
@@ -1728,7 +1663,7 @@ module.exports = function (config) {
         */
         bgRecords: function(callback){
           if(modelNumber === 'IR1285') {
-            readAllRecords(RECORD_TYPES.BLOOD_GLUCOSE.value, requestBG(), 80, function(err, data) {
+            readAllRecords(requestBG(), 80, function(err, data) {
               if(err) {
                 return callback(err,null);
               }


### PR DESCRIPTION
When Uploader requests the number of records from the Animas pump, the pump sometimes responds with something completely different. Even if Uploader retries and resets the connection about 10 times, it still gets an unexpected response, so it seems the pump goes into some weird state that it only gets out of if you disconnect/reconnect (which is not possible to do automatically because of the screen timeout issue).

As the spec provides the number of records for each record type, we now hard-code these instead (taking into account that they differ between Ping and Vibe for the BG/CGM calibration record type).

@darinkrauss, will you be able to review and test to see if it resolves your "Invalid packet" issue? I'm attaching a [dist.zip](https://github.com/tidepool-org/chrome-uploader/files/259326/dist.zip) (v0.260.2) that you can manually load as an unpacked extension.
