### PR TITLE
Using USB product ID and vendor ID (PID/VID) to find device (on Chrome 50+)

### DIFF
--- a/lib/core/device.js
+++ b/lib/core/device.js
@@ -277,28 +277,25 @@ device.detectUsb = function(driverId, cb) {
     var chromeVersion = /Chrome\/([0-9]+)/.exec(navigator.userAgent)[1];
     self.log('Chrome version detected as', chromeVersion);
 
-    if (chromeVersion >= 50) {
-      chrome.serial.getDevices(function(results) {
+    chrome.serial.getDevices(function(results) {
+      if (chromeVersion >= 50) {
         // As of Chrome 50, product ID and vendor ID is returned
         // on Windows (only) for serial.getDevices
         results = _.filter(results, function(p) {
           return (p.vendorId === driverManifest.vendorId) &&
           (p.productId === driverManifest.productId);
         });
-
-        getDevice(results);
-      });
-    }
-    else {
-      // this is the hotfix for Windows Chrome 49 and earlier
-      chrome.serial.getDevices(function(results) {
+      }
+      else{
+        // With Chrome 49 and earlier, there may be
+        // multiple connected devices
         self.log('Connected device(s): ');
         for(var i in results) {
             self.log(results[i].path);
         }
-        getDevice(results);
-      });
-    }
+      }
+      getDevice(results);
+    });
   }
   else {
     chrome.usb.getDevices(identification, function(results) {

--- a/lib/core/device.js
+++ b/lib/core/device.js
@@ -281,6 +281,7 @@ device.detectUsb = function(driverId, cb) {
       if (chromeVersion >= 50) {
         // As of Chrome 50, product ID and vendor ID is returned
         // on Windows (only) for serial.getDevices
+        // Chromium bug report: https://bugs.chromium.org/p/chromium/issues/detail?id=599101
         results = _.filter(results, function(p) {
           return (p.vendorId === driverManifest.vendorId) &&
           (p.productId === driverManifest.productId);

--- a/lib/core/device.js
+++ b/lib/core/device.js
@@ -232,11 +232,8 @@ device.detectUsb = function(driverId, cb) {
     vendorId: driverManifest.vendorId,
     productId: driverManifest.productId
   };
-  chrome.serial.getDevices(function(results) {
-    self.log('Connected device(s): ');
-    for(var i in results) {
-        self.log(results[i].path);
-    }
+
+  var getDevice = function(results) {
     var devices = _.map(results, function(result) {
       var retval = {
         driverId: driverId,
@@ -274,7 +271,42 @@ device.detectUsb = function(driverId, cb) {
       device.othersConnected = devices.length - 1;
     }
     return cb(null, devdata);
-  });
+  };
+
+  var chromeVersion = /Chrome\/([0-9]+)/.exec(navigator.userAgent)[1];
+  self.log('Chrome version detected as', chromeVersion);
+  if (chromeVersion >= 50) {
+    if (self._os === 'win') {
+      chrome.serial.getDevices(function(results) {
+        // As of Chrome 50, product ID and vendor ID is returned
+        // on Windows (only) for serial.getDevices
+        results = _.filter(results, function(p) {
+          return (p.vendorId === driverManifest.vendorId) &&
+          (p.productId === driverManifest.productId);
+        });
+
+        getDevice(results);
+      });
+    }
+    else {
+      chrome.usb.getDevices(identification, function(results) {
+        // this is the way it *should* work, with filtering done by
+        // usb.getDevices, but it is not working on Windows
+        getDevice(results);
+      });
+    }
+  }
+  else {
+    chrome.serial.getDevices(function(results) {
+      self.log('Connected device(s): ');
+      for(var i in results) {
+          self.log(results[i].path);
+      }
+      getDevice(results);
+    });
+  }
+
+
 };
 
 

--- a/lib/core/device.js
+++ b/lib/core/device.js
@@ -273,10 +273,11 @@ device.detectUsb = function(driverId, cb) {
     return cb(null, devdata);
   };
 
-  var chromeVersion = /Chrome\/([0-9]+)/.exec(navigator.userAgent)[1];
-  self.log('Chrome version detected as', chromeVersion);
-  if (chromeVersion >= 50) {
-    if (self._os === 'win') {
+  if (self._os === 'win') {
+    var chromeVersion = /Chrome\/([0-9]+)/.exec(navigator.userAgent)[1];
+    self.log('Chrome version detected as', chromeVersion);
+
+    if (chromeVersion >= 50) {
       chrome.serial.getDevices(function(results) {
         // As of Chrome 50, product ID and vendor ID is returned
         // on Windows (only) for serial.getDevices
@@ -289,24 +290,23 @@ device.detectUsb = function(driverId, cb) {
       });
     }
     else {
-      chrome.usb.getDevices(identification, function(results) {
-        // this is the way it *should* work, with filtering done by
-        // usb.getDevices, but it is not working on Windows
+      // this is the hotfix for Windows Chrome 49 and earlier
+      chrome.serial.getDevices(function(results) {
+        self.log('Connected device(s): ');
+        for(var i in results) {
+            self.log(results[i].path);
+        }
         getDevice(results);
       });
     }
   }
   else {
-    chrome.serial.getDevices(function(results) {
-      self.log('Connected device(s): ');
-      for(var i in results) {
-          self.log(results[i].path);
-      }
+    chrome.usb.getDevices(identification, function(results) {
+      // this is the way it *should* work, with filtering done by
+      // usb.getDevices, but it is not working on Windows
       getDevice(results);
     });
   }
-
-
 };
 
 


### PR DESCRIPTION
A regression in Google Chrome 45 has now partially been fixed in Chrome 50. 

How it used to work: We pass the USB PID/VID to `chrome.usb.getDevices`, and only get back the devices that match that combo

What broke and the hotfix: Windows doesn't return any serial devices, so we removed the PID/VID filter and returned all serial devices.

How it's fixed now in this PR: On Windows Chrome 50+, `chrome.serial.getDevices` now returns the PID/VID combo as well, so we can use this to filter ourselves. OS X does not return the PID/VID combo, so we use `chrome.usb.getDevices` on Mac.