### PR TITLE
Tandem bug fix: Handling events around a pump shutdown 

### DIFF
--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -1547,8 +1547,14 @@ module.exports = function (config) {
           .with_expectedExtended(bolus.bolex_insulin_requested);
       }
       record = record.set('index', bolus.index);
-      cfg.tzoUtil.fillInUTCInfo(record, bolus.jsDate);
-      records.push(record.done());
+
+      if(record.subType === 'normal' && bolus.insulin_delivered === undefined) {
+        debug('Only part of a bolus received, dropping:', bolus);
+      }
+      else{
+        cfg.tzoUtil.fillInUTCInfo(record, bolus.jsDate);
+        records.push(record.done());
+      }
 
       // wizard records
       if (_.includes(['standard', 'extended'], bolus.bolus_option) &&
@@ -1709,6 +1715,14 @@ module.exports = function (config) {
 
     for (var b = 0; b < newDayRecords.length; ++b) {
       var event = newDayRecords[b];
+
+      var nextEvent = data.log_records[data.log_records.indexOf(event) + 1 ];
+      if( nextEvent.header_id === PUMP_LOG_RECORDS.LID_TIME_CHANGED.value ||
+          nextEvent.header_id === PUMP_LOG_RECORDS.LID_DATE_CHANGED.value) {
+            debug('Dropping new-day event (',event.deviceTime,') followed by date/time change (', nextEvent.deviceTime,')');
+            continue;
+      };
+
       var rate = event.commanded_basal_rate;
       if ((rate !== null) && (rate > 0)) {
         // new day event; breaks up flat-rate basals

--- a/lib/tandem/tandemSimulator.js
+++ b/lib/tandem/tandemSimulator.js
@@ -166,11 +166,17 @@ exports.make = function(config){
 
           if (currBasal.deliveryType === 'temp') {
             if(!currBasal.isAssigned('duration')) {
-              if(currTempBasal && currTempBasal.time_left) {
-                // temp basal was cancelled
-                currBasal.duration = currTempBasal.duration - currTempBasal.time_left;
-              }else{
-                currBasal.duration = currTempBasal.duration;
+              if(currTempBasal != null) {
+                if (currTempBasal.time_left) {
+                  // temp basal was cancelled
+                  currBasal.duration = currTempBasal.duration - currTempBasal.time_left;
+                }else{
+                  currBasal.duration = currTempBasal.duration;
+                }
+              }
+              else {
+                currBasal.duration = 0;
+                annotate.annotateEvent(currBasal, 'basal/unknown-duration');
               }
             }
             currBasal = currBasal.done();


### PR DESCRIPTION
If a pump shutdown occurs and the clock is set back to 2008 it can cause unexpected issues. For those we've been able to reproduce, this PR does two things:

- Drops a normal bolus if it's incomplete because the start event is missing due to a time change
- Drops a new-day event if it is immediately followed by a time-change event. (We use new-day events to fabricate scheduled basals in order to break up flat-rate basals. They can occur after you switch the pump back on, but before you change the date from 2008 to the correct time, which means we fabricate a scheduled basal in 2024.) 

Ping @jh-bate for review.