### PR TITLE
Do not send byUser in upload record to new platform

### DIFF
--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -392,7 +392,6 @@ api.upload.toPlatform = function(data, sessionInfo, progress, groupId, cb, uploa
         .with_timeProcessing(sessionInfo.timeProcessing)
         .with_version(sessionInfo.version)
         .with_source(sessionInfo.source)
-        .with_byUser(tidepool.getUserId())
         .with_deviceTags(sessionInfo.deviceTags)
         .with_deviceManufacturers(sessionInfo.deviceManufacturers)
         .with_deviceModel(sessionInfo.deviceModel)
@@ -403,6 +402,7 @@ api.upload.toPlatform = function(data, sessionInfo, progress, groupId, cb, uploa
       if(uploadType === 'jellyfish') {
         uploadItem.with_uploadId('upid_' + md5(sessionInfo.deviceId + '_' + sessionInfo.start).slice(0, 12));
         uploadItem.with_guid(uuid.v4());
+        uploadItem.with_byUser(tidepool.getUserId());
       }
       uploadItem = uploadItem.done();
 

--- a/lib/objectBuilder.js
+++ b/lib/objectBuilder.js
@@ -458,7 +458,7 @@ module.exports = function () {
       version: REQUIRED,
       guid: OPTIONAL,
       uploadId: OPTIONAL,
-      byUser: REQUIRED,
+      byUser: OPTIONAL,
       deviceTags: REQUIRED,
       deviceManufacturers: REQUIRED,
       deviceModel: REQUIRED,

--- a/test/node/testObjectBuilder.js
+++ b/test/node/testObjectBuilder.js
@@ -635,7 +635,7 @@ describe('objectBuilder.js', function(){
       expect(upload.timezone).to.equal(REQUIRED);
       expect(upload.guid).to.equal(OPTIONAL);
       expect(upload.uploadId).to.equal(OPTIONAL);
-      expect(upload.byUser).to.equal(REQUIRED);
+      expect(upload.byUser).to.equal(OPTIONAL);
       expect(upload.deviceTags).to.equal(REQUIRED);
       expect(upload.deviceManufacturers).to.equal(REQUIRED);
       expect(upload.deviceModel).to.equal(REQUIRED);


### PR DESCRIPTION
@gniezen The platform sets this programmatically based upon the session token user (or will after I deploy the latest code).