### PR TITLE
Tandem multi-record issue

### DIFF
--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -18,6 +18,7 @@
 /* globals __DEBUG__ */
 
 var _ = require('lodash');
+var async = require('async');
 var struct = require('./../struct.js')();
 var sundial = require('sundial');
 
@@ -999,9 +1000,9 @@ module.exports = function (config) {
     }, INTERVAL_FREQ); // if we spin too quickly on this, packets don't get sent when window doesn't have focus
   };
 
-  var multiLogRequester = function (start, end, progress, callback) {
+  var multiLogRequester = function (start, howMany, progress, callback) {
     if (__DEBUG__) {
-      debug('multiLogRequester', start, end);
+      debug('multiLogRequester', start, howMany);
       var startExec = Date.now();
     }
     var sendSeq = start;
@@ -1010,8 +1011,9 @@ module.exports = function (config) {
     var prevPercentage = 0;
 
     var retryTimeout = function() {
-      debug('Retrying from record ', receiveSeq, ' onwards.', end-receiveSeq, ' record(s) left..');
-      tandemCommand(COMMANDS.LOG_ENTRY_SEQ_MULTI_REQ, [receiveSeq,end-receiveSeq+1], function (err) {
+      var recordsLeft = howMany+start-receiveSeq+1;
+      debug('Retrying from record ', receiveSeq, ' onwards.', recordsLeft, ' record(s) left..');
+      tandemCommand(COMMANDS.LOG_ENTRY_SEQ_MULTI_REQ, [receiveSeq,recordsLeft], function (err) {
         if(err) {
           callback(err,null);
         }
@@ -1019,9 +1021,8 @@ module.exports = function (config) {
     };
     var retryTimer = setTimeout(retryTimeout, RETRY_TIMEOUT);
 
-    tandemCommand(COMMANDS.LOG_ENTRY_SEQ_MULTI_REQ, [sendSeq, end-sendSeq+1], function (err) {
-      // second parameter is number of records to retrieve, which is the difference between
-      // the start and end indexes plus one
+    tandemCommand(COMMANDS.LOG_ENTRY_SEQ_MULTI_REQ, [sendSeq, howMany+1], function (err) {
+      // second parameter is number of records to retrieve, plus one to include last record
       if(err) {
         callback(err,null);
       }
@@ -1036,14 +1037,15 @@ module.exports = function (config) {
                 pkt.descriptor === RESPONSES.LOG_ENTRY_TE.value &&
                 pkt.payload['header_log_seq_no'] >= receiveSeq) {
                 if (receiveSeq != pkt.payload['header_log_seq_no']) {
-                  debug('Packet out of sequence');
+                  debug('Packet out of sequence:',pkt);
                 }
                 else {
                   clearTimeout(retryTimer);
                   retryTimer = setTimeout(retryTimeout,RETRY_TIMEOUT); // reset timeout
-                  receiveSeq = pkt.payload['header_log_seq_no'] + 1;
+                  receiveSeq = pkt.payload['header_log_seq_no'];
 
-                  percentage = ((receiveSeq-start)/(end-start) * 90)+10;
+
+                  percentage = ((receiveSeq-start)/howMany * 90)+10;
                   if(percentage > (prevPercentage+1)) {
                     // only update progress to UI if there's an increase of at least 1 percent
                     prevPercentage = percentage;
@@ -1051,9 +1053,9 @@ module.exports = function (config) {
                   }
 
                   if (receiveSeq % 1000 === 0) {
-                    debug('received ', receiveSeq, ' of ', end);
+                    debug('received ', receiveSeq, ' of ', start+howMany);
                   }
-                  if (receiveSeq > end) {
+                  if ((receiveSeq-start) >= howMany) {
                     if (__DEBUG__) {
                       var endExec = Date.now();
                       var time = endExec - startExec;
@@ -1063,6 +1065,7 @@ module.exports = function (config) {
                     clearTimeout(retryTimer);
                     clearInterval(listenTimer);
                   }
+                  receiveSeq += 1;
                   callback(null, pkt);
                 }
               } else {
@@ -1233,8 +1236,57 @@ module.exports = function (config) {
         if (result.payload.header_log_seq_no === end_seq) {
           debug('fetched all records');
           data.log_records = retval;
+          callback(null, data);
+        }
+      }
+    }
 
-          if(data.firmware_version >= COMMANDS.LOG_ENTRY_SEQ_MULTI_STOP_DUMP.version)
+    end_seq = data.end_seq;
+    start_seq = data.start_seq;
+    debug('Firmware version is #',data.firmware_version);
+
+    if(data.firmware_version >= COMMANDS.LOG_ENTRY_SEQ_MULTI_REQ.version) {
+      // woohoo, we can use multi-record downloads!
+      var MAX_RECORDS = 7000;
+      var numRequests = Math.ceil((end_seq-start_seq) / MAX_RECORDS);
+      var count = 0;
+      var begin = null;
+      var howMany = MAX_RECORDS;
+
+      async.whilst(
+        function () { return count < numRequests; },
+        function (cb) {
+          begin = start_seq+(count * MAX_RECORDS);
+
+          if( (end_seq - begin) < MAX_RECORDS) {
+            howMany = end_seq - begin;
+          }
+
+          console.log('Reading from', begin, 'to', begin+howMany, '...');
+          multiLogRequester(begin, howMany, progress, function(err, result) {
+            if (err) {
+              debug('error retrieving record ', result);
+              cb(err, null);
+            }
+            else {
+              if (!result.payload.tdeps) {
+                retval.push(result.payload);
+              }
+              if (result.payload.header_log_seq_no === end_seq ||
+                result.payload.header_log_seq_no === (begin + howMany)) {
+                count++;
+                cb(null,count);
+              }
+            }
+          });
+        },
+        function (err, n) {
+          debug('fetched all records');
+          data.log_records = retval;
+          if (err) {
+            return callback(err, null);
+          }
+          else {
             tandemCommand(COMMANDS.LOG_ENTRY_SEQ_MULTI_STOP_DUMP, null, function (err) {
               if(err) {
                 callback(err,null);
@@ -1243,19 +1295,9 @@ module.exports = function (config) {
                 callback(null,data);
               }
             });
-          else {
-            callback(null, data);
           }
         }
-      }
-    }
-
-    end_seq = data.end_seq;
-    start_seq = data.start_seq;
-    debug('Firmware version is #',data.firmware_version);
-    if(data.firmware_version >= COMMANDS.LOG_ENTRY_SEQ_MULTI_REQ.version) {
-      // woohoo, we can use multi-record downloads!
-      multiLogRequester(start_seq, end_seq, progress, iterate);
+      );
     }
     else{
       tandemLogRequester(start_seq, end_seq, progress, iterate);

--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -1065,6 +1065,8 @@ module.exports = function (config) {
                   }
                   callback(null, pkt);
                 }
+              } else {
+                console.log('Invalid packet:', pkt);
               }
             };
             processPacket(cfg.deviceComms.nextPacket());


### PR DESCRIPTION
It's possible that's there a max limit on how many records can be read with a multi-record request, even though this is not mentioned in the spec. This PR reads 7000 records at a time.

@jebeck, will you please check if it resolves the issue at all, and then review?