### PR TITLE
Animas bug fix: Final basal when rate not yet zero after suspend

### DIFF
--- a/lib/animas/animasSimulator.js
+++ b/lib/animas/animasSimulator.js
@@ -153,7 +153,7 @@ exports.make = function(config){
           // categorize the basal we're processing as a suspend basal if its rate
           // is zero and its start falls within the suspend event we have on deck
           var resumed = Date.parse(currStatus.time) + currStatus.duration;
-          if (resumed > Date.parse(event.time)) {
+          if (resumed >= Date.parse(event.time)) {
             //this basal is suspended
             event.deliveryType = 'suspend';
             delete event.rate;
@@ -178,6 +178,14 @@ exports.make = function(config){
       setCurrBasal(event);
       markIfBasalSuspendedByAlarm(lastAlarm,event);
 
+    },
+    finalBasal: function() {
+      if(currBasal != null && currBasal.rate !== 0 && currStatus.status === 'suspended') {
+        //basal rate has not yet changed to zero after final suspend event
+        currBasal.with_duration(Date.parse(currStatus.time) - Date.parse(currBasal.time));
+        currBasal = currBasal.done();
+        events.push(currBasal);
+      }
     },
     bolus: function(event) {
       delete event.syncCounter; //wizard events already synced up

--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -2085,6 +2085,7 @@ module.exports = function (config) {
             debug('[Hand-off to simulator] Unhandled type!', datum.type);
         }
       }
+      simulator.finalBasal();
 
       console.log('getEvents:',simulator.getEvents());
 


### PR DESCRIPTION
Fixes an edge case where at the time of upload the basal rate hasn't changed to zero yet. (It takes up to three minutes for the basal rate to change after a command is issued on the pump). 

This PR calculates the duration of the final basal based on the time of the suspend event, so that it can be displayed.