### PR TITLE
Animas bug fix: Some uploads stalling at 40%

### DIFF
--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -154,6 +154,8 @@ module.exports = function (config) {
   var modelNumber = null;
   var hasConfigInfo = false;
 
+  var prevPayload = {};
+
   var bytes2hex = function(bytes) {
     var message = '';
     for(var i in bytes) {
@@ -1251,7 +1253,6 @@ module.exports = function (config) {
         // sometimes, the same record is returned twice, so we have to check
         // the record index until we know we're at the last one
         var datum = {index:-1};
-        var prevPayload = {};
 
         async.whilst(function () { return datum.index+1 < numRecords; }, function(next){
 
@@ -1741,6 +1742,7 @@ module.exports = function (config) {
     // the result (data) object; it's then passed down the rest of the chain
     setup: function (deviceInfo, progress, cb) {
       debug('STEP: setup');
+      prevPayload = {};
       progress(100);
       cb(null, {deviceInfo: deviceInfo});
     },

--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -1220,6 +1220,9 @@ module.exports = function (config) {
     var year = (encoded.monthYear & 0x0f) + startYear;
     var month = (encoded.monthYear >> 4); // January = 0
     var date = sundial.buildTimestamp({year:year,month:month+1,day:encoded.day,hours:encoded.hour,minutes:encoded.minute,seconds:0});
+    if(!date) {
+      throw new Error('Could not read data from pump. Please retry.');
+    }
     return date;
   };
 
@@ -1278,7 +1281,11 @@ module.exports = function (config) {
               if (!_.isEqual(payload,prevPayload)) { // check that it's not duplicate
                 prevPayload = payload;
                 while (payload.length > 4) {
-                  datum = request.parser(payload);
+                  try {
+                    datum = request.parser(payload);
+                  } catch(err) {
+                    return cb(err,null);
+                  }
                   datum.empty = checkEmpty(payload);
                   datum.index = index;
                   console.log('Datum:', datum);
@@ -1306,7 +1313,11 @@ module.exports = function (config) {
               });
             }
             else {
-              datum = request.parser(payload);
+              try {
+                datum = request.parser(payload);
+              } catch(err) {
+                return cb(err,null);
+              }
               datum.empty = checkEmpty(payload);
               console.log('Datum:', datum);
 


### PR DESCRIPTION
During alpha testing some uploads are stalling at 40%. This is caused by an uncaught error where we are trying to parse a duplicate (empty) packet. This PR:

- makes sure we catch these errors and return them in the UI
- checks for duplicate packets across different requests, not only in each request
