### PR TITLE
Redux mock store updates

### DIFF
--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -94,6 +94,14 @@ api.makeBlipUrl = function(tail) {
 
 api.user = {};
 
+api.user.initializationInfo = function(cb){
+  async.series([
+    api.user.account,
+    api.user.loggedInProfile,
+    api.user.getUploadGroups
+  ], cb);
+};
+
 api.user.login = function(user, options, cb) {
   api.log('POST /auth/login');
 

--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -115,7 +115,7 @@ api.user.login = function(user, options, cb) {
 
 api.user.loginExtended = function(user, options, cb){
   async.series([
-    api.user.login(user, options),
+    api.user.login.bind(null, user, options),
     api.user.loggedInProfile,
     api.user.getUploadGroups
   ], cb);

--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -161,12 +161,12 @@ api.user.updateProfile = function(userId, updates, cb){
     if(err){
       return cb(err);
     }
-    var patient = _.get(profile, 'patient', {});
-    var patient_updates = _.get(updates, 'patient', {});
-    var new_patient = _.assign(patient, patient_updates);
-    var new_profile = _.merge(profile, updates);
-    new_profile.patient = new_patient;
-    return api.user.addProfile(userId, new_profile, cb);
+    var newProfile = _.merge(profile, updates, function(original, update){
+      if (_.isArray(original)) {
+        return update;
+      }
+    });
+    return api.user.addProfile(userId, newProfile, cb);
   });
 };
 

--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -33,6 +33,7 @@ var errorText = require('../redux/constants/errors');
 var log = isChromeApp ? bows('Api') : console.log;
 var builder = require('../objectBuilder')();
 var localStore = require('./localStore');
+var actionUtils = require('../redux/actions/utils');
 
 // for cli tools running in node
 if (typeof localStore === 'function') {
@@ -161,11 +162,7 @@ api.user.updateProfile = function(userId, updates, cb){
     if(err){
       return cb(err);
     }
-    var newProfile = _.merge(profile, updates, function(original, update){
-      if (_.isArray(original)) {
-        return update;
-      }
-    });
+    var newProfile = actionUtils.mergeProfileUpdates(profile, updates);
     return api.user.addProfile(userId, newProfile, cb);
   });
 };

--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -113,6 +113,14 @@ api.user.login = function(user, options, cb) {
   });
 };
 
+api.user.loginExtended = function(user, options, cb){
+  async.series([
+    api.user.login(user, options),
+    api.user.loggedInProfile,
+    api.user.getUploadGroups
+  ], cb);
+};
+
 api.user.account = function(cb) {
   api.log('GET /auth/user');
   tidepool.getCurrentUser(cb);

--- a/lib/redux/actions/async.js
+++ b/lib/redux/actions/async.js
@@ -431,19 +431,27 @@ export function doVersionCheck() {
 
 export function setTargetTimezone(userId, timezoneName) {
   return (dispatch, getState) => {
+    const { allUsers } = getState();
     const { api } = services;
     dispatch(syncActions.updateProfileRequest());
-    api.user.updateProfile(userId, {
+    let updates = {
       patient: {
         targetTimezone: timezoneName
       }
-    }, (err, profile) => {
+    };
+    api.user.updateProfile(userId, updates, (err, profile) => {
       // suppress unauthorized error until custodial vs normal permissions are ironed out
       // TODO: remove conditional when perms are finalized or accounts are converted
       if(err && _.get(err,'status') !== 401){
         dispatch(syncActions.updateProfileFailure(err));
       } else {
-        dispatch(syncActions.updateProfileSuccess());
+        let profile = allUsers[userId];
+        let patient = _.get(profile, 'patient', {});
+        let patient_updates = _.get(updates, 'patient', {});
+        let new_patient = _.assign(profile.patient, patient_updates);
+        let new_profile = _.merge(profile, updates);
+        new_profile.patient = new_patient;
+        dispatch(syncActions.updateProfileSuccess(new_profile, userId));
       }
       return dispatch(syncActions.setTargetTimezone(userId, timezoneName));
     });
@@ -452,21 +460,28 @@ export function setTargetTimezone(userId, timezoneName) {
 
 export function clickDeviceSelectionDone() {
   return (dispatch, getState) => {
-    const { targetDevices, uploadTargetUser } = getState();
+    const { targetDevices, uploadTargetUser, allUsers } = getState();
     const { api } = services;
     dispatch(syncActions.updateProfileRequest());
     if (!_.isEmpty(targetDevices[uploadTargetUser])) {
-      api.user.updateProfile(uploadTargetUser, {
+      let updates = {
         patient: {
           targetDevices: targetDevices[uploadTargetUser]
         }
-      }, (err, profile) => {
+      };
+      api.user.updateProfile(uploadTargetUser, updates, (err, profile) => {
         // suppress unauthorized error until custodial vs normal permissions are ironed out
         // TODO: remove conditional when perms are finalized or accounts are converted
         if(err && _.get(err,'status') !== 401){
           dispatch(syncActions.updateProfileFailure(err));
         } else {
-          dispatch(syncActions.updateProfileSuccess());
+          let profile = allUsers[uploadTargetUser];
+          let patient = _.get(profile, 'patient', {});
+          let patient_updates = _.get(updates, 'patient', {});
+          let new_patient = _.assign(profile.patient, patient_updates);
+          let new_profile = _.merge(profile, updates);
+          new_profile.patient = new_patient;
+          dispatch(syncActions.updateProfileSuccess(new_profile, uploadTargetUser));
         }
         return dispatch(syncActions.setPage(pages.MAIN));
       });
@@ -482,27 +497,20 @@ export function clickEditUserNext(profile) {
       dispatch(syncActions.updateProfileRequest());
       api.user.updateProfile(uploadTargetUser, profile, (err, profile) => {
         if (err) {
-          dispatch(syncActions.updateProfileFailure(err));
+          return dispatch(syncActions.updateProfileFailure(err));
         } else {
-          dispatch(syncActions.updateProfileSuccess());
-          async.series([
-            api.user.account,
-            api.user.loggedInProfile,
-            api.user.getUploadGroups
-          ], (err, results) => {
-            dispatch(syncActions.setAllUsers(results[0],results[1],results[2]));
-            const { targetDevices, devices, allUsers, loggedInUser } = getState();
-            const targetedDevices = _.get(targetDevices, uploadTargetUser, []);
-            const supportedDeviceKeys = Object.keys(devices);
-            const atLeastOneDeviceSupportedOnSystem = _.some(targetedDevices, (key) => {
-              return _.includes(supportedDeviceKeys, key);
-            });
-            if (_.isEmpty(targetedDevices) || !atLeastOneDeviceSupportedOnSystem) {
-              return dispatch(syncActions.setPage(pages.SETTINGS));
-            } else {
-              return dispatch(syncActions.setPage(pages.MAIN));
-            }
+          dispatch(syncActions.updateProfileSuccess(profile, uploadTargetUser));
+          const { targetDevices, devices, allUsers, loggedInUser } = getState();
+          const targetedDevices = _.get(targetDevices, uploadTargetUser, []);
+          const supportedDeviceKeys = Object.keys(devices);
+          const atLeastOneDeviceSupportedOnSystem = _.some(targetedDevices, (key) => {
+            return _.includes(supportedDeviceKeys, key);
           });
+          if (_.isEmpty(targetedDevices) || !atLeastOneDeviceSupportedOnSystem) {
+            return dispatch(syncActions.setPage(pages.SETTINGS));
+          } else {
+            return dispatch(syncActions.setPage(pages.MAIN));
+          }
         }
       });
     }
@@ -526,7 +534,7 @@ export function retrieveTargetsFromStorage() {
       dispatch(syncActions.setUsersTargets(targets));
     }
 
-    const { targetDevices, targetTimezones } = getState();
+    const { targetDevices, targetTimezones, allUsers } = getState();
 
     // redirect based on having a supported device
     if (!_.isEmpty(_.get(targetDevices, uploadTargetUser))) {
@@ -556,18 +564,25 @@ export function retrieveTargetsFromStorage() {
       } else {
         if (!_.isEmpty(targetDevices[uploadTargetUser]) && !_.isEmpty(targetTimezones[uploadTargetUser])) {
           dispatch(syncActions.updateProfileRequest());
-          api.user.updateProfile(uploadTargetUser, {
+          const updates = {
             patient: {
               targetDevices: targetDevices[uploadTargetUser],
               targetTimezone: targetTimezones[uploadTargetUser]
             }
-          }, (err, profile) => {
+          };
+          api.user.updateProfile(uploadTargetUser, updates, (err, profile) => {
             // suppress unauthorized error until custodial vs normal permissions are ironed out
             // TODO: remove conditional when perms are finalized or accounts are converted
             if(err && _.get(err,'status') !== 401){
               dispatch(syncActions.updateProfileFailure(err));
             } else {
-              dispatch(syncActions.updateProfileSuccess());
+              let profile = allUsers[uploadTargetUser];
+              let patient = _.get(profile, 'patient', {});
+              let patient_updates = _.get(updates, 'patient', {});
+              let new_patient = _.assign(profile.patient, patient_updates);
+              let new_profile = _.merge(profile, updates);
+              new_profile.patient = new_patient;
+              dispatch(syncActions.updateProfileSuccess(new_profile, uploadTargetUser));
             }
           });
         }

--- a/lib/redux/actions/async.js
+++ b/lib/redux/actions/async.js
@@ -511,6 +511,7 @@ export function clickEditUserNext(profile) {
           if(_.get(err,'status') !== 401) {
             return dispatch(syncActions.updateProfileFailure(err));
           } else {
+            const { allUsers } = getState();
             let profile = allUsers[uploadTargetUser];
             let patient = _.get(profile, 'patient', {});
             let patient_updates = _.get(updates, 'patient', {});
@@ -521,17 +522,17 @@ export function clickEditUserNext(profile) {
           }
         } else {
           dispatch(syncActions.updateProfileSuccess(profile, uploadTargetUser));
-          const { targetDevices, devices, allUsers, loggedInUser } = getState();
-          const targetedDevices = _.get(targetDevices, uploadTargetUser, []);
-          const supportedDeviceKeys = Object.keys(devices);
-          const atLeastOneDeviceSupportedOnSystem = _.some(targetedDevices, (key) => {
-            return _.includes(supportedDeviceKeys, key);
-          });
-          if (_.isEmpty(targetedDevices) || !atLeastOneDeviceSupportedOnSystem) {
-            return dispatch(syncActions.setPage(pages.SETTINGS));
-          } else {
-            return dispatch(syncActions.setPage(pages.MAIN));
-          }
+        }
+        const { targetDevices, devices, allUsers, loggedInUser } = getState();
+        const targetedDevices = _.get(targetDevices, uploadTargetUser, []);
+        const supportedDeviceKeys = Object.keys(devices);
+        const atLeastOneDeviceSupportedOnSystem = _.some(targetedDevices, (key) => {
+          return _.includes(supportedDeviceKeys, key);
+        });
+        if (_.isEmpty(targetedDevices) || !atLeastOneDeviceSupportedOnSystem) {
+          return dispatch(syncActions.setPage(pages.SETTINGS));
+        } else {
+          return dispatch(syncActions.setPage(pages.MAIN));
         }
       });
     }

--- a/lib/redux/actions/async.js
+++ b/lib/redux/actions/async.js
@@ -446,13 +446,8 @@ export function setTargetTimezone(userId, timezoneName) {
         if (_.get(err,'status') !== 401) {
           dispatch(syncActions.updateProfileFailure(err));
         } else {
-          let profile = allUsers[userId];
-          let patient = _.get(profile, 'patient', {});
-          let patient_updates = _.get(updates, 'patient', {});
-          let new_patient = _.assign(profile.patient, patient_updates);
-          let new_profile = _.merge(profile, updates);
-          new_profile.patient = new_patient;
-          dispatch(syncActions.updateProfileSuccess(new_profile, userId));
+          let newProfile = actionUtils.mergeProfileUpdates(allUsers[userId], updates);
+          dispatch(syncActions.updateProfileSuccess(newProfile, userId));
         }
       } else {
         dispatch(syncActions.updateProfileSuccess(profile, userId));
@@ -480,13 +475,8 @@ export function clickDeviceSelectionDone() {
           if (_.get(err,'status') !== 401) {
             dispatch(syncActions.updateProfileFailure(err));
           } else {
-            let profile = allUsers[uploadTargetUser];
-            let patient = _.get(profile, 'patient', {});
-            let patient_updates = _.get(updates, 'patient', {});
-            let new_patient = _.assign(profile.patient, patient_updates);
-            let new_profile = _.merge(profile, updates);
-            new_profile.patient = new_patient;
-            dispatch(syncActions.updateProfileSuccess(new_profile, uploadTargetUser));
+            let newProfile = actionUtils.mergeProfileUpdates(allUsers[uploadTargetUser], updates);
+            dispatch(syncActions.updateProfileSuccess(newProfile, uploadTargetUser));
           }
         } else {
           dispatch(syncActions.updateProfileSuccess(profile, uploadTargetUser));
@@ -512,13 +502,8 @@ export function clickEditUserNext(profile) {
             return dispatch(syncActions.updateProfileFailure(err));
           } else {
             const { allUsers } = getState();
-            let profile = allUsers[uploadTargetUser];
-            let patient = _.get(profile, 'patient', {});
-            let patient_updates = _.get(updates, 'patient', {});
-            let new_patient = _.assign(profile.patient, patient_updates);
-            let new_profile = _.merge(profile, updates);
-            new_profile.patient = new_patient;
-            dispatch(syncActions.updateProfileSuccess(new_profile, uploadTargetUser));
+            let newProfile = actionUtils.mergeProfileUpdates(allUsers[uploadTargetUser], updates);
+            dispatch(syncActions.updateProfileSuccess(newProfile, uploadTargetUser));
           }
         } else {
           dispatch(syncActions.updateProfileSuccess(profile, uploadTargetUser));
@@ -599,13 +584,8 @@ export function retrieveTargetsFromStorage() {
               if (_.get(err,'status') !== 401) {
                 dispatch(syncActions.updateProfileFailure(err));
               } else {
-                let profile = allUsers[uploadTargetUser];
-                let patient = _.get(profile, 'patient', {});
-                let patient_updates = _.get(updates, 'patient', {});
-                let new_patient = _.assign(profile.patient, patient_updates);
-                let new_profile = _.merge(profile, updates);
-                new_profile.patient = new_patient;
-                dispatch(syncActions.updateProfileSuccess(new_profile, uploadTargetUser));
+                let newProfile = actionUtils.mergeProfileUpdates(allUsers[uploadTargetUser], updates);
+                dispatch(syncActions.updateProfileSuccess(newProfile, uploadTargetUser));
               }
             } else {
               dispatch(syncActions.updateProfileSuccess(profile, uploadTargetUser));

--- a/lib/redux/actions/async.js
+++ b/lib/redux/actions/async.js
@@ -442,16 +442,20 @@ export function setTargetTimezone(userId, timezoneName) {
     api.user.updateProfile(userId, updates, (err, profile) => {
       // suppress unauthorized error until custodial vs normal permissions are ironed out
       // TODO: remove conditional when perms are finalized or accounts are converted
-      if(err && _.get(err,'status') !== 401){
-        dispatch(syncActions.updateProfileFailure(err));
+      if (err){
+        if (_.get(err,'status') !== 401) {
+          dispatch(syncActions.updateProfileFailure(err));
+        } else {
+          let profile = allUsers[userId];
+          let patient = _.get(profile, 'patient', {});
+          let patient_updates = _.get(updates, 'patient', {});
+          let new_patient = _.assign(profile.patient, patient_updates);
+          let new_profile = _.merge(profile, updates);
+          new_profile.patient = new_patient;
+          dispatch(syncActions.updateProfileSuccess(new_profile, userId));
+        }
       } else {
-        let profile = allUsers[userId];
-        let patient = _.get(profile, 'patient', {});
-        let patient_updates = _.get(updates, 'patient', {});
-        let new_patient = _.assign(profile.patient, patient_updates);
-        let new_profile = _.merge(profile, updates);
-        new_profile.patient = new_patient;
-        dispatch(syncActions.updateProfileSuccess(new_profile, userId));
+        dispatch(syncActions.updateProfileSuccess(profile, userId));
       }
       return dispatch(syncActions.setTargetTimezone(userId, timezoneName));
     });
@@ -472,16 +476,20 @@ export function clickDeviceSelectionDone() {
       api.user.updateProfile(uploadTargetUser, updates, (err, profile) => {
         // suppress unauthorized error until custodial vs normal permissions are ironed out
         // TODO: remove conditional when perms are finalized or accounts are converted
-        if(err && _.get(err,'status') !== 401){
-          dispatch(syncActions.updateProfileFailure(err));
+        if (err) {
+          if (_.get(err,'status') !== 401) {
+            dispatch(syncActions.updateProfileFailure(err));
+          } else {
+            let profile = allUsers[uploadTargetUser];
+            let patient = _.get(profile, 'patient', {});
+            let patient_updates = _.get(updates, 'patient', {});
+            let new_patient = _.assign(profile.patient, patient_updates);
+            let new_profile = _.merge(profile, updates);
+            new_profile.patient = new_patient;
+            dispatch(syncActions.updateProfileSuccess(new_profile, uploadTargetUser));
+          }
         } else {
-          let profile = allUsers[uploadTargetUser];
-          let patient = _.get(profile, 'patient', {});
-          let patient_updates = _.get(updates, 'patient', {});
-          let new_patient = _.assign(profile.patient, patient_updates);
-          let new_profile = _.merge(profile, updates);
-          new_profile.patient = new_patient;
-          dispatch(syncActions.updateProfileSuccess(new_profile, uploadTargetUser));
+          dispatch(syncActions.updateProfileSuccess(profile, uploadTargetUser));
         }
         return dispatch(syncActions.setPage(pages.MAIN));
       });
@@ -491,13 +499,26 @@ export function clickDeviceSelectionDone() {
 
 export function clickEditUserNext(profile) {
   return (dispatch, getState) => {
-    const { uploadTargetUser } = getState();
+    const { uploadTargetUser, allUsers } = getState();
     const { api } = services;
+    const updates = profile;
     if (!_.isEmpty(profile)){
       dispatch(syncActions.updateProfileRequest());
       api.user.updateProfile(uploadTargetUser, profile, (err, profile) => {
+        // suppress unauthorized error until custodial vs normal permissions are ironed out
+        // TODO: remove conditional when perms are finalized or accounts are converted
         if (err) {
-          return dispatch(syncActions.updateProfileFailure(err));
+          if(_.get(err,'status') !== 401) {
+            return dispatch(syncActions.updateProfileFailure(err));
+          } else {
+            let profile = allUsers[uploadTargetUser];
+            let patient = _.get(profile, 'patient', {});
+            let patient_updates = _.get(updates, 'patient', {});
+            let new_patient = _.assign(profile.patient, patient_updates);
+            let new_profile = _.merge(profile, updates);
+            new_profile.patient = new_patient;
+            dispatch(syncActions.updateProfileSuccess(new_profile, uploadTargetUser));
+          }
         } else {
           dispatch(syncActions.updateProfileSuccess(profile, uploadTargetUser));
           const { targetDevices, devices, allUsers, loggedInUser } = getState();
@@ -573,16 +594,20 @@ export function retrieveTargetsFromStorage() {
           api.user.updateProfile(uploadTargetUser, updates, (err, profile) => {
             // suppress unauthorized error until custodial vs normal permissions are ironed out
             // TODO: remove conditional when perms are finalized or accounts are converted
-            if(err && _.get(err,'status') !== 401){
-              dispatch(syncActions.updateProfileFailure(err));
+            if(err){
+              if (_.get(err,'status') !== 401) {
+                dispatch(syncActions.updateProfileFailure(err));
+              } else {
+                let profile = allUsers[uploadTargetUser];
+                let patient = _.get(profile, 'patient', {});
+                let patient_updates = _.get(updates, 'patient', {});
+                let new_patient = _.assign(profile.patient, patient_updates);
+                let new_profile = _.merge(profile, updates);
+                new_profile.patient = new_patient;
+                dispatch(syncActions.updateProfileSuccess(new_profile, uploadTargetUser));
+              }
             } else {
-              let profile = allUsers[uploadTargetUser];
-              let patient = _.get(profile, 'patient', {});
-              let patient_updates = _.get(updates, 'patient', {});
-              let new_patient = _.assign(profile.patient, patient_updates);
-              let new_profile = _.merge(profile, updates);
-              new_profile.patient = new_patient;
-              dispatch(syncActions.updateProfileSuccess(new_profile, uploadTargetUser));
+              dispatch(syncActions.updateProfileSuccess(profile, uploadTargetUser));
             }
           });
         }

--- a/lib/redux/actions/async.js
+++ b/lib/redux/actions/async.js
@@ -83,52 +83,59 @@ export function doAppInit(opts, servicesToInit) {
       dispatch(syncActions.setSignUpUrl(api.makeBlipUrl(paths.SIGNUP)));
       cb();
     }
+    let results = [];
+    let error;
 
-    async.series([
+    _.forEach([
       initializeLocalStore,
       initializeDevice,
       initializeCareLink,
       initializeApi,
       setApiHosts
-    ], (err, results) => {
+    ], (func, index) => {
+        func((err, res) => {
+          error = err;
+          results[index] = res;
+        });
+        if(error){
+           return false;
+        }
+      });
+
+    if(error){
+      return dispatch(syncActions.initFailure(error));
+    }
+
+    let session = results[3];
+    if (session === undefined) {
+      dispatch(syncActions.setPage(pages.LOGIN));
+      dispatch(syncActions.initSuccess());
+      return dispatch(doVersionCheck());
+    }
+
+    api.user.initializationInfo((err, results) => {
       if (err) {
         return dispatch(syncActions.initFailure(err));
       }
-      let session = results[3];
-      if (session === undefined) {
-        dispatch(syncActions.setPage(pages.LOGIN));
-        dispatch(syncActions.initSuccess());
-        return dispatch(doVersionCheck());
+      // remove env-switching context menu after login
+      if (typeof chrome !== 'undefined') {
+        services.log('Removing Chrome context menu');
+        chrome.contextMenus.removeAll();
       }
-
-      async.series([
-        api.user.account,
-        api.user.loggedInProfile,
-        api.user.getUploadGroups
-      ], (err, results) => {
-        if (err) {
-          return dispatch(syncActions.initFailure(err));
-        }
-        // remove env-switching context menu after login
-        if (typeof chrome !== 'undefined') {
-          services.log('Removing Chrome context menu');
-          chrome.contextMenus.removeAll();
-        }
-        dispatch(syncActions.initSuccess());
-        dispatch(doVersionCheck());
-        dispatch(syncActions.setUserInfoFromToken({
-          user: results[0],
-          profile: results[1],
-          memberships: results[2]
-        }));
-        const { uploadTargetUser } = getState();
-        if (uploadTargetUser !== null) {
-          dispatch(syncActions.setBlipViewDataUrl(
-            api.makeBlipUrl(actionUtils.viewDataPathForUser(uploadTargetUser))
-          ));
-        }
-        dispatch(retrieveTargetsFromStorage());
-      });
+      dispatch(syncActions.initSuccess());
+      dispatch(doVersionCheck());
+      dispatch(syncActions.setUserInfoFromToken({
+        user: results[0],
+        profile: results[1],
+        memberships: results[2]
+      }));
+      const { uploadTargetUser } = getState();
+      if (uploadTargetUser !== null) {
+        dispatch(syncActions.setBlipViewDataUrl(
+          api.makeBlipUrl(actionUtils.viewDataPathForUser(uploadTargetUser))
+        ));
+      }
+      dispatch(retrieveTargetsFromStorage());
     });
   };
 }

--- a/lib/redux/actions/async.js
+++ b/lib/redux/actions/async.js
@@ -145,11 +145,7 @@ export function doLogin(creds, opts) {
     const { api } = services;
     dispatch(syncActions.loginRequest());
 
-    async.series([
-      api.user.login.bind(null, creds, opts),
-      api.user.loggedInProfile,
-      api.user.getUploadGroups
-    ], (err, results) => {
+    api.user.loginExtended(creds, opts, (err, results) => {
       if (err) {
         return dispatch(syncActions.loginFailure(err.status));
       }

--- a/lib/redux/actions/sync.js
+++ b/lib/redux/actions/sync.js
@@ -490,9 +490,10 @@ export function updateProfileRequest() {
   };
 }
 
-export function updateProfileSuccess() {
+export function updateProfileSuccess(profile, userId) {
   return {
     type: actionTypes.UPDATE_PROFILE_SUCCESS,
+    payload: { profile, userId },
     meta: {source: actionSources[actionTypes.UPDATE_PROFILE_SUCCESS]}
   };
 }

--- a/lib/redux/actions/utils.js
+++ b/lib/redux/actions/utils.js
@@ -93,3 +93,12 @@ export function makeUploadCb(dispatch, getState, errCode, utc) {
 export function viewDataPathForUser(uploadTargetUser) {
   return `/patients/${uploadTargetUser}/data`;
 }
+
+export function mergeProfileUpdates(profile, updates){
+  // merge property values except arrays, which get replaced entirely
+  return _.merge(profile, updates, (original, update) => {
+    if (_.isArray(original)) {
+      return update;
+    }
+  });
+}

--- a/lib/redux/reducers/users.js
+++ b/lib/redux/reducers/users.js
@@ -24,7 +24,7 @@ export function allUsers(state = {}, action) {
   switch (action.type) {
     case actionTypes.LOGIN_SUCCESS:
     case actionTypes.SET_USER_INFO_FROM_TOKEN:
-    case actionTypes.SET_ALL_USERS:
+    case actionTypes.SET_ALL_USERS: {
       const { user, profile, memberships } = action.payload;
       let newState = {};
       _.each(memberships, (membership) => {
@@ -33,9 +33,13 @@ export function allUsers(state = {}, action) {
           Object.assign({}, membership.profile);
       });
       return newState;
+    }
     case actionTypes.CREATE_CUSTODIAL_ACCOUNT_SUCCESS:
       const { account } = action.payload;
       return update(state, {$merge: {[account.userid]: account.profile}});
+    case actionTypes.UPDATE_PROFILE_SUCCESS:
+      const { userId, profile } = action.payload;
+      return update(state, {$merge: {[userId]: profile}});
     case actionTypes.LOGOUT_REQUEST:
       return {};
     default:

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "redux-devtools-dock-monitor": "1.1.0",
     "redux-devtools-log-monitor": "1.0.5",
     "redux-logger": "2.6.1",
-    "redux-mock-store": "0.0.6",
+    "redux-mock-store": "1.1.2",
     "salinity": "0.0.8",
     "sinon": "1.17.3",
     "style-loader": "0.13.1",

--- a/test/browser/redux/actions/async.test.js
+++ b/test/browser/redux/actions/async.test.js
@@ -298,7 +298,7 @@ describe('Asynchronous Actions', () => {
   });
 
   describe('doLogin [no error]', () => {
-    it('should dispatch LOGIN_REQUEST, LOGIN_SUCCESS actions', () => {
+    it('should dispatch LOGIN_REQUEST, LOGIN_SUCCESS, SET_BLIP_VIEW_DATA_URL, RETRIEVING_USERS_TARGETS, SET_PAGE (SETTINGS) actions', () => {
       // NB: this is not what these objects actually look like
       // actual shape is irrelevant to testing action creators
       const userObj = {user: {userid: 'abc123'}};
@@ -1928,7 +1928,7 @@ describe('Asynchronous Actions', () => {
 
   describe('clickEditUserNext', () => {
     describe('update profile success, user has devices selected', () => {
-      it('should dispatch UPDATE_PROFILE_REQUEST, UPDATE_PROFILE_SUCCESS, SET_ALL_USERS, SET_PAGE (main)', () => {
+      it('should dispatch UPDATE_PROFILE_REQUEST, UPDATE_PROFILE_SUCCESS, SET_PAGE (main)', () => {
         const userObj = {user: {userid: 'abc123', roles: ['clinic']}};
         const profile = {fullName: 'Jane Doe'};
         const memberships = [{userid: 'def456'}, {userid: 'ghi789'}];
@@ -1993,7 +1993,7 @@ describe('Asynchronous Actions', () => {
       });
     });
     describe('update profile success, user doesn\'t have devices selected', () => {
-      it('should dispatch UPDATE_PROFILE_REQUEST, UPDATE_PROFILE_SUCCESS, SET_ALL_USERS, SET_PAGE (settings)', () => {
+      it('should dispatch UPDATE_PROFILE_REQUEST, UPDATE_PROFILE_SUCCESS, SET_PAGE (settings)', () => {
         const userObj = {user: {userid: 'abc123', roles: ['clinic']}};
         const profile = {fullName: 'Jane Doe'};
         const memberships = [{userid: 'def456'}, {userid: 'ghi789'}];

--- a/test/browser/redux/actions/async.test.js
+++ b/test/browser/redux/actions/async.test.js
@@ -358,7 +358,6 @@ describe('Asynchronous Actions', () => {
         {remember: false}
       ));
       const actions = store.getActions();
-      console.log(actions, expectedActions, store.getState());
       expect(actions).to.deep.equal(expectedActions);
     });
   });
@@ -1690,6 +1689,12 @@ describe('Asynchronous Actions', () => {
   describe('clickDeviceSelectionDone', () => {
     describe('no targets in local storage', () => {
       it('should dispatch UPDATE_PROFILE_REQUEST, UPDATE_PROFILE_SUCCESS, SET_PAGE (redirect to main page)', () => {
+        const profile = {
+          fullName: 'John',
+          patient: {
+            birthday: '1990-08-08'
+          }
+        };
         const expectedActions = [
           {
             type: actionTypes.UPDATE_PROFILE_REQUEST,
@@ -1697,6 +1702,7 @@ describe('Asynchronous Actions', () => {
           },
           {
             type: actionTypes.UPDATE_PROFILE_SUCCESS,
+            payload: {userId: 'abc123', profile: profile},
             meta: {source: actionSources[actionTypes.UPDATE_PROFILE_SUCCESS]}
           },
           {
@@ -1712,7 +1718,7 @@ describe('Asynchronous Actions', () => {
                 cb(null);
               },
               updateProfile: (user, update, cb) => {
-                cb(null);
+                cb(null, profile);
               }
             }
           },
@@ -1728,7 +1734,10 @@ describe('Asynchronous Actions', () => {
           targetTimezones: {
             abc123: 'Europe/Budapest'
           },
-          uploadTargetUser: 'abc123'
+          uploadTargetUser: 'abc123',
+          allUsers: {
+            abc123: profile
+          }
         };
         const store = mockStore(state);
         store.dispatch(asyncActions.clickDeviceSelectionDone());
@@ -1739,6 +1748,12 @@ describe('Asynchronous Actions', () => {
 
     describe('existing targets in local storage', () => {
       it('should dispatch UPDATE_PROFILE_REQUEST, UPDATE_PROFILE_SUCCESS, SET_PAGE (redirect to main page)', () => {
+        const profile = {
+          fullName: 'John',
+          patient: {
+            birthday: '1990-08-08'
+          }
+        };
         const expectedActions = [
           {
             type: actionTypes.UPDATE_PROFILE_REQUEST,
@@ -1746,6 +1761,7 @@ describe('Asynchronous Actions', () => {
           },
           {
             type: actionTypes.UPDATE_PROFILE_SUCCESS,
+            payload: {userId: 'abc123', profile: profile},
             meta: {source: actionSources[actionTypes.UPDATE_PROFILE_SUCCESS]}
           },
           {
@@ -1761,7 +1777,7 @@ describe('Asynchronous Actions', () => {
                 cb(null);
               },
               updateProfile: (user, update, cb) => {
-                cb(null);
+                cb(null, profile);
               }
             }
           },
@@ -1786,7 +1802,10 @@ describe('Asynchronous Actions', () => {
           targetTimezones: {
             abc123: 'Europe/Budapest'
           },
-          uploadTargetUser: 'abc123'
+          uploadTargetUser: 'abc123',
+          allUsers: {
+            abc123: profile
+          }
         };
         const store = mockStore(state);
         store.dispatch(asyncActions.clickDeviceSelectionDone());
@@ -1797,6 +1816,7 @@ describe('Asynchronous Actions', () => {
 
     describe('profile API endpoint failure', () => {
       it('should dispatch UPDATE_PROFILE_REQUEST, UPDATE_PROFILE_FAILURE, SET_PAGE (redirect to main page)', () => {
+        const err = new Error(getUpdateProfileErrorMessage());
         const expectedActions = [
           {
             type: actionTypes.UPDATE_PROFILE_REQUEST,
@@ -1805,7 +1825,7 @@ describe('Asynchronous Actions', () => {
           {
             type: actionTypes.UPDATE_PROFILE_FAILURE,
             meta: {source: actionSources[actionTypes.UPDATE_PROFILE_FAILURE]},
-            payload: new Error(getUpdateProfileErrorMessage()),
+            payload: err,
             error: true
           },
           {
@@ -1821,7 +1841,7 @@ describe('Asynchronous Actions', () => {
                 cb(null);
               },
               updateProfile: (user, update, cb) => {
-                cb(getUpdateProfileErrorMessage());
+                cb(err);
               }
             }
           },
@@ -1848,6 +1868,12 @@ describe('Asynchronous Actions', () => {
 
     describe('profile API endpoint failure (unauthorized)', () => {
       it('should dispatch UPDATE_PROFILE_REQUEST, UPDATE_PROFILE_SUCCESS, SET_PAGE (redirect to main page)', () => {
+        const profile = {
+          fullName: 'John',
+          patient: {
+            birthday: '1990-08-08'
+          }
+        };
         const expectedActions = [
           {
             type: actionTypes.UPDATE_PROFILE_REQUEST,
@@ -1855,6 +1881,7 @@ describe('Asynchronous Actions', () => {
           },
           {
             type: actionTypes.UPDATE_PROFILE_SUCCESS,
+            payload: {userId: 'abc123', profile: profile},
             meta: {source: actionSources[actionTypes.UPDATE_PROFILE_SUCCESS]}
           },
           {
@@ -1886,7 +1913,10 @@ describe('Asynchronous Actions', () => {
           targetTimezones: {
             abc123: 'Europe/Budapest'
           },
-          uploadTargetUser: 'abc123'
+          uploadTargetUser: 'abc123',
+          allUsers: {
+            abc123: profile
+          }
         };
         const store = mockStore(state);
         store.dispatch(asyncActions.clickDeviceSelectionDone());
@@ -1909,15 +1939,8 @@ describe('Asynchronous Actions', () => {
           },
           {
             type: actionTypes.UPDATE_PROFILE_SUCCESS,
+            payload: {userId: 'def456', profile: {}},
             meta: {source: actionSources[actionTypes.UPDATE_PROFILE_SUCCESS]}
-          },
-          {
-            type: actionTypes.SET_ALL_USERS,
-            payload: {
-              user: userObj.user,
-              profile, memberships
-            },
-            meta: {source: actionSources[actionTypes.SET_ALL_USERS]}
           },
           {
             type: actionTypes.SET_PAGE,
@@ -1931,7 +1954,7 @@ describe('Asynchronous Actions', () => {
               account: (cb) => cb(null, userObj.user),
               loggedInProfile: (cb) => cb(null, profile),
               getUploadGroups: (cb) => cb(null, memberships),
-              updateProfile: (user, update, cb) => cb(null)
+              updateProfile: (user, update, cb) => cb(null, {})
             }
           }
         });
@@ -1981,15 +2004,8 @@ describe('Asynchronous Actions', () => {
           },
           {
             type: actionTypes.UPDATE_PROFILE_SUCCESS,
+            payload: {userId: 'def456', profile: {}},
             meta: {source: actionSources[actionTypes.UPDATE_PROFILE_SUCCESS]}
-          },
-          {
-            type: actionTypes.SET_ALL_USERS,
-            payload: {
-              user: userObj.user,
-              profile, memberships
-            },
-            meta: {source: actionSources[actionTypes.SET_ALL_USERS]}
           },
           {
             type: actionTypes.SET_PAGE,
@@ -2003,7 +2019,7 @@ describe('Asynchronous Actions', () => {
               account: (cb) => cb(null, userObj.user),
               loggedInProfile: (cb) => cb(null, profile),
               getUploadGroups: (cb) => cb(null, memberships),
-              updateProfile: (user, update, cb) => cb(null)
+              updateProfile: (user, update, cb) => cb(null, {})
             }
           },
           log: _.noop
@@ -2071,6 +2087,12 @@ describe('Asynchronous Actions', () => {
   describe('setTargetTimezone', () => {
     describe('update profile success', () => {
       it('should dispatch UPDATE_PROFILE_REQUEST, UPDATE_PROFILE_SUCCESS, SET_TARGET_TIMEZONE', () => {
+        const profile = {
+          fullName: 'John',
+          patient: {
+            birthday: '1990-08-08'
+          }
+        };
         const expectedActions = [
           {
             type: actionTypes.UPDATE_PROFILE_REQUEST,
@@ -2078,6 +2100,7 @@ describe('Asynchronous Actions', () => {
           },
           {
             type: actionTypes.UPDATE_PROFILE_SUCCESS,
+            payload: {userId: 'abc123', profile: profile},
             meta: {source: actionSources[actionTypes.UPDATE_PROFILE_SUCCESS]}
           },
           {
@@ -2093,7 +2116,7 @@ describe('Asynchronous Actions', () => {
                 cb(null);
               },
               updateProfile: (user, update, cb) => {
-                cb(null);
+                cb(null, profile);
               }
             }
           }
@@ -2105,7 +2128,10 @@ describe('Asynchronous Actions', () => {
           targetTimezones: {
             abc123: 'Europe/Budapest'
           },
-          uploadTargetUser: 'abc123'
+          uploadTargetUser: 'abc123',
+          allUsers: {
+            abc123: profile
+          }
         };
         const store = mockStore(state);
         store.dispatch(asyncActions.setTargetTimezone('abc123', 'US/Central'));
@@ -2163,6 +2189,12 @@ describe('Asynchronous Actions', () => {
 
     describe('update profile failure (unauthorized)', () => {
       it('should dispatch UPDATE_PROFILE_REQUEST, UPDATE_PROFILE_SUCCESS, SET_TARGET_TIMEZONE', () => {
+        const profile = {
+          fullName: 'John',
+          patient: {
+            birthday: '1990-08-08'
+          }
+        };
         const expectedActions = [
           {
             type: actionTypes.UPDATE_PROFILE_REQUEST,
@@ -2170,6 +2202,7 @@ describe('Asynchronous Actions', () => {
           },
           {
             type: actionTypes.UPDATE_PROFILE_SUCCESS,
+            payload: {userId: 'abc123', profile: profile},
             meta: {source: actionSources[actionTypes.UPDATE_PROFILE_SUCCESS]},
           },
           {
@@ -2197,7 +2230,10 @@ describe('Asynchronous Actions', () => {
           targetTimezones: {
             abc123: 'Europe/Budapest'
           },
-          uploadTargetUser: 'abc123'
+          uploadTargetUser: 'abc123',
+          allUsers: {
+            abc123: profile
+          }
         };
         const store = mockStore(state);
         store.dispatch(asyncActions.setTargetTimezone('abc123', 'US/Central'));
@@ -2210,6 +2246,12 @@ describe('Asynchronous Actions', () => {
   describe('retrieveTargetsFromStorage', () => {
     const url = 'http://acme-blip.com/patients/abc123/data';
     const blipUrlMaker = (path) => { return 'http://acme-blip.com' + path; };
+    const profile = {
+      fullName: 'John',
+      patient: {
+        birthday: '1990-08-08'
+      }
+    };
     describe('no targets retrieved from local storage, no targets exist in state', () => {
       it('should dispatch RETRIEVING_USERS_TARGETS, SET_PAGE (redirect to settings page)', () => {
         const expectedActions = [
@@ -2469,7 +2511,8 @@ describe('Asynchronous Actions', () => {
           },
           {
             type: actionTypes.UPDATE_PROFILE_SUCCESS,
-            meta: {source: actionSources[actionTypes.UPDATE_PROFILE_SUCCESS]}
+            payload: {userId: 'abc123', profile: profile},
+            meta: {source: actionSources[actionTypes.UPDATE_PROFILE_SUCCESS]},
           },
           {
             type: actionTypes.SET_PAGE,
@@ -2497,7 +2540,7 @@ describe('Asynchronous Actions', () => {
         const store = mockStore({
           allUsers: {
             ghi789: {},
-            abc123: {},
+            abc123: profile,
             def456: {},
           },
           devices: {
@@ -2555,6 +2598,7 @@ describe('Asynchronous Actions', () => {
           },
           {
             type: actionTypes.UPDATE_PROFILE_SUCCESS,
+            payload: {userId: 'abc123', profile: profile},
             meta: {source: actionSources[actionTypes.UPDATE_PROFILE_SUCCESS]}
           },
           {
@@ -2583,7 +2627,7 @@ describe('Asynchronous Actions', () => {
         const store = mockStore({
           allUsers: {
             ghi789: {},
-            abc123: {},
+            abc123: profile,
             def456: {},
           },
           devices: {
@@ -2704,6 +2748,7 @@ describe('Asynchronous Actions', () => {
           },
           {
             type: actionTypes.UPDATE_PROFILE_SUCCESS,
+            payload: {userId: 'abc123', profile: profile},
             meta: {source: actionSources[actionTypes.UPDATE_PROFILE_SUCCESS]}
           },
           {
@@ -2719,7 +2764,7 @@ describe('Asynchronous Actions', () => {
                 cb(null);
               },
               updateProfile: (user, update, cb) => {
-                cb(null);
+                cb(null, profile);
               }
             },
             makeBlipUrl: blipUrlMaker
@@ -2732,7 +2777,7 @@ describe('Asynchronous Actions', () => {
         const store = mockStore({
           allUsers: {
             ghi789: {},
-            abc123: {},
+            abc123: profile,
             def456: {},
           },
           devices: {
@@ -2787,6 +2832,7 @@ describe('Asynchronous Actions', () => {
           },
           {
             type: actionTypes.UPDATE_PROFILE_SUCCESS,
+            payload: {userId: 'abc123', profile: profile},
             meta: {source: actionSources[actionTypes.UPDATE_PROFILE_SUCCESS]}
           },
           {
@@ -2815,7 +2861,7 @@ describe('Asynchronous Actions', () => {
         const store = mockStore({
           allUsers: {
             ghi789: {},
-            abc123: {},
+            abc123: profile,
             def456: {},
           },
           devices: {
@@ -2937,6 +2983,12 @@ describe('Asynchronous Actions', () => {
         ];
         asyncActions.__Rewire__('services', apiRewire);
         const store = mockStore({
+          devices: {
+            a_pump: {}
+          },
+          targetDevices: {
+            abc123: ['a_pump']
+          },
           users: {
             abc123: {
               targets: {
@@ -3012,6 +3064,9 @@ describe('Asynchronous Actions', () => {
             carelink: {},
             dexcom: {},
             omnipod: {}
+          },
+          targetDevices: {
+            abc123: ['carelink']
           },
           users: {
             abc123: {

--- a/test/browser/redux/actions/async.test.js
+++ b/test/browser/redux/actions/async.test.js
@@ -138,8 +138,16 @@ describe('Asynchronous Actions', () => {
       asyncActions.__Rewire__('versionInfo', {
         semver: config.version
       });
-      const store = mockStore({working: {initializingApp: true}}, expectedActions, done);
+      const store = mockStore({working: {initializingApp: true}});
       store.dispatch(asyncActions.doAppInit(config, servicesToInit));
+
+      // See: https://github.com/arnaudbenard/redux-mock-store/issues/31
+      setTimeout(() => {
+        const actions = store.getActions();
+
+        expect(actions).to.deep.equal(expectedActions);
+        done();
+      }, 10);
     });
   });
 

--- a/test/browser/redux/actions/async.test.js
+++ b/test/browser/redux/actions/async.test.js
@@ -319,14 +319,26 @@ describe('Asynchronous Actions', () => {
             source: actionSources[actionTypes.LOGIN_SUCCESS],
             metric: {eventName: metrics.LOGIN_SUCCESS}
           }
+        },
+        {
+          type: actionTypes.SET_BLIP_VIEW_DATA_URL,
+          payload: {url: `http://www.acme.com/patients/${userObj.user.userid}/data`},
+          meta: {source: actionSources[actionTypes.SET_BLIP_VIEW_DATA_URL]}
+        },
+        {
+          type: actionTypes.RETRIEVING_USERS_TARGETS,
+          meta: {source: actionSources[actionTypes.RETRIEVING_USERS_TARGETS]}
+        },
+        {
+          type: actionTypes.SET_PAGE,
+          payload: {page: pages.SETTINGS},
+          meta: {source: actionSources[actionTypes.SET_PAGE]}
         }
       ];
       asyncActions.__Rewire__('services', {
         api: {
           user: {
-            login: (creds, opts, cb) => cb(null, userObj),
-            loggedInProfile: (cb) => cb(null, profile),
-            getUploadGroups: (cb) => cb(null, memberships)
+            loginExtended: (creds, opts, cb) => cb(null, [userObj, profile, memberships])
           },
           makeBlipUrl: (path) => {
             return 'http://www.acme.com' + path;
@@ -338,17 +350,15 @@ describe('Asynchronous Actions', () => {
           setItem: () => null
         }
       });
-      const store = mockStore({});
-      // CM: I found this pattern useful to see what actions are actually getting dispatched
-      store.subscribe(function(){
-        var actions = store.getActions();
-        console.log(actions.length && actions[actions.length - 1]);
+      const store = mockStore({
+        uploadTargetUser: userObj.user.userid,
       });
       store.dispatch(asyncActions.doLogin(
         {username: 'jane.doe@me.com', password: 'password'},
         {remember: false}
       ));
       const actions = store.getActions();
+      console.log(actions, expectedActions, store.getState());
       expect(actions).to.deep.equal(expectedActions);
     });
   });
@@ -370,8 +380,7 @@ describe('Asynchronous Actions', () => {
       asyncActions.__Rewire__('services', {
         api: {
           user: {
-            login: (creds, opts, cb) => cb(getLoginErrorMessage()),
-            getUploadGroups: (cb) => cb(null, [])
+            loginExtended: (creds, opts, cb) => cb(getLoginErrorMessage())
           }
         },
         localStore: {
@@ -421,9 +430,7 @@ describe('Asynchronous Actions', () => {
       asyncActions.__Rewire__('services', {
         api: {
           user: {
-            login: (creds, opts, cb) => cb(null, userObj),
-            loggedInProfile: (cb) => cb(null, profile),
-            getUploadGroups: (cb) => cb(null, memberships)
+            loginExtended: (creds, opts, cb) => cb(null, [userObj, profile, memberships])
           }
         },
         log: _.noop

--- a/test/browser/redux/actions/async.test.js
+++ b/test/browser/redux/actions/async.test.js
@@ -161,9 +161,7 @@ describe('Asynchronous Actions', () => {
             getVersions: (cb) => { cb(null, {uploaderMinimum: config.version}); }
           },
           user: {
-            account: (cb) => { cb(null, pwd.user); },
-            loggedInProfile: (cb) => { cb(null, pwd.profile); },
-            getUploadGroups: (cb) => { cb(null, pwd.memberships); }
+            initializationInfo: (cb) => { cb(null, [pwd.user, pwd.profile, pwd.memberships] ); }
           }
         },
         carelink: {

--- a/test/browser/redux/actions/async.test.js
+++ b/test/browser/redux/actions/async.test.js
@@ -2527,7 +2527,7 @@ describe('Asynchronous Actions', () => {
                 cb(null);
               },
               updateProfile: (user, update, cb) => {
-                cb(null);
+                cb(null, profile);
               }
             },
             makeBlipUrl: blipUrlMaker

--- a/test/browser/redux/actions/utils.test.js
+++ b/test/browser/redux/actions/utils.test.js
@@ -1,0 +1,109 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2014, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+/*eslint-env mocha*/
+
+import _ from 'lodash';
+
+import * as utils from '../../../../lib/redux/actions/utils';
+
+describe('utils', () => {
+  describe('mergeProfileUpdates', () => {
+    const profile = {
+      emails: ['joe@example.com'],
+      emailVerified: true,
+      fullName: 'Joe',
+      patient: {
+        birthday: '1980-02-05',
+        diagnosisDate: '1990-02-06',
+        targetDevices: ['carelink', 'omnipod'],
+        targetTimezone: 'US/Central'
+      },
+      termsAccepted: '2016-05-09T14:33:59-04:00',
+      username: 'joe@example.com'
+    };
+
+    it('should merge profile updates', () => {
+      var update = {fullName: 'New Joe'};
+      expect(utils.mergeProfileUpdates(_.cloneDeep(profile), update)).to.deep.equal({
+        emails: ['joe@example.com'],
+        emailVerified: true,
+        fullName: 'New Joe',
+        patient: {
+          birthday: '1980-02-05',
+          diagnosisDate: '1990-02-06',
+          targetDevices: ['carelink', 'omnipod'],
+          targetTimezone: 'US/Central'
+        },
+        termsAccepted: '2016-05-09T14:33:59-04:00',
+        username: 'joe@example.com'
+      });
+    });
+
+    it('should merge patient updates', () => {
+      var update = {patient: {birthday: '1981-02-05'}};
+      expect(utils.mergeProfileUpdates(_.cloneDeep(profile), update)).to.deep.equal({
+        emails: ['joe@example.com'],
+        emailVerified: true,
+        fullName: 'Joe',
+        patient: {
+          birthday: '1981-02-05',
+          diagnosisDate: '1990-02-06',
+          targetDevices: ['carelink', 'omnipod'],
+          targetTimezone: 'US/Central'
+        },
+        termsAccepted: '2016-05-09T14:33:59-04:00',
+        username: 'joe@example.com'
+      });
+    });
+
+    it('should replace emails array on update', () => {
+      var update = {emails:['joe2@example.com']};
+      expect(utils.mergeProfileUpdates(_.cloneDeep(profile), update)).to.deep.equal({
+        emails: ['joe2@example.com'],
+        emailVerified: true,
+        fullName: 'Joe',
+        patient: {
+          birthday: '1980-02-05',
+          diagnosisDate: '1990-02-06',
+          targetDevices: ['carelink', 'omnipod'],
+          targetTimezone: 'US/Central'
+        },
+        termsAccepted: '2016-05-09T14:33:59-04:00',
+        username: 'joe@example.com'
+      });
+    });
+
+    it('should replace targetDevices array on update', () => {
+      var update = {patient: {targetDevices: ['tandem']}};
+      expect(utils.mergeProfileUpdates(_.cloneDeep(profile), update)).to.deep.equal({
+        emails: ['joe@example.com'],
+        emailVerified: true,
+        fullName: 'Joe',
+        patient: {
+          birthday: '1980-02-05',
+          diagnosisDate: '1990-02-06',
+          targetDevices: ['tandem'],
+          targetTimezone: 'US/Central'
+        },
+        termsAccepted: '2016-05-09T14:33:59-04:00',
+        username: 'joe@example.com'
+      });
+    });
+
+  });
+});

--- a/test/browser/redux/reducers/users.test.js
+++ b/test/browser/redux/reducers/users.test.js
@@ -18,6 +18,7 @@
 /*eslint-env mocha*/
 
 import _ from 'lodash';
+import mutationTracker from 'object-invariant-test-helper';
 
 import * as actionTypes from '../../../../lib/redux/constants/actionTypes';
 import * as users from '../../../../lib/redux/reducers/users';
@@ -95,12 +96,12 @@ describe('users', () => {
         type: actionTypes.UPDATE_PROFILE_SUCCESS,
         payload: { profile, userId: 'a1b2c3' }
       };
-      expect(users.allUsers(undefined, action)).to.deep.equal({
+      let initialState = {};
+      const tracked = mutationTracker.trackObj(initialState);
+      expect(users.allUsers(initialState, action)).to.deep.equal({
         a1b2c3: profile
       });
-      let initialState = {};
-      // test to be sure not *mutating* state object but rather returning new!
-      expect(initialState === users.allUsers(initialState, action)).to.be.false;
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
 
     it('should handle LOGOUT_REQUEST', () => {

--- a/test/browser/redux/reducers/users.test.js
+++ b/test/browser/redux/reducers/users.test.js
@@ -90,6 +90,19 @@ describe('users', () => {
       expect(initialState === users.allUsers(initialState, action)).to.be.false;
     });
 
+    it('should handle UPDATE_PROFILE_SUCCESS', () => {
+      const action = {
+        type: actionTypes.UPDATE_PROFILE_SUCCESS,
+        payload: { profile, userId: 'a1b2c3' }
+      };
+      expect(users.allUsers(undefined, action)).to.deep.equal({
+        a1b2c3: profile
+      });
+      let initialState = {};
+      // test to be sure not *mutating* state object but rather returning new!
+      expect(initialState === users.allUsers(initialState, action)).to.be.false;
+    });
+
     it('should handle LOGOUT_REQUEST', () => {
       let initialState = {foo: 'bar'};
       let result = users.allUsers(initialState, {


### PR DESCRIPTION
Updates to unit tests to conform to the new redux-mock-store API and move the `async` library calls out of action creators and into the API layer so that they can be stubbed out to work with the new redux-mock-store. Also took the opportunity to rework `clickEditUserNext` to pass the updates through `updateProfileSuccess` properly instead of a larger state tree refresh. 