### PR TITLE
Animas: Cap long running suspended basals after 5 days

### DIFF
--- a/lib/animas/animasSimulator.js
+++ b/lib/animas/animasSimulator.js
@@ -74,6 +74,21 @@ exports.make = function(config){
     return e;
   }
 
+  function validateDuration(basal) {
+    var fiveDays = (5 * 1440 * sundial.MIN_TO_MSEC);
+    if(basal.isAssigned('duration')) {
+      if(basal.duration > fiveDays) {
+        //flat-rate basal
+        basal.duration = fiveDays;
+        annotate.annotateEvent(basal, 'animas/basal/flat-rate');
+      }
+    } else {
+      basal.with_duration(0);
+      annotate.annotateEvent(basal, 'basal/unknown-duration');
+    }
+    return basal;
+  }
+
   function simpleSimulate(e) {
     ensureTimestamp(e);
     events.push(e);
@@ -93,16 +108,13 @@ exports.make = function(config){
 
       ensureTimestamp(event);
 
-      if (currBasal != null && !currBasal.isAssigned('duration')) {
-        // calculate current basal's duration
-        var duration = Date.parse(event.time) - Date.parse(currBasal.time);
-        var fiveDays = (5 * 1440 * sundial.MIN_TO_MSEC);
-        if(duration > fiveDays) {
-          //flat-rate basal
-          duration = fiveDays;
-          annotate.annotateEvent(currBasal, 'animas/basal/flat-rate');
+      if (currBasal != null) {
+        if(!currBasal.isAssigned('duration')) {
+          // calculate current basal's duration
+          var duration = Date.parse(event.time) - Date.parse(currBasal.time);
+          currBasal.with_duration(duration);
         }
-        currBasal.with_duration(duration);
+        currBasal = validateDuration(currBasal);
       }
 
       if (event.rate === 0 ) {
@@ -169,6 +181,7 @@ exports.make = function(config){
       if(currBasal != null && currBasal.rate !== 0 && currStatus.status === 'suspended') {
         //basal rate has not yet changed to zero after final suspend event
         currBasal.with_duration(Date.parse(currStatus.time) - Date.parse(currBasal.time));
+        currBasal = validateDuration(currBasal);
         currBasal = currBasal.done();
         events.push(currBasal);
       }
@@ -252,7 +265,7 @@ exports.make = function(config){
 
           // Filter out dates 2008 and earlier, as this is year 0 for Vibe.
           // We are doing this because we expect no pump to have true 2008 dates,
-          // so anything generated in 2008 or earlier is really just because 
+          // so anything generated in 2008 or earlier is really just because
           // someone didn't immediately set the date upon powering up the pump
           // for a while. Thus, we are dropping these events because we don't
           // know the actual, real time for them.

--- a/lib/animas/animasSimulator.js
+++ b/lib/animas/animasSimulator.js
@@ -74,7 +74,7 @@ exports.make = function(config){
     return e;
   }
 
-  function validateDuration(basal) {
+  function truncateDuration(basal) {
     var fiveDays = (5 * 1440 * sundial.MIN_TO_MSEC);
     if(basal.isAssigned('duration')) {
       if(basal.duration > fiveDays) {
@@ -114,7 +114,7 @@ exports.make = function(config){
           var duration = Date.parse(event.time) - Date.parse(currBasal.time);
           currBasal.with_duration(duration);
         }
-        currBasal = validateDuration(currBasal);
+        currBasal = truncateDuration(currBasal);
       }
 
       if (event.rate === 0 ) {
@@ -181,7 +181,7 @@ exports.make = function(config){
       if(currBasal != null && currBasal.rate !== 0 && currStatus.status === 'suspended') {
         //basal rate has not yet changed to zero after final suspend event
         currBasal.with_duration(Date.parse(currStatus.time) - Date.parse(currBasal.time));
-        currBasal = validateDuration(currBasal);
+        currBasal = truncateDuration(currBasal);
         currBasal = currBasal.done();
         events.push(currBasal);
       }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Tidepool Uploader",
   "short_name": "Uploader",
-  "version": "0.275.2",
+  "version": "0.275.3",
   "description": "The Tidepool Uploader helps you get your data from insulin pumps, CGMs and BG meters into Tidepool’s secure cloud platform.",
   "minimum_chrome_version": "38",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "0.275.2",
+  "version": "0.275.3",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",


### PR DESCRIPTION
We were capping scheduled basals after 5 days, but this logic wasn't applied correctly to suspended or final basals. This PR breaks out the functionality into its own validation function so it can be applied to all basal types.

Pinging @jebeck for review - BA has confirmed that it works with tester pump.