### PR TITLE
Support for different Medtronic models and fix for calculator boluses

### DIFF
--- a/lib/drivers/medtronicDriver.js
+++ b/lib/drivers/medtronicDriver.js
@@ -470,7 +470,7 @@ module.exports = function (config) {
     getConfigInfo: function (progress, data, cb) {
       if(!isBrowser) {
         data.connect = true;
-        data.settings = {modelNumber: 'Medtronic-from-cli'};
+        data.settings = {modelNumber: '523'}; //TODO: get from device
         return cb(null, data);
       }
       debug('in getConfigInfo', data);

--- a/lib/medtronic/processData.js
+++ b/lib/medtronic/processData.js
@@ -104,10 +104,14 @@ var RECORD_TYPES = {
 };
 
 var BITMASKS = {
-  LEFT_TWO: 0xc0,   // b11000000
-  RIGHT_SIX: 0x3f,  // b00111111
-  RIGHT_FIVE: 0x1f, // b00011111
-  RIGHT_SEVEN: 0x7f // b01111111
+  LEFT_TWO: 0xc0,     // b11000000
+  RIGHT_SIX: 0x3f,    // b00111111
+  RIGHT_FIVE: 0x1f,   // b00011111
+  RIGHT_SEVEN: 0x7f,  // b01111111
+  RIGHT_TWO: 0x03,    // b00000011
+  RIGHT_1100: 0x0c,   // b00001100
+  RIGHT_THREE: 0x07,  // b00000111
+  LEFT_00111: 0x38    // b00111000
 };
 
 var cfg;
@@ -195,18 +199,29 @@ var buildWizardRecords = function (records) {
   wizardRecords.forEach(function(record) {
     console.log('Wizard:', record.jsDate, common.bytes2hex(record.date), common.bytes2hex(record.body));
 
-    var carbInput, bgRaw, bgInput, carbRatio, bgTarget = {}, isf, recommended = {}, iob;
+    var carbInput, bgInput, carbRatio, bgTarget = {}, isf, recommended = {}, iob;
     if (larger) {
-      carbInput = struct.extractByte(record.body,0);
-      bgRaw = [struct.extractByte(record.head,1)];
-      bgRaw = bgRaw.concat(struct.extractByte(record.body,1) & 0x0f);
-      bgInput = struct.extractShort(bgRaw,0);
-      carbRatio = struct.extractByte(record.body,14) / 10.0;
+      var bgRaw = [struct.extractByte(record.body,1) & BITMASKS.RIGHT_TWO];
+      bgRaw = bgRaw.concat(struct.extractByte(record.head,1));
+      bgInput = struct.extractBEShort(bgRaw,0);
+
+      var carbRaw = [(struct.extractByte(record.body,1) & BITMASKS.RIGHT_1100) >> 2];
+      carbRaw = carbRaw.concat(struct.extractByte(record.body,0));
+      carbInput = struct.extractBEShort(carbRaw,0);
+
+      var carbRatioRaw = [struct.extractByte(record.body,2) & BITMASKS.RIGHT_THREE];
+      carbRatioRaw = carbRatioRaw.concat(struct.extractByte(record.body,3));
+      carbRatio = struct.extractBEShort(carbRatioRaw,0) / 10.0;
+
       bgTarget.low = struct.extractByte(record.body,5);
       isf = struct.extractByte(record.body,4);
-      bgTarget.high = struct.extractByte(record.body,3);
+      bgTarget.high = struct.extractByte(record.body,14);
       recommended.carb = struct.extractBEShort(record.body,7) / strokesPerUnit;
-      recommended.correction = struct.extractByte(record.body,6) / strokesPerUnit;
+
+      var correctionRaw = [(struct.extractByte(record.body,9) & BITMASKS.LEFT_00111) >> 3];
+      correctionRaw = correctionRaw.concat(struct.extractByte(record.body,6));
+      recommended.correction = struct.extractBEShort(correctionRaw,0) / strokesPerUnit;
+
       recommended.net = struct.extractBEShort(record.body,12) / strokesPerUnit;
       iob =  struct.extractBEShort(record.body,10) / strokesPerUnit;
     } else {

--- a/lib/medtronic/processData.js
+++ b/lib/medtronic/processData.js
@@ -27,7 +27,8 @@ var savedFileEntry, fileDisplayPath;
 var debug = (typeof __DEBUG__ === 'undefined') ? false : __DEBUG__;
 var isBrowser = typeof window !== 'undefined';
 
-var larger = true; //TODO: this should be based on model number
+var larger = false; // model 523 has larger records
+var strokesPerUnit = 10.0; // for model 523 it's 40.0
 
 var RECORD_TYPES = {
   BOLUS: { value: 0x01, head_length: 5, larger: { head_length: 8 }, name: 'BOLUS'},
@@ -193,20 +194,24 @@ var buildWizardRecords = function (records) {
   var postrecords = [];
   wizardRecords.forEach(function(record) {
     console.log('Wizard:', record.jsDate, common.bytes2hex(record.date), common.bytes2hex(record.body));
-    var carbInput = struct.extractByte(record.body,0);
-    var bgRaw = [struct.extractByte(record.head,1)];
-    bgRaw = bgRaw.concat(struct.extractByte(record.body,1) & 0x0f);
-    var bgInput = struct.extractShort(bgRaw,0);
-    var carbRatio = struct.extractByte(record.body,14) / 10.0;
-    var bgTarget = {};
-    bgTarget.low = struct.extractByte(record.body,5);
-    var isf = struct.extractByte(record.body,4);
-    bgTarget.high = struct.extractByte(record.body,3);
-    var recommended = {};
-    recommended.carb = struct.extractBEShort(record.body,7) / 40.0;
-    recommended.correction = struct.extractByte(record.body,6) / 40.0;
-    recommended.net = struct.extractBEShort(record.body,12) / 40.0;
-    var iob =  struct.extractBEShort(record.body,10) / 40.0;
+
+    var carbInput, bgRaw, bgInput, carbRatio, bgTarget = {}, isf, recommended = {}, iob;
+    if (larger) {
+      carbInput = struct.extractByte(record.body,0);
+      bgRaw = [struct.extractByte(record.head,1)];
+      bgRaw = bgRaw.concat(struct.extractByte(record.body,1) & 0x0f);
+      bgInput = struct.extractShort(bgRaw,0);
+      carbRatio = struct.extractByte(record.body,14) / 10.0;
+      bgTarget.low = struct.extractByte(record.body,5);
+      isf = struct.extractByte(record.body,4);
+      bgTarget.high = struct.extractByte(record.body,3);
+      recommended.carb = struct.extractBEShort(record.body,7) / strokesPerUnit;
+      recommended.correction = struct.extractByte(record.body,6) / strokesPerUnit;
+      recommended.net = struct.extractBEShort(record.body,12) / strokesPerUnit;
+      iob =  struct.extractBEShort(record.body,10) / strokesPerUnit;
+    } else {
+      //TODO: need to get a smaller wizard record first
+    }
 
     var wizard = cfg.builder.makeWizard()
       .with_recommended({
@@ -250,74 +255,78 @@ var buildBolusRecords = function (records) {
 
     var bolus;
 
-    if (larger) {
-      var duration = record.head[7] * 30 * sundial.MIN_TO_MSEC;
-      var amount = struct.extractBEShort(record.head,3)/40.0;
-      var programmed = struct.extractBEShort(record.head,1)/40.0;
-      var iob = struct.extractBEShort(record.head,5)/40.0;
-      if (duration > 0) {
-        //TODO: put iob in payload?
+    var amount, programmed, iob;
+    if(larger) {
+      amount = struct.extractBEShort(record.head,3)/strokesPerUnit;
+      programmed = struct.extractBEShort(record.head,1)/strokesPerUnit;
+      iob = struct.extractBEShort(record.head,5)/strokesPerUnit;
+    } else {
+      amount = struct.extractByte(record.head,2)/strokesPerUnit;
+      programmed = struct.extractByte(record.head,1)/strokesPerUnit;
+      iob = null;
+    }
 
-        if((record.date[2] & BITMASKS.LEFT_TWO) === 0x80) {
-          // we mask out the time from the hour byte and check if the result is binary 10
-          bolus = cfg.builder.makeDualBolus()
+    var duration = record.head[7] * 30 * sundial.MIN_TO_MSEC;
+
+    if (duration > 0) {
+      //TODO: put iob in payload?
+
+      if((record.date[2] & BITMASKS.LEFT_TWO) === 0x80) {
+        // we mask out the time from the hour byte and check if the result is binary 10
+        bolus = cfg.builder.makeDualBolus()
+          .with_duration(duration)
+          .with_extended(amount);
+
+          if(programmed !== amount) {
+            // dual bolus was cancelled
+            var actualDuration = Math.round((amount / (programmed * 1.0)) * duration);
+            bolus = bolus.with_expectedExtended(programmed)
+                      .with_expectedDuration(duration)
+                      .with_duration(actualDuration);
+          }
+
+          i+=1; // advance to next bolus for normal portion
+          //TODO: add second index to payload
+          record = bolusRecords[i];
+          amount = struct.extractBEShort(record.head,3)/strokesPerUnit;
+          programmed = struct.extractBEShort(record.head,1)/strokesPerUnit;
+          iob = struct.extractBEShort(record.head,5)/strokesPerUnit;
+
+          bolus = bolus.with_normal(amount);
+          if(programmed !== amount) {
+            bolus = bolus.with_expectedNormal(programmed);
+          }
+      } else {
+          bolus = cfg.builder.makeSquareBolus()
             .with_duration(duration)
             .with_extended(amount);
 
             if(programmed !== amount) {
-              // dual bolus was cancelled
+              // square bolus was cancelled
               var actualDuration = Math.round((amount / (programmed * 1.0)) * duration);
               bolus = bolus.with_expectedExtended(programmed)
                         .with_expectedDuration(duration)
                         .with_duration(actualDuration);
             }
-
-            i+=1; // advance to next bolus for normal portion
-            //TODO: add second index to payload
-            record = bolusRecords[i];
-            amount = struct.extractBEShort(record.head,3)/40.0;
-            programmed = struct.extractBEShort(record.head,1)/40.0;
-            iob = struct.extractBEShort(record.head,5)/40.0;
-
-            bolus = bolus.with_normal(amount);
-            if(programmed !== amount) {
-              bolus = bolus.with_expectedNormal(programmed);
-            }
-        } else {
-            bolus = cfg.builder.makeSquareBolus()
-              .with_duration(duration)
-              .with_extended(amount);
-
-              if(programmed !== amount) {
-                // square bolus was cancelled
-                var actualDuration = Math.round((amount / (programmed * 1.0)) * duration);
-                bolus = bolus.with_expectedExtended(programmed)
-                          .with_expectedDuration(duration)
-                          .with_duration(actualDuration);
-              }
-          }
-
-        } else {
-          // normal bolus
-          bolus = cfg.builder.makeNormalBolus()
-            .with_normal(amount);
-
-          if(programmed !== amount) {
-            bolus = bolus.with_expectedNormal(programmed);
-          }
         }
 
-      bolus = bolus.with_deviceTime(sundial.formatDeviceTime(record.jsDate))
-          .set('index', record.index)
-          .set('jsDate', record.jsDate);
+      } else {
+        // normal bolus
+        bolus = cfg.builder.makeNormalBolus()
+          .with_normal(amount);
 
-      cfg.tzoUtil.fillInUTCInfo(bolus, record.jsDate);
-      bolus = bolus.done();
-      postrecords.push(bolus);
+        if(programmed !== amount) {
+          bolus = bolus.with_expectedNormal(programmed);
+        }
+      }
 
-    } else {
-      // TODO: handle smaller bolus records
-    }
+    bolus = bolus.with_deviceTime(sundial.formatDeviceTime(record.jsDate))
+        .set('index', record.index)
+        .set('jsDate', record.jsDate);
+
+    cfg.tzoUtil.fillInUTCInfo(bolus, record.jsDate);
+    bolus = bolus.done();
+    postrecords.push(bolus);
 
   };
 
@@ -330,6 +339,11 @@ var processPages = function(data, callback) {
   var numRecords = 0;
   var pages = data.pages;
   var MAX_PAGE_SIZE = 1024;
+
+  if(data.settings.modelNumber === '523') {
+    strokesPerUnit = 40.0;
+    larger = true;
+  }
 
   if(debug && isBrowser) {
     savePages(pages);

--- a/lib/medtronic/processData.js
+++ b/lib/medtronic/processData.js
@@ -111,7 +111,8 @@ var BITMASKS = {
   RIGHT_TWO: 0x03,    // b00000011
   RIGHT_1100: 0x0c,   // b00001100
   RIGHT_THREE: 0x07,  // b00000111
-  LEFT_00111: 0x38    // b00111000
+  LEFT_00111: 0x38,   // b00111000
+  RIGHT_FOUR: 0x0f    // b00001111
 };
 
 var cfg;
@@ -193,6 +194,13 @@ var filterHistory = function (types, log_records) {
   });
 };
 
+var twosComplement = function (value) {
+  if((value & 128) != 0 ) { // check if highest bit is set
+    value = value - 256; // use two complement to get negative value
+  }
+  return value;
+};
+
 var buildWizardRecords = function (records) {
   var wizardRecords = filterHistory([RECORD_TYPES.BOLUS_WIZARD], records);
   var postrecords = [];
@@ -225,7 +233,24 @@ var buildWizardRecords = function (records) {
       recommended.net = struct.extractBEShort(record.body,12) / strokesPerUnit;
       iob =  struct.extractBEShort(record.body,10) / strokesPerUnit;
     } else {
-      //TODO: need to get a smaller wizard record first
+      var bgRaw = [struct.extractByte(record.body,1) & BITMASKS.RIGHT_FOUR];
+      bgRaw = bgRaw.concat(struct.extractByte(record.head,1));
+      bgInput = struct.extractBEShort(bgRaw,0);
+
+      carbInput = struct.extractByte(record.body,0);
+      carbRatio = struct.extractByte(record.body,2);
+
+      bgTarget.low = struct.extractByte(record.body,4);
+      isf = struct.extractByte(record.body,3);
+      bgTarget.high = struct.extractByte(record.body,12);
+      recommended.carb = struct.extractBEShort(record.body,6) / strokesPerUnit;
+
+      var correctionRaw = [twosComplement(struct.extractByte(record.body,5) & BITMASKS.RIGHT_FOUR)];
+      correctionRaw = correctionRaw.concat(twosComplement(struct.extractByte(record.body,7)));
+      recommended.correction = struct.extractBEShort(correctionRaw,0) / strokesPerUnit;
+
+      recommended.net = struct.extractBEShort(record.body,11) / strokesPerUnit;
+      iob =  struct.extractBEShort(record.body,9) / strokesPerUnit;
     }
 
     var wizard = cfg.builder.makeWizard()

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Tidepool Uploader",
   "short_name": "Uploader",
-  "version": "0.286.1",
+  "version": "0.286.2",
   "description": "The Tidepool Uploader helps you get your data from insulin pumps, CGMs and BG meters into Tidepool’s secure cloud platform.",
   "minimum_chrome_version": "38",
   "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Tidepool Uploader",
   "short_name": "Uploader",
-  "version": "0.286.4",
+  "version": "0.286.5",
   "description": "The Tidepool Uploader helps you get your data from insulin pumps, CGMs and BG meters into Tidepool’s secure cloud platform.",
   "minimum_chrome_version": "38",
   "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Tidepool Uploader",
   "short_name": "Uploader",
-  "version": "0.286.3",
+  "version": "0.286.4",
   "description": "The Tidepool Uploader helps you get your data from insulin pumps, CGMs and BG meters into Tidepool’s secure cloud platform.",
   "minimum_chrome_version": "38",
   "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Tidepool Uploader",
   "short_name": "Uploader",
-  "version": "0.286.6",
+  "version": "0.286.7",
   "description": "The Tidepool Uploader helps you get your data from insulin pumps, CGMs and BG meters into Tidepool’s secure cloud platform.",
   "minimum_chrome_version": "38",
   "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Tidepool Uploader",
   "short_name": "Uploader",
-  "version": "0.286.2",
+  "version": "0.286.3",
   "description": "The Tidepool Uploader helps you get your data from insulin pumps, CGMs and BG meters into Tidepool’s secure cloud platform.",
   "minimum_chrome_version": "38",
   "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Tidepool Uploader",
   "short_name": "Uploader",
-  "version": "0.286.0",
+  "version": "0.286.1",
   "description": "The Tidepool Uploader helps you get your data from insulin pumps, CGMs and BG meters into Tidepool’s secure cloud platform.",
   "minimum_chrome_version": "38",
   "icons": {
@@ -25,7 +25,11 @@
     "http://localhost/",
     "https://*.tidepool.org/",
     "contextMenus",
-    {"fileSystem": ["write"]},
+    {
+      "fileSystem": [
+        "write"
+      ]
+    },
     "system.storage",
     "storage",
     "serial",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Tidepool Uploader",
   "short_name": "Uploader",
-  "version": "0.286.5",
+  "version": "0.286.6",
   "description": "The Tidepool Uploader helps you get your data from insulin pumps, CGMs and BG meters into Tidepool’s secure cloud platform.",
   "minimum_chrome_version": "38",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "0.286.3",
+  "version": "0.286.4",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "0.286.0",
+  "version": "0.286.1",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "0.286.2",
+  "version": "0.286.3",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "0.286.1",
+  "version": "0.286.2",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "0.286.6",
+  "version": "0.286.7",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "0.286.5",
+  "version": "0.286.6",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "0.286.4",
+  "version": "0.286.5",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",


### PR DESCRIPTION
The 523 model (used for development) has some differences compared to other pump models:
- Some records are larger
- Some units from the pump need to be divided by 40.0 instead of 10.0 (`strokesPerUnit`) to get the correct value

This PR also fixes some issues with calculator/wizard boluses and adds support for the other pump models.