### PR TITLE
Use dataservices endpoint, not platform

### DIFF
--- a/.config.js
+++ b/.config.js
@@ -39,7 +39,7 @@ module.exports = {
   // the defaults for these need to be pointing to prod
   API_URL: process.env.API_URL || 'https://api.tidepool.org',
   UPLOAD_URL: process.env.UPLOAD_URL || 'https://uploads.tidepool.org',
-  DATA_URL: process.env.DATA_URL || 'https://api.tidepool.org/platform',
+  DATA_URL: process.env.DATA_URL || 'https://api.tidepool.org/dataservices',
   BLIP_URL: process.env.BLIP_URL || 'https://blip.tidepool.org',
   DEFAULT_TIMEZONE: process.env.DEFAULT_TIMEZONE || 'America/Los_Angeles',
   DEFAULT_CARELINK_DAYS: process.env.DEFAULT_CARELINK_DAYS || '180'

--- a/config/integration.sh
+++ b/config/integration.sh
@@ -1,7 +1,7 @@
 export API_URL='https://int-api.tidepool.org'
 export UPLOAD_URL='https://int-uploads.tidepool.org'
 export BLIP_URL='https://int-blip.tidepool.org'
-export DATA_URL='https://int-api.tidepool.org/platform'
+export DATA_URL='https://int-api.tidepool.org/dataservices'
 export DEBUG_ERROR=false
 export REDUX_LOG=false
 export REDUX_DEV_UI=false

--- a/config/staging.sh
+++ b/config/staging.sh
@@ -1,7 +1,7 @@
 export API_URL='https://stg-api.tidepool.org'
 export UPLOAD_URL='https://stg-uploads.tidepool.org'
 export BLIP_URL='https://stg-blip.tidepool.org'
-export DATA_URL='https://stg-api.tidepool.org/platform'
+export DATA_URL='https://stg-api.tidepool.org/dataservices'
 export DEBUG_ERROR=false
 export REDUX_LOG=false
 export REDUX_DEV_UI=false

--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -494,7 +494,7 @@ api.upload.toPlatform = function(data, sessionInfo, progress, groupId, cb, uploa
         post_dataset_create(uploadItem, function(err, dataset){
           if(_.isEmpty(err)){
             api.log('created dataset');
-            datasetId = _.get(dataset, 'uploadId');
+            datasetId = _.get(dataset, 'data.uploadId');
             if(_.isEmpty(datasetId)){
               api.log('created dataset does not include uploadId');
               return callback(new Error(format('Dataset response does not contain uploadId.')));

--- a/main.js
+++ b/main.js
@@ -58,14 +58,6 @@ var contextMenus = [
   },
   {
     type: 'radio',
-    id: 'Clinic',
-    title: 'Clinic',
-    contexts: contexts,
-    parentId: 'MENUROOT',
-    checked: false
-  },
-  {
-    type: 'radio',
     id: 'Staging',
     title: 'Staging',
     contexts: contexts,
@@ -103,12 +95,6 @@ function setServer(window, info) {
       UPLOAD_URL: 'https://dev-uploads.tidepool.org',
       DATA_URL: 'https://dev-api.tidepool.org/platform',
       BLIP_URL: 'https://dev-blip.tidepool.org'
-    },
-    Clinic: {
-      API_URL: 'https://dev-clinic-api.tidepool.org',
-      UPLOAD_URL: 'https://dev-clinic-uploads.tidepool.org',
-      DATA_URL: 'https://dev-clinic-api.tidepool.org/platform',
-      BLIP_URL: 'https://dev-clinic-blip.tidepool.org'
     },
     Staging: {
       API_URL: 'https://stg-api.tidepool.org',

--- a/main.js
+++ b/main.js
@@ -93,25 +93,25 @@ function setServer(window, info) {
     Development: {
       API_URL: 'https://dev-api.tidepool.org',
       UPLOAD_URL: 'https://dev-uploads.tidepool.org',
-      DATA_URL: 'https://dev-api.tidepool.org/platform',
+      DATA_URL: 'https://dev-api.tidepool.org/dataservices',
       BLIP_URL: 'https://dev-blip.tidepool.org'
     },
     Staging: {
       API_URL: 'https://stg-api.tidepool.org',
       UPLOAD_URL: 'https://stg-uploads.tidepool.org',
-      DATA_URL: 'https://stg-api.tidepool.org/platform',
+      DATA_URL: 'https://stg-api.tidepool.org/dataservices',
       BLIP_URL: 'https://stg-blip.tidepool.org'
     },
     Integration: {
       API_URL: 'https://int-api.tidepool.org',
       UPLOAD_URL: 'https://int-uploads.tidepool.org',
-      DATA_URL: 'https://int-api.tidepool.org/platform',
+      DATA_URL: 'https://int-api.tidepool.org/dataservices',
       BLIP_URL: 'https://int-blip.tidepool.org'
     },
     Production: {
       API_URL: 'https://api.tidepool.org',
       UPLOAD_URL: 'https://uploads.tidepool.org',
-      DATA_URL: 'https://api.tidepool.org/platform',
+      DATA_URL: 'https://api.tidepool.org/dataservices',
       BLIP_URL: 'https://blip.tidepool.org'
     }
   };

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "semver": "5.1.0",
     "stack-trace": "0.0.9",
     "sundial": "1.6.0",
-    "tidepool-platform-client": "0.27.0"
+    "tidepool-platform-client": "0.28.0"
   },
   "devDependencies": {
     "babel-core": "5.8.38",


### PR DESCRIPTION
@gniezen Use the dataservices endpoints (rather than platform; using 'platform' for the entry was a mistake since we know there are multiple "platform services" that need to be exposed).

Subtle changes to the API since we have to change the endpoints anyhow.

Also removed old Clinic endpoints.

This can only be deployed after the Delete Errant Uploads work (which includes the platform related separation) is deployed to prd.

CC @jh-bate 