### PR TITLE
Fix for Animas missing records bug

### DIFF
--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -1500,8 +1500,6 @@ module.exports = function (config) {
           firstPass = false;
 
         }, function(err, result) {
-          // remove empty and invalid records
-          _.remove(result, function (item) { return item.empty || item.jsDate === null;});
           cb(null,result);
         });
       }
@@ -2042,6 +2040,10 @@ module.exports = function (config) {
         }
 
         if(!missing) {
+
+          // remove empty and invalid records
+          _.remove(records, function (item) { return item.empty || item.jsDate === null;});
+
           return records;
         } else {
           return false;

--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -1599,16 +1599,16 @@ module.exports = function (config) {
     var wizard = null;
     for(var b in data.wizardRecords) {
       var wizarddatum = data.wizardRecords[b];
-      var bolusdatum = postrecords[b];
+      var bolusdatum = _.findWhere(postrecords, { 'index': wizarddatum.index, 'syncCounter': wizarddatum.sync_counter });
 
-      if(bolusdatum.payload.bgOrCarbTriggered === undefined || bolusdatum.payload.bgOrCarbTriggered === 'neither') {
+      if(bolusdatum == null || bolusdatum.payload.bgOrCarbTriggered === undefined || bolusdatum.payload.bgOrCarbTriggered === 'neither') {
         // don't build wizard records if it wasn't actually triggered by ezBG or ezCarb,
         // the wizard data will be stale and from a previous record
         continue;
       }
-      postrecords[b] = undefined; // we're going to embed the bolus in the wizard event
+      postrecords[_.indexOf(postrecords,bolusdatum)] = undefined; // we're going to embed the bolus in the wizard event
 
-      // bolus and wizard records must be matched to fill in timestamp
+      // double-check that bolus and wizard records are matched to fill in timestamp
       // needed for sorting, before passing to simulator
       if (bolusdatum.syncCounter !==  wizarddatum.sync_counter) {
         throw Error('Wizard bolus mismatch!', bolusdatum.syncCounter, wizarddatum.sync_counter);

--- a/lib/drivers/animasDriver.js
+++ b/lib/drivers/animasDriver.js
@@ -1599,7 +1599,7 @@ module.exports = function (config) {
     var wizard = null;
     for(var b in data.wizardRecords) {
       var wizarddatum = data.wizardRecords[b];
-      var bolusdatum = _.findWhere(postrecords, { 'index': wizarddatum.index, 'syncCounter': wizarddatum.sync_counter });
+      var bolusdatum = _.find(postrecords, { 'index': wizarddatum.index, 'syncCounter': wizarddatum.sync_counter });
 
       if(bolusdatum == null || bolusdatum.payload.bgOrCarbTriggered === undefined || bolusdatum.payload.bgOrCarbTriggered === 'neither') {
         // don't build wizard records if it wasn't actually triggered by ezBG or ezCarb,


### PR DESCRIPTION
See https://trello.com/c/skctayOf for more details.

In short: It's possible that a wizard record is completely empty. We only checked if all records are in sequence (e.g. 406, 407, 408) _after_ we delete empty records (which meant that we're getting a "missing record" error). Empty records are usually only found at the end, not in between other records, which is why this issue has not presented itself during testing. The solution is to delete empty records after the sequence check.

We also need to update the code that matches bolus records with wizard records, as we now know that some of these wizard records may be empty and cannot be matched up.
