### PR TITLE
Download binary blob and POST data, even if upload fails

### DIFF
--- a/lib/components/Upload.js
+++ b/lib/components/Upload.js
@@ -119,6 +119,45 @@ export default class Upload extends Component {
     }
   }
 
+  getDebugLinks(data) {
+
+    if(Array.isArray(data.post_records)) {
+
+      let filename = 'uploader-processed-records.json';
+      let jsonData = JSON.stringify(data.post_records, undefined, 4);
+      let blob = new Blob([jsonData], {type: 'text/json'});
+      let dataHref = URL.createObjectURL(blob);
+
+      let binary_link = null;
+      if(data.pages) {
+        let filenameBinary = 'binary-blob.json';
+        let jsonDataBinary = JSON.stringify(data.pages, undefined, 4);
+        let blobBinary = new Blob([jsonDataBinary], {type: 'text/json'});
+        let dataHrefBinary = URL.createObjectURL(blobBinary);
+        binary_link = (
+          <a href={dataHrefBinary}
+            className={styles.dataDownloadLink}
+            download={filenameBinary}
+            data-downloadurl={['text/json', filenameBinary, dataHrefBinary].join(':')}>
+            Binary blob
+          </a>
+        );
+      }
+      return (
+        <div>
+          <a href={dataHref}
+            className={styles.dataDownloadLink}
+            download={filename}
+            data-downloadurl={['text/json', filename, dataHref].join(':')}>
+            POST data
+          </a>&nbsp;
+          {binary_link}
+        </div>
+      );
+    }
+    return null;
+  }
+
   render() {
     return (
       <div className={styles.main}>
@@ -338,21 +377,18 @@ export default class Upload extends Component {
 
     if (upload.successful) {
       let dataDownloadLink = null;
-      if (__DEBUG__ && (!_.isEmpty(this.props.upload.data) && Array.isArray(this.props.upload.data))) {
-        let filename = 'uploader-processed-records.json';
-        let jsonData = JSON.stringify(this.props.upload.data, undefined, 4);
-        let blob = new Blob([jsonData], {type: 'text/json'});
-        let dataHref = URL.createObjectURL(blob);
-        dataDownloadLink = (
-          <a href={dataHref}
-            className={styles.dataDownloadLink}
-            download={filename}
-            data-downloadurl={['text/json', filename, dataHref].join(':')}>
-            Download POST data
-          </a>
-        );
+      if (__DEBUG__ && this.props.upload.data) {
+        dataDownloadLink = this.getDebugLinks(this.props.upload.data);
       }
       return <div className={styles.status}>{this.props.text.UPLOAD_COMPLETE}&nbsp;{dataDownloadLink}</div>;
+    }
+
+    if(upload.failed) {
+      let dataDownloadLink = null;
+      if (__DEBUG__ && this.props.upload.error.data) {
+        dataDownloadLink = this.getDebugLinks(this.props.upload.error.data);
+      }
+      return <div className={styles.status}>{dataDownloadLink}</div>;
     }
 
     if (this.isBlockModeFileChosen()) {

--- a/lib/components/Upload.js
+++ b/lib/components/Upload.js
@@ -384,7 +384,7 @@ export default class Upload extends Component {
 
     if (upload.successful) {
       let dataDownloadLink = null;
-      if (__DEBUG__ && this.props.upload.data) {
+      if (__DEBUG__ && !_.isEmpty(this.props.upload.data)) {
         dataDownloadLink = this.getDebugLinks(this.props.upload.data);
       }
       return <div className={styles.status}>{this.props.text.UPLOAD_COMPLETE}&nbsp;{dataDownloadLink}</div>;

--- a/lib/components/Upload.js
+++ b/lib/components/Upload.js
@@ -121,38 +121,44 @@ export default class Upload extends Component {
 
   getDebugLinks(data) {
 
+    let post_link = null;
     if(Array.isArray(data.post_records)) {
 
       let filename = 'uploader-processed-records.json';
       let jsonData = JSON.stringify(data.post_records, undefined, 4);
       let blob = new Blob([jsonData], {type: 'text/json'});
       let dataHref = URL.createObjectURL(blob);
+      post_link = (
+        <a href={dataHref}
+          className={styles.dataDownloadLink}
+          download={filename}
+          data-downloadurl={['text/json', filename, dataHref].join(':')}>
+          POST data
+        </a>
+      );
+    }
 
-      let binary_link = null;
-      if(data.pages) {
-        let filenameBinary = 'binary-blob.json';
-        let blob = { settings:data.settings, pages:data.pages };
-        let jsonDataBinary = JSON.stringify(blob, undefined, 4);
-        let blobBinary = new Blob([jsonDataBinary], {type: 'text/json'});
-        let dataHrefBinary = URL.createObjectURL(blobBinary);
-        binary_link = (
-          <a href={dataHrefBinary}
-            className={styles.dataDownloadLink}
-            download={filenameBinary}
-            data-downloadurl={['text/json', filenameBinary, dataHrefBinary].join(':')}>
-            Binary blob
-          </a>
-        );
-      }
+    let binary_link = null;
+    if(Array.isArray(data.pages)) {
+      let filenameBinary = 'binary-blob.json';
+      let blob = { settings:data.settings, pages:data.pages };
+      let jsonDataBinary = JSON.stringify(blob, undefined, 4);
+      let blobBinary = new Blob([jsonDataBinary], {type: 'text/json'});
+      let dataHrefBinary = URL.createObjectURL(blobBinary);
+      binary_link = (
+        <a href={dataHrefBinary}
+          className={styles.dataDownloadLink}
+          download={filenameBinary}
+          data-downloadurl={['text/json', filenameBinary, dataHrefBinary].join(':')}>
+          Binary blob
+        </a>
+      );
+    }
+
+    if(post_link || binary_link) {
       return (
         <div>
-          <a href={dataHref}
-            className={styles.dataDownloadLink}
-            download={filename}
-            data-downloadurl={['text/json', filename, dataHref].join(':')}>
-            POST data
-          </a>&nbsp;
-          {binary_link}
+          {post_link}&nbsp;{binary_link}
         </div>
       );
     }

--- a/lib/components/Upload.js
+++ b/lib/components/Upload.js
@@ -131,7 +131,8 @@ export default class Upload extends Component {
       let binary_link = null;
       if(data.pages) {
         let filenameBinary = 'binary-blob.json';
-        let jsonDataBinary = JSON.stringify(data.pages, undefined, 4);
+        let blob = { settings:data.settings, pages:data.pages };
+        let jsonDataBinary = JSON.stringify(blob, undefined, 4);
         let blobBinary = new Blob([jsonDataBinary], {type: 'text/json'});
         let dataHrefBinary = URL.createObjectURL(blobBinary);
         binary_link = (

--- a/lib/core/device.js
+++ b/lib/core/device.js
@@ -357,10 +357,7 @@ device.detectAll = function(cb) {
 device.upload = function(driverId, options, cb) {
   var dm = this._createDriverManager(driverId, options);
   dm.process(driverId, function(err, result) {
-    if (err) {
-      return cb(err);
-    }
-    return cb(null, result.post_records);
+    return cb(err, result);
   });
 };
 

--- a/lib/drivers/medtronicDriver.js
+++ b/lib/drivers/medtronicDriver.js
@@ -857,7 +857,6 @@ module.exports = function (config) {
         data.processData = true;
 
         data.post_records = simulator.getEvents();
-        delete data.pages;
         console.log('Data:', JSON.stringify(data, null, '\t'));
         cb(null, data);
       });

--- a/lib/medtronic/processData.js
+++ b/lib/medtronic/processData.js
@@ -157,46 +157,6 @@ var decodeDate = function (payload) {
  return date;
 };
 
-var savePages = function(data) {
-  function exportToFileEntry(fileEntry) {
-    savedFileEntry = fileEntry;
-
-    // TODO: this should be changed to a link that says "Download blob" instead
-    chrome.fileSystem.getDisplayPath(fileEntry, function(path) {
-      fileDisplayPath = path;
-      console.log('Exporting to '+path);
-
-      fileEntry.createWriter(function(fileWriter) {
-        var json = JSON.stringify(data);
-        var blob = new Blob([json], {type: 'application/json'});
-
-        fileWriter.onwriteend = function(e) {
-          console.log('Export to '+fileDisplayPath+' completed');
-        };
-
-        fileWriter.onerror = function(e) {
-          console.log('Export failed: '+e.toString());
-        };
-
-        fileWriter.write(blob);
-
-      });
-    });
-  }
-
-  if (savedFileEntry) {
-    exportToFileEntry(savedFileEntry);
-  } else {
-    chrome.fileSystem.chooseEntry( {
-      type: 'saveFile',
-      suggestedName: 'medtronicPages.json',
-      accepts: [ { description: 'Binary files (*.json)',
-                   extensions: ['json']} ],
-      acceptsAllTypes: true
-    }, exportToFileEntry);
-  }
-};
-
 var getType = function (idx) {
   for (var i in RECORD_TYPES) {
     if (RECORD_TYPES[i].value === idx) {
@@ -747,12 +707,6 @@ var processPages = function(data, callback) {
   var numRecords = 0;
   var pages = data.pages;
   var MAX_PAGE_SIZE = 1024;
-
-  if(debug && isBrowser) {
-    var fileData  = { pages: pages,
-                      settings: _.clone(data.settings) };
-    savePages(fileData);
-  }
 
   for(var i = pages.length - 1; i >= 0; i--) {
     // pages are reverse chronological, but records in each page are chronological

--- a/lib/redux/actions/utils.js
+++ b/lib/redux/actions/utils.js
@@ -72,7 +72,8 @@ export function makeUploadCb(dispatch, getState, errCode, utc) {
         datasetId: err.datasetId || null,
         requestTrace: err.requestTrace || null,
         code: errCode,
-        version: version
+        version: version,
+        data: recs
       };
 
       if (!__TEST__) {


### PR DESCRIPTION
The Medtronic driver is able to provide us with both the raw binary (blob) data and processed (POST) data. The changes in this PR allows you to download both files, even if the upload has failed.