### PR TITLE
fix Markdown filename in SUMMARY.md

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -36,4 +36,4 @@
    * [PWD "simulators"](docs/misc/PWDSimulators.md)
    * [challenges of flat basal profiles](docs/misc/FlatRateBasals.md)
    * [2015.06 CareLink CSV updates](docs/misc/2015.06.29CareLinkCSVChanges.md)
-   * [Medtronic packet diagrams](lib/medtronic/docs/PacketStructure.md)
+   * [Medtronic packet diagrams](lib/medtronic/docs/packetStructure.md)


### PR DESCRIPTION
Was this your issue? The packet structure file wasn't being read properly by Gitbook at all because you had a typo in the SUMMARY.md... (This was fairly obvious to me because the item for the page in the left-hand TOC was grayed out.)

Will the SUMMARY.md fixed, I see all the images locally.