### PR TITLE
Bugfix: Now correctly handles cancelled temp basals running over midnight

### DIFF
--- a/lib/medtronic/medtronicSimulator.js
+++ b/lib/medtronic/medtronicSimulator.js
@@ -96,9 +96,15 @@ exports.make = function(config){
           console.log(currBasal.deviceTime, 'startTime:', startTime, 'endTime', endTime, 'currSchedule.start', currSchedule[i].start, currSchedule[i].rate);
 
           if(cancelled) {
-            // we should stop when a temp basal was cancelled
-            var cancelTime = common.computeMillisInCurrentDay(cancelled);
-            if (cancelTime < currSchedule[i].start) {
+            // we should stop looking for schedule changes after a temp basal was cancelled
+
+            if (currBasal.time.slice(0,10) === cancelled.time.slice(0,10) && (durationBeforeMidnight > 0)) {
+              // temp basal was cancelled before midnight and we're now looking after midnight
+              break;
+            }
+
+            if (common.computeMillisInCurrentDay(cancelled) < currSchedule[i].start ) {
+              // temp basal was cancelled before new schedule started
               break;
             }
           }
@@ -169,7 +175,7 @@ exports.make = function(config){
 
       if (endTime >= TWENTY_FOUR_HOURS) {
         //check before midnight
-        checkSchedules(startTime, TWENTY_FOUR_HOURS - startTime, 0);
+        checkSchedules(startTime, TWENTY_FOUR_HOURS, 0);
         //check after midnight
         checkSchedules(0, endTime - TWENTY_FOUR_HOURS, TWENTY_FOUR_HOURS - startTime);
       } else {
@@ -252,6 +258,7 @@ exports.make = function(config){
             currBasal = currBasal.done();
             events.push(currBasal);
             setCurrBasal(null);
+
             return;
           }
 


### PR DESCRIPTION
Even if a temp basal is cancelled, we still need to figure out if there were any scheduled basal changes while the temp basal was running to make sure the suppressed info is correct. 

The issue here was that if a temp basal runs over midnight, we should make sure that we don't look for schedule changes after midnight if the temp basal was already cancelled before midnight.

Why is this so tricky? Well, schedule changes are stated in "milliseconds since midnight", which is why there are edge cases if a temp basal runs over midnight.

I added unit tests for:
- a temp basal that should run over midnight but is cancelled before a schedule change at midnight
- a temp basal runs over midnight and is cancelled after a schedule change at midnight