### PR TITLE
Medtronic initial settings

### DIFF
--- a/lib/drivers/medtronicDriver.js
+++ b/lib/drivers/medtronicDriver.js
@@ -1083,7 +1083,8 @@ module.exports = function (config) {
             postrecords = postrecords.concat(proc.buildBGRecords(records));
             postrecords = postrecords.concat(proc.buildTempBasalRecords(records));
             postrecords = postrecords.concat(proc.buildBasalRecords(records));
-            postrecords = postrecords.concat(proc.buildSettings(records));
+            var buildsettings = proc.buildSettings(records);
+            postrecords = postrecords.concat(buildsettings.postrecords);
             postrecords = postrecords.concat(proc.buildSuspendResumeRecords(records));
             postrecords = postrecords.concat(proc.buildAlarmRecords(records));
             postrecords = postrecords.concat(proc.buildPrimeRecords(records));
@@ -1099,6 +1100,14 @@ module.exports = function (config) {
 
           // sort by log index
           postrecords = _.sortBy(postrecords, function(d) { return d.index; });
+
+          // use first record's date for initial settings
+          var initialSettings = buildsettings.initialSettings;
+          initialSettings.set('index', postrecords[0].index)
+            .with_deviceTime(sundial.formatDeviceTime(postrecords[0].jsDate));
+          cfg.tzoUtil.fillInUTCInfo(initialSettings, postrecords[0].jsDate);
+          postrecords.unshift(initialSettings.done());
+
           // sort by time
           postrecords = _.sortBy(postrecords, function(d) { return d.time; });
 

--- a/lib/medtronic/processData.js
+++ b/lib/medtronic/processData.js
@@ -884,14 +884,13 @@ function buildSettings(records) {
               .with_carbRatio(first.carbRatio)
               .with_insulinSensitivity(first.insulinSensitivity)
               .with_bgTarget(first.bgTarget)
-              .set('index', records[0].index)
               .with_basalSchedules(first.basalSchedules)
-              .with_activeSchedule(first.activeSchedule)
-              .with_deviceTime(sundial.formatDeviceTime(records[0].jsDate));
-  cfg.tzoUtil.fillInUTCInfo(initialSettings, records[0].jsDate);
-  postrecords.push(initialSettings.done());
+              .with_activeSchedule(first.activeSchedule);
 
-  return postrecords;
+  return {
+            postrecords : postrecords,
+            initialSettings : initialSettings
+         };
 
 }
 

--- a/lib/medtronic/processData.js
+++ b/lib/medtronic/processData.js
@@ -875,6 +875,22 @@ function buildSettings(records) {
 
   }
 
+  // also, record initial pump settings. We don't know exactly when these initial
+  // settings were record, so we use the time of the first available record
+  var initialSettings = cfg.builder.makePumpSettings();
+  var first = settingsChanges[settingsChanges.length-1];
+
+  initialSettings.with_units(first.units)
+              .with_carbRatio(first.carbRatio)
+              .with_insulinSensitivity(first.insulinSensitivity)
+              .with_bgTarget(first.bgTarget)
+              .set('index', records[0].index)
+              .with_basalSchedules(first.basalSchedules)
+              .with_activeSchedule(first.activeSchedule)
+              .with_deviceTime(sundial.formatDeviceTime(records[0].jsDate));
+  cfg.tzoUtil.fillInUTCInfo(initialSettings, records[0].jsDate);
+  postrecords.push(initialSettings.done());
+
   return postrecords;
 
 }


### PR DESCRIPTION
While we do record all pump settings changes, this PR adds the initial pump settings at the first data point. We have a record of both the old and the new setting at a given time, so we build up the settings history by starting from the current settings and working our way back through the changes. This means that the first "old" settings will be the initial settings.