### PR TITLE
Not using mult-record requests for firmware 54676

### DIFF
--- a/lib/drivers/tandemDriver.js
+++ b/lib/drivers/tandemDriver.js
@@ -1251,6 +1251,14 @@ module.exports = function (config) {
     var end_seq;
     var start_seq;
 
+    var isMultiRecordFirmware = function() {
+      return (data.firmware_version >= COMMANDS.LOG_ENTRY_SEQ_MULTI_REQ.version) &&
+      (data.firmware_version !== 54676);
+      // Firmware #54676 is a special case, where it is supposed to be able to perform
+      // multi-record downloads, but sometimes fails halfway through. Tandem has confirmed
+      // there is an issue with that specific build, so we fall back to regular requests.
+    };
+
     function iterate(err, result) {
       if (err) {
         if(err.name === 'multi-fail') {
@@ -1269,7 +1277,7 @@ module.exports = function (config) {
           debug('fetched all records');
           data.log_records = retval;
 
-          if(data.firmware_version >= COMMANDS.LOG_ENTRY_SEQ_MULTI_STOP_DUMP.version)
+          if(isMultiRecordFirmware())
             tandemCommand(COMMANDS.LOG_ENTRY_SEQ_MULTI_STOP_DUMP, null, function (err) {
               if(err) {
                 callback(err,null);
@@ -1288,7 +1296,7 @@ module.exports = function (config) {
     end_seq = data.end_seq;
     start_seq = data.start_seq;
     debug('Firmware version is #',data.firmware_version);
-    if(data.firmware_version >= COMMANDS.LOG_ENTRY_SEQ_MULTI_REQ.version) {
+    if(isMultiRecordFirmware()) {
       // woohoo, we can use multi-record downloads!
       debug('Using multi-record requests');
       multiLogRequester(start_seq, end_seq, progress, iterate);


### PR DESCRIPTION
See https://trello.com/c/A5tVANo1 for details.

@jebeck Can you review and test with your #54676 pump firmware? If you search for `firmware` in the logs, it should show with something like

```
Firmware version is # 54676
tandemLogRequester 26088 31932
```

instead of

```
Firmware version is # 54676
Using multi-record requests
multiLogRequester 62805 97808
```