### PR TITLE
OmniPod: drop unbootstrappable alarms that fail UTC lookup

### DIFF
--- a/lib/TimezoneOffsetUtil.js
+++ b/lib/TimezoneOffsetUtil.js
@@ -231,14 +231,14 @@ module.exports = function(timezone, mostRecent, changes) {
     var res = this.lookup(jsDate, lookupIndex);
     if (!res) {
       debug('Could not look up UTC info for:', obj);
-      throw new Error('Failed to look up UTC info!');
-    }
-    obj.time = res.time;
-    obj.timezoneOffset = res.timezoneOffset;
-    obj.clockDriftOffset = res.clockDriftOffset;
-    obj.conversionOffset = res.conversionOffset;
-    if (obj.index == null) {
-      annotate.annotateEvent(obj, 'uncertain-timestamp');
+    } else {
+      obj.time = res.time;
+      obj.timezoneOffset = res.timezoneOffset;
+      obj.clockDriftOffset = res.clockDriftOffset;
+      obj.conversionOffset = res.conversionOffset;
+      if (obj.index == null) {
+        annotate.annotateEvent(obj, 'uncertain-timestamp');
+      }
     }
     return obj;
   };

--- a/lib/drivers/docs/insuletOmniPod.md
+++ b/lib/drivers/docs/insuletOmniPod.md
@@ -108,6 +108,8 @@ Device-specific? (Add any device-specific notes/additions here.)
 
 Device-specific? (Add any device-specific notes/additions here.)
 
+**NB:** Some OmniPod alarms are not "history" events with the log index necessary for bootstrapping to UTC. If one of these alarms fails the backup bootstrapping method (employed for events with no log index), we just drop it from the upload. (And if we succeed at "guessing" a `time` value for one of these using the backuup bootstrapping method, we keep it but annotate it with the `uncertain-timestamp` code.)
+
 #### SMBG
 
   - `[x]` blood glucose value

--- a/lib/drivers/insuletDriver.js
+++ b/lib/drivers/insuletDriver.js
@@ -788,12 +788,19 @@ module.exports = function (config) {
       }
       // handle non-history alarms
       else {
-        // alarm.alarm.alarm is not a typo!
-        if (alarm.alarm.alarm_text != null) {
-          alarmValue = alarm.alarm.alarm;
+        // will occur for non-history alarms that aren't bootstrappable
+        // since we're no longer erroring on failure to look up UTC info
+        if (postalarm.time == '**REQUIRED**') {
+          postalarm = null;
         }
         else {
-          postalarm = null;
+          // alarm.alarm.alarm is not a typo!
+          if (alarm.alarm.alarm_text != null) {
+            alarmValue = alarm.alarm.alarm;
+          }
+          else {
+            postalarm = null;
+          }
         }
       }
       var alarmText = getNameForValue(ALARM_TYPES, alarmValue);

--- a/lib/drivers/insuletDriver.js
+++ b/lib/drivers/insuletDriver.js
@@ -790,17 +790,15 @@ module.exports = function (config) {
       else {
         // will occur for non-history alarms that aren't bootstrappable
         // since we're no longer erroring on failure to look up UTC info
-        if (postalarm.time == '**REQUIRED**') {
+        if (postalarm.time === '**REQUIRED**') {
           postalarm = null;
         }
-        else {
+        else if (alarm.alarm.alarm_text != null) {
           // alarm.alarm.alarm is not a typo!
-          if (alarm.alarm.alarm_text != null) {
-            alarmValue = alarm.alarm.alarm;
-          }
-          else {
-            postalarm = null;
-          }
+          alarmValue = alarm.alarm.alarm;
+        }
+        else {
+          postalarm = null;
         }
       }
       var alarmText = getNameForValue(ALARM_TYPES, alarmValue);

--- a/test/browser/testTimezoneOffsetUtil.js
+++ b/test/browser/testTimezoneOffsetUtil.js
@@ -593,6 +593,34 @@ describe('TimezoneOffsetUtil.js', function(){
       });
       expect(noChangesUtil.fillInUTCInfo(obj, dt)).to.deep.equal(expectedRes);
     });
+
+    // for OmniPod unbootstrappable alarms
+    it('does not add `time` etc. to the object if lookup failed', () => {
+        var ambiguousDeviceTime = '2015-03-31T23:59:00';
+        var wrongMonth = builder.makeDeviceEventTimeChange()
+          .with_change({
+            from: '2015-04-01T06:00:00',
+            to: '2015-05-01T06:00:00'
+          })
+          .with_deviceTime('2015-04-01T06:00:00')
+          .set('jsDate', new Date('2015-04-01T06:00:00'))
+          .set('index', 50);
+        var clockDrift = builder.makeDeviceEventTimeChange()
+          .with_change({
+            from: '2015-05-14T23:57:00',
+            to: '2015-05-15T00:00:00',
+          })
+          .with_deviceTime('2015-05-15T00:03:00')
+          .set('jsDate', new Date('2015-05-15T00:03:00'))
+          .set('index', 75);
+        var util = new TZOUtil('US/Mountain', '2015-06-01T00:00:00.000Z', [wrongMonth, clockDrift]);
+        const obj = { index: null };
+        util.fillInUTCInfo(obj, new Date(ambiguousDeviceTime));
+        expect(obj.time).to.be.undefined;
+        expect(obj.timezoneOffset).to.be.undefined;
+        expect(obj.clockDriftOffset).to.be.undefined;
+        expect(obj.conversionOffset).to.be.undefined;
+    });
   });
 });
 


### PR DESCRIPTION
As I think you'll see pretty quickly @gniezen the changes here ended up being more (i.e., completely) isolated to the OmniPod driver than I(/we?) initially thought. The issue is that since the `fillInUTCInfo` method *mutates* objects (and *also* returns them, but that's mostly for testing purposes), it's not up to the TZOUtil to "drop" things on the floor. The driver has to do the dropping, so I had to update the OmniPod driver code to look for the incomplete (i.e., non-mutated) resulting objects (in this case: alarms) after the call to `fillInUTCInfo`.

There's a small risk here that there's some other case (i.e., a non-alarm event in OmniPod or an event in another device) where lookup will fail, but in that case the `.done()` step of the object builder will throw the error for us when there's no `time` field on the object, so we'll still get a surfaced error in those cases (and then we can figure out what the cause is and potentially drop them from the upload in the same way).

Let me know if this makes sense, happy to chat about it if not.