### PR TITLE
Handle temp basal being suspended and not resumed before upload

### DIFF
--- a/lib/medtronic/medtronicSimulator.js
+++ b/lib/medtronic/medtronicSimulator.js
@@ -318,46 +318,51 @@ exports.make = function(config){
           if(currBasal.deliveryType === 'temp') {
             // nest suppressed scheduled basal in temp basal inside suspended basal
             event.suppressed.suppressed = currBasal.suppressed;
+            var resumeBasal = null;
 
-            var tempStartToResumeDuration = Date.parse(currStatus.time) - Date.parse(currBasal.time) + currStatus.duration;
-            if(currBasal.duration > tempStartToResumeDuration) {
-            // temp basal is still active after suspend, so restart temp basal on resume
+            if(currStatus.duration > 0) {
+              // basal was resumed, check if temp basal was still active
+              var tempStartToResumeDuration = Date.parse(currStatus.time) - Date.parse(currBasal.time) + currStatus.duration;
+              if(currBasal.duration > tempStartToResumeDuration) {
+              // temp basal is still active after suspend, so restart temp basal on resume
 
-              // check that the indexes are the same, as the suspended basal was
-              // created from the same record as the suspend/resume event
-              if(currStatus && currStatus.index === event.index) {
+                // check that the indexes are the same, as the suspended basal was
+                // created from the same record as the suspend/resume event
+                if(currStatus && currStatus.index === event.index) {
 
-                event.duration = currStatus.duration;
+                  event.duration = currStatus.duration;
 
-                var resumeBasal = _.clone(currBasal);
-                resumeBasal.time = new Date(Date.parse(currStatus.time) + currStatus.duration).toISOString();
-                resumeBasal.deviceTime = sundial.formatDeviceTime(Date.parse(currStatus.deviceTime) + currStatus.duration);
-                resumeBasal.index = event.resumeIndex;
-                delete resumeBasal.duration; // we don't know the new duration yet
-
-                // finish up the temp basal before the suspend
-                if(currBasal.duration) {
-                  currBasal.with_expectedDuration(currBasal.duration);
-                  var duration = Date.parse(event.time) - Date.parse(currBasal.time);
-                  currBasal.with_duration(duration);
-
-                  resumeBasal.duration = currBasal.expectedDuration - currBasal.duration - currStatus.duration;
+                  resumeBasal = _.clone(currBasal);
+                  resumeBasal.time = new Date(Date.parse(currStatus.time) + currStatus.duration).toISOString();
+                  resumeBasal.deviceTime = sundial.formatDeviceTime(Date.parse(currStatus.deviceTime) + currStatus.duration);
+                  resumeBasal.index = event.resumeIndex;
+                  delete resumeBasal.duration; // we don't know the new duration yet
                 }
-                common.truncateDuration(currBasal, 'medtronic');
-                events.push(currBasal.done());
-
-                // check if suspended basal is crossing schedule changes
-                setCurrBasal(event);
-                if (checkForScheduleChanges()) {
-                  // we should remember to update resume basal's suppressed too
-                  resumeBasal.suppressed = currBasal.suppressed.suppressed;
-                }
-                common.truncateDuration(currBasal, 'medtronic');
-                events.push(currBasal.done());
-
-                setCurrBasal(resumeBasal);
-                return;
               }
+            }
+
+            // finish up the temp basal before the suspend
+            if(currBasal.duration) {
+              currBasal.with_expectedDuration(currBasal.duration);
+              var duration = Date.parse(event.time) - Date.parse(currBasal.time);
+              currBasal.with_duration(duration);
+            }
+
+            if(resumeBasal) {
+              resumeBasal.duration = currBasal.expectedDuration - currBasal.duration - currStatus.duration;
+              common.truncateDuration(currBasal, 'medtronic');
+              events.push(currBasal.done());
+              setCurrBasal(event);
+              // check if suspended basal is crossing schedule changes before resumed
+              if (checkForScheduleChanges()) {
+                // we should remember to update resume basal's suppressed too
+                resumeBasal.suppressed = currBasal.suppressed.suppressed;
+              }
+              common.truncateDuration(currBasal, 'medtronic');
+              events.push(currBasal.done());
+
+              setCurrBasal(resumeBasal);
+              return;
             }
           }
         }


### PR DESCRIPTION
@darinkrauss noticed during deduplicator testing that if a temp basal is suspended, and not resumed before upload, additional incorrect events will be added to the data.

This PR contains a fix and relevant tests.