### PR TITLE
direct 'Get support' link to support.tidepool.org instead of oft-broken mailto link

### DIFF
--- a/lib/pages/App.js
+++ b/lib/pages/App.js
@@ -277,7 +277,7 @@ export class App extends Component {
       <div className={styles.footerRow}>
         <div className={styles.version}>{`v${version} beta`}</div>
         <div className="mailto">
-          <a className={styles.footerLink} href="mailto:support@tidepool.org?Subject=Feedback on Uploader" target="mailto">Get support</a>
+          <a className={styles.footerLink} href="http://support.tidepool.org/" target="_blank">Get support</a>
         </div>
       </div>
     );


### PR DESCRIPTION
What it says on the tin. I believe the consensus was just to get quick approval on this and merge to master right away and let it go out with the next release, remembering to add a small note to test the new functionality?

CC @darinkrauss for interpretation of process and quick approval?