### PR TITLE
Medtronic Direct bugfix: Handle empty CGM pages

### DIFF
--- a/lib/drivers/medtronic/processData.js
+++ b/lib/drivers/medtronic/processData.js
@@ -445,6 +445,12 @@ function buildBGRecords(records) {
 function buildCGMRecords(events) {
 
   var postrecords = [];
+
+  if(events.length === 0 || events[events.length-1].jsDate == null) {
+    // CGM pages are empty
+    return postrecords;
+  }
+
   var start = events[events.length-1].jsDate;
   var recordsSinceTimestamp = null;
 


### PR DESCRIPTION
Sometimes the pump reports a non-zero number of CGM pages, but the pages themselves are empty.

@pazaan Here's a chance for you to say "I told you so"! ;) For reference, see https://github.com/tidepool-org/chrome-uploader/pull/373#discussion_r101445663. I'm going to merge this PR already so that I can build Eric a new test version, and will create a new PR if you find something here that needs to change.