### PR TITLE
Medtronic Direct checksum fix

### DIFF
--- a/lib/drivers/medtronic/medtronicDriver.js
+++ b/lib/drivers/medtronic/medtronicDriver.js
@@ -1007,9 +1007,11 @@ module.exports = function (config) {
           var count = 0;
           var pages = [];
           var done = false;
+          var retried = 0;
+          var abort = false;
 
           async.whilst(
-              function () { return count < numberOfPages; },
+              function () { return (count < numberOfPages) && !abort; },
               function (callback) {
                 var readHistory = function(historycb) {
 
@@ -1071,7 +1073,15 @@ module.exports = function (config) {
                                 debug('Calculated checksum for page:', calculated);
                                 debug('Checksum from page:', checksum);
                                 if(calculated !== checksum) {
-                                  debug('Checksum mismatch, waiting before retry..');
+                                  debug('Checksum mismatch...');
+                                  retried += 1;
+                                  if(retried === RETRIES) {
+                                    // data from pump itself is corrupted,
+                                    // let's take what we have and get outta here
+                                    debug('Aborting further reading..');
+                                    abort = true;
+                                    return historycb(null, count);
+                                  }
                                   checksumFlag = false;
                                   var waitTimer = setTimeout(function () {
                                     return historycb(new Error('Checksums not matching. Please try again.'));
@@ -1098,6 +1108,7 @@ module.exports = function (config) {
                   });
                 };
 
+                retried = 0;
                 async.retry(RETRIES, readHistory, function(err, result) {
                   if(err) {
                     return callback(err,null);


### PR DESCRIPTION
*Problem*: In some instances, even requesting the same packets 5 times after getting a checksum mismatch, the pump still sends the exact same packets. 

*Solution*:
It will retry 5 times, after which it will assume the data from the pump itself is corrupted. It will then just return the data it already has. Since the pump sends the newest data first, this means it will have all current data back to the date the data got corrupted, and all older (possibly corrupted) data will be ignored. This seems to be what CareLink does as well.