### PR TITLE
MedT Direct: Fix wizard carb units and pump settings

### DIFF
--- a/lib/drivers/medtronic/medtronicSimulator.js
+++ b/lib/drivers/medtronic/medtronicSimulator.js
@@ -394,6 +394,17 @@ exports.make = function(config){
           currWizard.bolus = _.clone(event);
           delete currWizard.bolus.jsDate;
           delete currWizard.bolus.index;
+
+          if(currPumpSettings != null) {
+            if(currPumpSettings.units.carb === 'exchanges') {
+              // until the data model supports units for the carb ratio in wizard
+              // records, we have to check if the pump was set to exchanges and
+              // convert if necessary
+              currWizard.carbInput = Math.round(currWizard.carbInput / 10.0 * 15);
+              currWizard.insulinCarbRatio = Math.round(15 / (currWizard.insulinCarbRatio / 100.0));
+            }
+          }
+
           currWizard = currWizard.done();
           simpleSimulate(currWizard);
         } else {

--- a/lib/drivers/medtronic/processData.js
+++ b/lib/drivers/medtronic/processData.js
@@ -768,11 +768,9 @@ function buildSettings(records) {
               .with_bgTarget(settings.bgTarget)
               .with_basalSchedules(settings.basalSchedules)
               .with_activeSchedule(settings.activeSchedule)
-              // current settings do not have an index, so can't use TZOUtil.
-              .with_time(sundial.applyTimezone(settings.currentDeviceTime, cfg.timezone).toISOString())
-              .with_deviceTime(sundial.formatDeviceTime(settings.currentDeviceTime))
-              .with_timezoneOffset(sundial.getOffsetFromZone(settings.currentDeviceTime, cfg.timezone))
-              .with_conversionOffset(0);
+              .set('index', changes[0].index)
+              .with_deviceTime(sundial.formatDeviceTime(changes[0].jsDate));
+  cfg.tzoUtil.fillInUTCInfo(postsettings, changes[0].jsDate);
   postrecords.push(postsettings.done());
 
   changes.forEach(function (settingsEntry) {


### PR DESCRIPTION
Two changes in this PR:

- for the current pump settings, use the the time at which they were actually activated, instead of the current device time
- always convert carb input and ratio to grams, as the data model doesn't currently support different carb units (e.g. exchanges) for wizard records