### PR TITLE
Medtronic Direct: Prevent async.retry from running 5 x 10 = 50 times

### DIFF
--- a/lib/drivers/medtronic/medtronicDriver.js
+++ b/lib/drivers/medtronic/medtronicDriver.js
@@ -1172,6 +1172,9 @@ module.exports = function (config) {
 
                   getOneRecord(sendCommand(historyType), true, true, function (err, result) {
                     if(err) {
+                      if(err.name === 'TIMEOUT') {
+                        return callback(err, null);
+                      }
                       return historycb(err,null);
                     }
                     if(result) {


### PR DESCRIPTION
This PR fixes the instance where a consistent timeout can cause 50 retries from two interacting `async.retry`s.
