### PR TITLE
MedT Direct bugfix: Missing temp basal duration

### DIFF
--- a/lib/commonFunctions.js
+++ b/lib/commonFunctions.js
@@ -49,7 +49,7 @@ exports.truncateDuration = function(basal, source) {
       annotate.annotateEvent(basal, source + '/basal/flat-rate');
     }
   } else {
-    basal.with_duration(0);
+    basal.duration = 0;
     annotate.annotateEvent(basal, 'basal/unknown-duration');
   }
   return basal;

--- a/lib/drivers/medtronic/medtronicSimulator.js
+++ b/lib/drivers/medtronic/medtronicSimulator.js
@@ -131,7 +131,7 @@ exports.make = function(config){
             var adjustedDuration = durationBeforeMidnight + currSchedule[i].start - startTime;
             durationBeforeMidnight = 0; // we've now taken account of the duration before midnight in the adjusted duration
             var oldDuration = currBasal.duration;
-            currBasal.with_duration(adjustedDuration);
+            currBasal.duration = adjustedDuration;
             if(currBasal.isAssigned('payload')) {
              currBasal.payload.duration =  oldDuration;
             }else{
@@ -216,9 +216,10 @@ exports.make = function(config){
         if (suspendingEvent != null) {
           // The current basal only ran until the suspending event occurred
           var duration = Date.parse(suspendingEvent.time) - Date.parse(currBasal.time);
+
           if(duration > 0) {
             // suspending event did happen after the basal event
-            currBasal.with_duration(duration);
+            currBasal.duration = duration;
             common.truncateDuration(currBasal, 'medtronic');
             currBasal = currBasal.done();
             events.push(currBasal);
@@ -259,6 +260,7 @@ exports.make = function(config){
         }
 
         if(!currBasal.isAssigned('duration')) {
+
           // calculate current basal's duration
           var duration = Date.parse(event.time) - Date.parse(currBasal.time);
           currBasal.duration = duration;
@@ -274,10 +276,10 @@ exports.make = function(config){
               // We use the time this record was sent to calculate the actual duration.
               checkForScheduleChanges(event);
               if(currBasal.duration !== 0) {
-                currBasal.with_expectedDuration(currBasal.duration);
+                currBasal.expectedDuration = currBasal.duration;
               }
               var duration = Date.parse(event.time) - Date.parse(currBasal.time);
-              currBasal.with_duration(duration);
+              currBasal.duration = duration;
 
               common.truncateDuration(currBasal, 'medtronic');
               currBasal = currBasal.done();
@@ -291,9 +293,9 @@ exports.make = function(config){
           if(currBasal.deliveryType === 'temp') {
             // temp basal was updated
             if(currBasal.duration !== 0) {
-              currBasal.with_expectedDuration(currBasal.duration);
+              currBasal.expectedDuration = currBasal.duration;
             }
-            currBasal.with_duration(Date.parse(event.time) - Date.parse(currBasal.time));
+            currBasal.duration = Date.parse(event.time) - Date.parse(currBasal.time);
             event.suppressed = _.clone(currBasal.suppressed);
           }
 


### PR DESCRIPTION
During an alpha test, a temp basal that was suspended and then resumed, followed by a reservoir change, resulted in a missing duration. This PR changes instances of `with_duration` so that we're always setting the duration after the initial record was created.

It also adds a regression test for the situation that triggered the missing duration in the first case.