### PR TITLE
Electron Uploader: Updating metrics

### DIFF
--- a/app/actions/sync.js
+++ b/app/actions/sync.js
@@ -400,11 +400,10 @@ export function uploadProgress(step, percentage) {
   };
 }
 
-export function uploadSuccess(userId, device, upload, data, utc, sessionInfo) {
+export function uploadSuccess(userId, device, upload, data, utc) {
   utc = actionUtils.getUtc(utc);
   const numRecs = data.length;
-  console.log("DEVICE:", device);
-  var test = {
+  return {
     type: actionTypes.UPLOAD_SUCCESS,
     payload: { userId, deviceKey: device.key, data, utc },
     meta: {
@@ -421,8 +420,6 @@ export function uploadSuccess(userId, device, upload, data, utc, sessionInfo) {
       }
     }
   };
-  console.log("UPLOADSUCCESS:", test);
-  return test;
 }
 
 export function uploadFailure(err, errProps, device) {

--- a/app/actions/sync.js
+++ b/app/actions/sync.js
@@ -382,10 +382,10 @@ export function uploadRequest(userId, device, utc) {
     meta: {
       source: actionSources[actionTypes.UPLOAD_REQUEST],
       metric: {
-        eventName: `${metrics.UPLOAD_REQUEST} ${actionUtils.getUploadTrackingId(device)}`,
+        eventName: `${metrics.UPLOAD_REQUEST}`,
         properties: {
           type: _.get(device, 'source.type', undefined),
-          source: _.get(device, 'source.driverId', undefined)
+          source: `${actionUtils.getUploadTrackingId(device)}`
         }
       }
     }
@@ -400,19 +400,20 @@ export function uploadProgress(step, percentage) {
   };
 }
 
-export function uploadSuccess(userId, device, upload, data, utc) {
+export function uploadSuccess(userId, device, upload, data, utc, sessionInfo) {
   utc = actionUtils.getUtc(utc);
   const numRecs = data.length;
-  return {
+  console.log("DEVICE:", device);
+  var test = {
     type: actionTypes.UPLOAD_SUCCESS,
     payload: { userId, deviceKey: device.key, data, utc },
     meta: {
       source: actionSources[actionTypes.UPLOAD_SUCCESS],
       metric: {
-        eventName: `${metrics.UPLOAD_SUCCESS} ${actionUtils.getUploadTrackingId(device)}`,
+        eventName: `${metrics.UPLOAD_SUCCESS}`,
         properties: {
           type: _.get(device, 'source.type', undefined),
-          source: _.get(device, 'source.driverId', undefined),
+          source: `${actionUtils.getUploadTrackingId(device)}`,
           started: upload.history[0].start || '',
           finished: utc || '',
           processed: numRecs || 0
@@ -420,6 +421,8 @@ export function uploadSuccess(userId, device, upload, data, utc) {
       }
     }
   };
+  console.log("UPLOADSUCCESS:", test);
+  return test;
 }
 
 export function uploadFailure(err, errProps, device) {
@@ -431,10 +434,10 @@ export function uploadFailure(err, errProps, device) {
     meta: {
       source: actionSources[actionTypes.UPLOAD_FAILURE],
       metric: {
-        eventName: `${metrics.UPLOAD_FAILURE} ${actionUtils.getUploadTrackingId(device)}`,
+        eventName: `${metrics.UPLOAD_FAILURE}`,
         properties: {
           type: _.get(device, 'source.type', undefined),
-          source: _.get(device, 'source.driverId', undefined),
+          source: `${actionUtils.getUploadTrackingId(device)}`,
           error: err
         }
       }

--- a/test/app/actions/async.test.js
+++ b/test/app/actions/async.test.js
@@ -782,7 +782,7 @@ describe('Asynchronous Actions', () => {
           meta: {
             source: actionSources[actionTypes.UPLOAD_REQUEST],
             metric: {
-              eventName: 'Upload Attempted AcmePump',
+              eventName: 'Upload Attempted',
               properties: {type: targetDevice.source.type, source: targetDevice.source.driverId}
             }
           }
@@ -798,7 +798,7 @@ describe('Asynchronous Actions', () => {
           meta: {
             source: actionSources[actionTypes.UPLOAD_FAILURE],
             metric: {
-              eventName: 'Upload Failed AcmePump',
+              eventName: 'Upload Failed',
               properties: {
                 type: targetDevice.source.type,
                 source: targetDevice.source.driverId,
@@ -882,7 +882,7 @@ describe('Asynchronous Actions', () => {
           meta: {
             source: actionSources[actionTypes.UPLOAD_REQUEST],
             metric: {
-              eventName: 'Upload Attempted AcmePump',
+              eventName: 'Upload Attempted',
               properties: {type: targetDevice.source.type, source: targetDevice.source.driverId}
             }
           }
@@ -898,7 +898,7 @@ describe('Asynchronous Actions', () => {
           meta: {
             source: actionSources[actionTypes.UPLOAD_FAILURE],
             metric: {
-              eventName: 'Upload Failed AcmePump',
+              eventName: 'Upload Failed',
               properties: {
                 type: targetDevice.source.type,
                 source: targetDevice.source.driverId,
@@ -982,7 +982,7 @@ describe('Asynchronous Actions', () => {
           meta: {
             source: actionSources[actionTypes.UPLOAD_REQUEST],
             metric: {
-              eventName: 'Upload Attempted AcmePump',
+              eventName: 'Upload Attempted',
               properties: {type: targetDevice.source.type, source: targetDevice.source.driverId}
             }
           }
@@ -998,7 +998,7 @@ describe('Asynchronous Actions', () => {
           meta: {
             source: actionSources[actionTypes.UPLOAD_FAILURE],
             metric: {
-              eventName: 'Upload Failed AcmePump',
+              eventName: 'Upload Failed',
               properties: {
                 type: targetDevice.source.type,
                 source: targetDevice.source.driverId,
@@ -1086,7 +1086,7 @@ describe('Asynchronous Actions', () => {
           meta: {
             source: actionSources[actionTypes.UPLOAD_REQUEST],
             metric: {
-              eventName: 'Upload Attempted AcmePump',
+              eventName: 'Upload Attempted',
               properties: {type: targetDevice.source.type, source: targetDevice.source.driverId}
             }
           }
@@ -1102,7 +1102,7 @@ describe('Asynchronous Actions', () => {
           meta: {
             source: actionSources[actionTypes.UPLOAD_FAILURE],
             metric: {
-              eventName: 'Upload Failed AcmePump',
+              eventName: 'Upload Failed',
               properties: {
                 type: targetDevice.source.type,
                 source: targetDevice.source.driverId,
@@ -1177,7 +1177,7 @@ describe('Asynchronous Actions', () => {
           meta: {
             source: actionSources[actionTypes.UPLOAD_REQUEST],
             metric: {
-              eventName: 'Upload Attempted AcmePump',
+              eventName: 'Upload Attempted',
               properties: {type: targetDevice.source.type, source: targetDevice.source.driverId}
             }
           }
@@ -1192,7 +1192,7 @@ describe('Asynchronous Actions', () => {
           meta: {
             source: actionSources[actionTypes.UPLOAD_SUCCESS],
             metric: {
-              eventName: 'Upload Successful AcmePump',
+              eventName: 'Upload Successful',
               properties: {
                 type: targetDevice.source.type,
                 source: targetDevice.source.driverId,
@@ -1277,8 +1277,8 @@ describe('Asynchronous Actions', () => {
           meta: {
             source: actionSources[actionTypes.UPLOAD_REQUEST],
             metric: {
-              eventName: 'Upload Attempted CareLink',
-              properties: {type: targetDevice.source.type, source: targetDevice.source.driverId}
+              eventName: 'Upload Attempted',
+              properties: {type: targetDevice.source.type, source: 'CareLink'}
             }
           }
         },
@@ -1303,10 +1303,10 @@ describe('Asynchronous Actions', () => {
           meta: {
             source: actionSources[actionTypes.UPLOAD_FAILURE],
             metric: {
-              eventName: 'Upload Failed CareLink',
+              eventName: 'Upload Failed',
               properties: {
                 type: targetDevice.source.type,
-                source: targetDevice.source.driverId,
+                source: 'CareLink',
                 error: err
               }
             }
@@ -1385,8 +1385,8 @@ describe('Asynchronous Actions', () => {
           meta: {
             source: actionSources[actionTypes.UPLOAD_REQUEST],
             metric: {
-              eventName: 'Upload Attempted CareLink',
-              properties: {type: targetDevice.source.type, source: targetDevice.source.driverId}
+              eventName: 'Upload Attempted',
+              properties: {type: targetDevice.source.type, source: 'CareLink'}
             }
           }
         },
@@ -1411,10 +1411,10 @@ describe('Asynchronous Actions', () => {
           meta: {
             source: actionSources[actionTypes.UPLOAD_FAILURE],
             metric: {
-              eventName: 'Upload Failed CareLink',
+              eventName: 'Upload Failed',
               properties: {
                 type: targetDevice.source.type,
-                source: targetDevice.source.driverId,
+                source: 'CareLink',
                 error: err
               }
             }
@@ -1499,8 +1499,8 @@ describe('Asynchronous Actions', () => {
           meta: {
             source: actionSources[actionTypes.UPLOAD_REQUEST],
             metric: {
-              eventName: 'Upload Attempted CareLink',
-              properties: {type: targetDevice.source.type, source: undefined}
+              eventName: 'Upload Attempted',
+              properties: {type: targetDevice.source.type, source: 'CareLink'}
             }
           }
         },
@@ -1524,10 +1524,10 @@ describe('Asynchronous Actions', () => {
           meta: {
             source: actionSources[actionTypes.UPLOAD_FAILURE],
             metric: {
-              eventName: 'Upload Failed CareLink',
+              eventName: 'Upload Failed',
               properties: {
                 type: targetDevice.source.type,
-                source: targetDevice.source.driverId,
+                source: 'CareLink',
                 error: err
               }
             }
@@ -1599,8 +1599,8 @@ describe('Asynchronous Actions', () => {
           meta: {
             source: actionSources[actionTypes.UPLOAD_REQUEST],
             metric: {
-              eventName: 'Upload Attempted CareLink',
-              properties: {type: targetDevice.source.type, source: undefined}
+              eventName: 'Upload Attempted',
+              properties: {type: targetDevice.source.type, source: 'CareLink'}
             }
           }
         },
@@ -1623,10 +1623,10 @@ describe('Asynchronous Actions', () => {
           meta: {
             source: actionSources[actionTypes.UPLOAD_SUCCESS],
             metric: {
-              eventName: 'Upload Successful CareLink',
+              eventName: 'Upload Successful',
               properties: {
                 type: targetDevice.source.type,
-                source: targetDevice.source.driverId,
+                source: 'CareLink',
                 started: time,
                 finished: time,
                 processed: 4

--- a/test/app/actions/sync.test.js
+++ b/test/app/actions/sync.test.js
@@ -693,7 +693,7 @@ describe('Synchronous Actions', () => {
           meta: {
             source: actionSources[actionTypes.UPLOAD_REQUEST],
             metric: {
-              eventName: 'Upload Attempted AcmePump',
+              eventName: 'Upload Attempted',
               properties: {type: device.source.type, source: device.source.driverId}
             }
           }
@@ -746,7 +746,7 @@ describe('Synchronous Actions', () => {
           meta: {
             source: actionSources[actionTypes.UPLOAD_SUCCESS],
             metric: {
-              eventName: `${metrics.UPLOAD_SUCCESS} ${device.source.driverId}`,
+              eventName: `${metrics.UPLOAD_SUCCESS}`,
               properties: {
                 type: device.source.type,
                 source: device.source.driverId,
@@ -788,7 +788,7 @@ describe('Synchronous Actions', () => {
           meta: {
             source: actionSources[actionTypes.UPLOAD_FAILURE],
             metric: {
-              eventName: `${metrics.UPLOAD_FAILURE} ${device.source.driverId}`,
+              eventName: `${metrics.UPLOAD_FAILURE}`,
               properties: {
                 type: device.source.type,
                 source: device.source.driverId,

--- a/test/app/actions/utils.test.js
+++ b/test/app/actions/utils.test.js
@@ -77,7 +77,7 @@ describe('utils', () => {
         meta: {
           source: 'USER_VISIBLE',
           metric: {
-            eventName: 'Upload Failed bar',
+            eventName: 'Upload Failed',
             properties: {
               type: 'device',
               source: 'bar',
@@ -113,7 +113,7 @@ describe('utils', () => {
         meta: {
           source: 'USER_VISIBLE',
           metric: {
-            eventName: 'Upload Failed bar',
+            eventName: 'Upload Failed',
             properties: {
               type: 'device',
               source: 'bar',


### PR DESCRIPTION
This PR removes the device ID from the metric event name and ensures that it's returned in the `source` property. Previously CareLink would have `undefined` as `source`.