### PR TITLE
Medtronic Direct: CGM timestamps

### DIFF
--- a/lib/drivers/medtronic/medtronicDriver.js
+++ b/lib/drivers/medtronic/medtronicDriver.js
@@ -79,6 +79,7 @@ module.exports = function (config) {
   };
 
   var MESSAGES = {
+    WRITE_CBG_TIMESTAMP : 0x28,
     READ_TIME : 0x70,
     READ_BATTERY_STATUS: 0x72,
     READ_HISTORY : 0x80,
@@ -330,6 +331,25 @@ module.exports = function (config) {
         var activeSchedule = proc.PROFILES[medtronicMessage[11]];
 
         return { activeSchedule : activeSchedule };
+      }
+    };
+  };
+
+  var writeCBGTimestamp = function () {
+
+    return {
+      command: buildMedtronicPacket(COMMANDS.SEND_MESSAGE,MESSAGES.WRITE_CBG_TIMESTAMP),
+      parser: function (packet) {
+
+        var medtronicMessage = packet.slice(MEDTRONIC_PACKET_START);
+
+        var success = false;
+        if(medtronicMessage[0] === ASCII_CONTROL.ACK) {
+          success = true;
+        }
+
+        debug('Written CBG timestamp:', success);
+        return { success : success };
       }
     };
   };
@@ -1081,6 +1101,14 @@ module.exports = function (config) {
         },
         settings : function(callback){
           getOneRecord(readSettings(), false, true, function(err, result) {
+            if(err) {
+              return cb(err,null);
+            }
+            callback(null, result);
+          });
+        },
+        cbg_timestamp : function(callback){
+          getOneRecord(writeCBGTimestamp(), false, true, function(err, result) {
             if(err) {
               return cb(err,null);
             }

--- a/lib/drivers/medtronic/processData.js
+++ b/lib/drivers/medtronic/processData.js
@@ -453,26 +453,26 @@ function buildCGMRecords(events) {
     return postrecords;
   }
 
-  var start = events[events.length-1].jsDate;
+  var start = null;
   var recordsSinceTimestamp = null;
 
   // we have to work through the CGM records in reverse, as sensor timestamps
   // affect previous values and are subject to time changes
 
-  for( var i = events.length - 1 ; i >= 0; i-- ) {
+  for (var i = events.length - 1; i >= 0; i--) {
     var event = events[i];
 
-    if(event.jsDate != false) {
-      if(__DEBUG__) {
+    if (event.jsDate != false) {
+      if (__DEBUG__) {
         debug('CGM event:',sundial.formatDeviceTime(event.jsDate), event.type.name, common.bytes2hex([event.head]),common.bytes2hex(event.date),common.bytes2hex(event.body),common.bytes2hex(event.descriptor) );
       }
 
-      if(event.type.value === CBG_RECORD_TYPES.SENSOR_TIMESTAMP.value) {
+      if (event.type.value === CBG_RECORD_TYPES.SENSOR_TIMESTAMP.value) {
         start = event.jsDate;
         recordsSinceTimestamp = 0;
       }
 
-      if (event.body) {
+      if (event.body && start !== null) {
         var offset = event.body.length;
         var index = event.index - offset;
 

--- a/lib/drivers/medtronic/processData.js
+++ b/lib/drivers/medtronic/processData.js
@@ -596,7 +596,7 @@ function buildSuspendResumeRecords(records) {
 
       debug('Suspended at', suspendResume.deviceTime);
 
-      while(suspendResumeRecords[i].type.value === RECORD_TYPES.PUMP_SUSPEND.value) {
+      while((i < suspendResumeRecords.length) && suspendResumeRecords[i].type.value === RECORD_TYPES.PUMP_SUSPEND.value) {
         // we use a while loop here, as the user can select suspend in the
         // UI multiple times or not respond to the suspend
 
@@ -647,7 +647,10 @@ function buildSuspendResumeRecords(records) {
         suspendResume.with_duration(duration)
                      .set('resumeIndex', resumeEntry.index);
       } else {
-        debug('Incomplete suspend/resume at', suspendResume.time, ':', resumeEntry.type.name, '(',resumeEntry.head[1],')');
+        debug('Incomplete suspend/resume at', suspendResume.time);
+        if(resumeEntry) {
+          debug('resume entry:', resumeEntry.type.name, '(',resumeEntry.head[1],')');
+        }
         suspendResume.with_duration(0);
         annotate.annotateEvent(suspendResume,'status/incomplete-tuple');
       }

--- a/lib/drivers/medtronic/processData.js
+++ b/lib/drivers/medtronic/processData.js
@@ -128,7 +128,7 @@ var CBG_RECORD_TYPES = {
   SENSOR_SYNC: { value: 0x0D, name:'SENSOR_SYNC'},
   SENSOR_CAL_BG: { value: 0x0E, name:'SENSOR_CAL_BG'},
   SENSOR_CAL_FACTOR: { value: 0x0F, name:'SENSOR_CAL_FACTOR'},
-  SENSOR_CAL: { value: 0x10, name:'SENSOR_CAL'},
+  SENSOR_SPECIAL_DISPLAY_EVENT: { value: 0x10, name:'SENSOR_SPECIAL_DISPLAY_EVENT'},
   NO_OP: { value: 0x13, name:'NO_OP'},
   GLUCOSE_40_TO_400_MIN: { value: 0x14, name: 'GLUCOSE_40_TO_400_MIN'},
   GLUCOSE_40_TO_400_MAX: { value: 0xC8, name: 'GLUCOSE_40_TO_400_MAX'}

--- a/lib/drivers/medtronic/processData.js
+++ b/lib/drivers/medtronic/processData.js
@@ -472,7 +472,7 @@ function buildCGMRecords(events) {
         recordsSinceTimestamp = 0;
       }
 
-      if (event.body && start !== null) {
+      if (event.body) {
         var offset = event.body.length;
         var index = event.index - offset;
 
@@ -489,6 +489,11 @@ function buildCGMRecords(events) {
           if (descriptor > 255) {
             var annotation = null;
             var cbg = (descriptor & 0x01) + (event.body[offset] << 1);
+
+            if (start === null) {
+              debug('Dropping CBG values without timestamp');
+              break;
+            }
 
             var date = sundial.applyOffset(start, -(recordsSinceTimestamp * 5));
             recordsSinceTimestamp += 1;


### PR DESCRIPTION
When there's no `SENSOR_TIMESTAMP` at the end of a CGM history, the timestamps for CBG values are different between values.

This PR ensures a new CGM history timestamp is written before reading CGM history. It also fixes a regression where a suspended pump could not be uploaded (surfacing as `type` error).