### PR TITLE
MedT Direct: Fill in one-second gaps

### DIFF
--- a/lib/drivers/medtronic/medtronicSimulator.js
+++ b/lib/drivers/medtronic/medtronicSimulator.js
@@ -398,6 +398,36 @@ exports.make = function(config){
         }
       }
 
+      if (currBasal && event.deliveryType === 'scheduled' && currBasal.deliveryType === 'temp') {
+        //check for possible one-second gap between end of temp basal and start of scheduled basal
+
+        var supposedEndTime = Date.parse(currBasal.time) + currBasal.duration;
+        var nextBasalTime = Date.parse(event.time);
+
+        if(supposedEndTime !== nextBasalTime) {
+          // there's a gap
+          if(nextBasalTime - supposedEndTime === 1000) {
+            // it's the expected one second gap, fabricate a basal
+            var jsDate = addDurationToDeviceTime(currBasal, currBasal.duration);
+            var oneSecondBasal = config.builder.makeTempBasal()
+              .with_duration(1000)
+              .with_rate(currBasal.rate)
+              .with_deviceTime(sundial.formatDeviceTime(jsDate))
+              .set('index', currBasal.index);
+            if(currBasal.suppressed) {
+              oneSecondBasal.set('suppressed', currBasal.suppressed);
+            }
+
+            config.tzoUtil.fillInUTCInfo(oneSecondBasal, jsDate);
+            annotate.annotateEvent(oneSecondBasal, 'medtronic/basal/one-second-gap');
+            oneSecondBasal = oneSecondBasal.done();
+            events.push(oneSecondBasal);
+          } else {
+            debug('Unexpected gap in basal just before ',event.time);
+          }
+        }
+      }
+
       setCurrBasal(event);
     },
     bolus: function(event) {

--- a/lib/drivers/medtronic/medtronicSimulator.js
+++ b/lib/drivers/medtronic/medtronicSimulator.js
@@ -402,12 +402,11 @@ exports.make = function(config){
 
       if (event.deliveryType === 'scheduled') {
 
-        // check if previous basal was a temp basal
+        // check if current or cancelled (previous) basal was a temp basal
         var tempBasal = null;
         if(currBasal == null) {
-          if(prevBasal && prevBasal.deliveryType === 'temp') {
-            // temp basal was cancelled, get it from stack
-            tempBasal = _.clone(events[events.length-1]);
+          if(prevBasal && prevBasal.deliveryType === 'temp' && prevBasal.expectedDuration > 0) {
+            tempBasal = prevBasal;
           }
         } else {
           if(currBasal.deliveryType === 'temp') {

--- a/lib/drivers/medtronic/medtronicSimulator.js
+++ b/lib/drivers/medtronic/medtronicSimulator.js
@@ -46,8 +46,10 @@ exports.make = function(config){
   var currPumpSettings = null;
   var suspendingEvent = null;
   var currStatus = null;
+  var prevBasal = null;
 
   function setCurrBasal(basal) {
+    prevBasal = _.clone(currBasal);
     currBasal = basal;
   }
 
@@ -398,32 +400,48 @@ exports.make = function(config){
         }
       }
 
-      if (currBasal && event.deliveryType === 'scheduled' && currBasal.deliveryType === 'temp') {
-        //check for possible one-second gap between end of temp basal and start of scheduled basal
+      if (event.deliveryType === 'scheduled') {
 
-        var supposedEndTime = Date.parse(currBasal.time) + currBasal.duration;
-        var nextBasalTime = Date.parse(event.time);
+        // check if previous basal was a temp basal
+        var tempBasal = null;
+        if(currBasal == null) {
+          if(prevBasal && prevBasal.deliveryType === 'temp') {
+            // temp basal was cancelled, get it from stack
+            tempBasal = _.clone(events[events.length-1]);
+          }
+        } else {
+          if(currBasal.deliveryType === 'temp') {
+            tempBasal = _.clone(currBasal);
+          }
+        }
 
-        if(supposedEndTime !== nextBasalTime) {
-          // there's a gap
-          if(nextBasalTime - supposedEndTime === 1000) {
-            // it's the expected one second gap, fabricate a basal
-            var jsDate = addDurationToDeviceTime(currBasal, currBasal.duration);
-            var oneSecondBasal = config.builder.makeTempBasal()
-              .with_duration(1000)
-              .with_rate(currBasal.rate)
-              .with_deviceTime(sundial.formatDeviceTime(jsDate))
-              .set('index', currBasal.index);
-            if(currBasal.suppressed) {
-              oneSecondBasal.set('suppressed', currBasal.suppressed);
+        if(tempBasal) {
+          //check for possible one-second gap between end of temp basal and start of scheduled basal
+
+          var supposedEndTime = Date.parse(tempBasal.time) + tempBasal.duration;
+          var nextBasalTime = Date.parse(event.time);
+
+          if(supposedEndTime !== nextBasalTime) {
+            // there's a gap
+            if(nextBasalTime - supposedEndTime === 1000) {
+              // it's the expected one second gap, fabricate a basal
+              var jsDate = addDurationToDeviceTime(tempBasal, tempBasal.duration);
+              var oneSecondBasal = config.builder.makeTempBasal()
+                .with_duration(1000)
+                .with_rate(tempBasal.rate)
+                .with_deviceTime(sundial.formatDeviceTime(jsDate))
+                .set('index', tempBasal.index);
+              if(tempBasal.suppressed) {
+                oneSecondBasal.set('suppressed', tempBasal.suppressed);
+              }
+
+              config.tzoUtil.fillInUTCInfo(oneSecondBasal, jsDate);
+              annotate.annotateEvent(oneSecondBasal, 'medtronic/basal/one-second-gap');
+              oneSecondBasal = oneSecondBasal.done();
+              events.push(oneSecondBasal);
+            } else {
+              debug('Unexpected gap in basal just before ',event.time);
             }
-
-            config.tzoUtil.fillInUTCInfo(oneSecondBasal, jsDate);
-            annotate.annotateEvent(oneSecondBasal, 'medtronic/basal/one-second-gap');
-            oneSecondBasal = oneSecondBasal.done();
-            events.push(oneSecondBasal);
-          } else {
-            debug('Unexpected gap in basal just before ',event.time);
           }
         }
       }

--- a/test/node/medtronic/testMedtronicSimulator.js
+++ b/test/node/medtronic/testMedtronicSimulator.js
@@ -1356,6 +1356,33 @@ describe('medtronicSimulator.js', function() {
         ]);
 
       });
+
+      it('has a one-second gap before a scheduled basal', function() {
+        var basal = builder.makeScheduledBasal()
+          .with_time('2014-09-25T18:40:01.000Z')
+          .with_deviceTime('2014-09-25T18:40:01')
+          .with_timezoneOffset(0)
+          .with_conversionOffset(0)
+          .with_rate(0.75);
+
+        var expectedTempBasal = _.cloneDeep(tempBasal).done();
+        delete expectedTempBasal.index;
+
+        var oneSecondTemp = _.cloneDeep(expectedTempBasal);
+        oneSecondTemp.time = '2014-09-25T18:40:00.000Z';
+        oneSecondTemp.deviceTime = '2014-09-25T18:40:00';
+        oneSecondTemp.clockDriftOffset = 0;
+        oneSecondTemp.duration = 1000;
+        oneSecondTemp.annotations = [{code: 'medtronic/basal/one-second-gap'}];
+
+        simulator.basal(tempBasal);
+        simulator.basal(basal);
+
+        expect(simulator.getEvents()).deep.equals([
+          expectedTempBasal,
+          oneSecondTemp
+        ]);
+      });
     });
 
   });

--- a/test/node/medtronic/testMedtronicSimulator.js
+++ b/test/node/medtronic/testMedtronicSimulator.js
@@ -1383,6 +1383,38 @@ describe('medtronicSimulator.js', function() {
           oneSecondTemp
         ]);
       });
+
+      it('is cancelled and has a one-second gap before a scheduled basal', function() {
+
+        tempBasal.duration = 1200000;
+        tempBasal.expectedDuration = 1800000;
+
+        var basal = builder.makeScheduledBasal()
+          .with_time('2014-09-25T18:30:01.000Z')
+          .with_deviceTime('2014-09-25T18:30:01')
+          .with_timezoneOffset(0)
+          .with_conversionOffset(0)
+          .with_rate(0.75);
+
+        var expectedTempBasal = _.cloneDeep(tempBasal).done();
+        delete expectedTempBasal.index;
+
+        var oneSecondTemp = _.cloneDeep(expectedTempBasal);
+        oneSecondTemp.time = '2014-09-25T18:30:00.000Z';
+        oneSecondTemp.deviceTime = '2014-09-25T18:30:00';
+        oneSecondTemp.clockDriftOffset = 0;
+        oneSecondTemp.duration = 1000;
+        oneSecondTemp.annotations = [{code: 'medtronic/basal/one-second-gap'}];
+        delete oneSecondTemp.expectedDuration;
+
+        simulator.basal(tempBasal);
+        simulator.basal(basal);
+
+        expect(simulator.getEvents()).deep.equals([
+          expectedTempBasal,
+          oneSecondTemp
+        ]);
+      });
     });
 
   });


### PR DESCRIPTION
In 10-20% of cases a scheduled basal starts one second _after_ a temp basal duration ends. 

This PR fills in the one-second gap with a one-second temp basal equivalent to the one that preceded it (including suppressed info) so that we can calculate bolus-to-bolus ratio stats correctly.

A unit test is also included.