### PR TITLE
MedT Direct: Schedule change before a basal is suppressed

### DIFF
--- a/lib/drivers/medtronic/medtronicSimulator.js
+++ b/lib/drivers/medtronic/medtronicSimulator.js
@@ -325,6 +325,8 @@ exports.make = function(config){
 
         if (event.deliveryType === 'suspend' && currBasal.deliveryType !== 'suspend') {
 
+          checkForScheduleChanges(event); //check for schedule changes before basal is suspended
+
           event.suppressed = {
             type: 'basal',
             deliveryType: currBasal.deliveryType,


### PR DESCRIPTION
This PR fixes a bug discovered during alpha testing, that affects temp basals that are suspended and resumed before the end of the temp basal, where there is a schedule change _before_ the suspend.