### PR TITLE
MedT Direct: handle case where bolus event is more than 5 seconds after bolus wizard

### DIFF
--- a/lib/drivers/medtronic/medtronicSimulator.js
+++ b/lib/drivers/medtronic/medtronicSimulator.js
@@ -405,10 +405,10 @@ exports.make = function(config){
         // A wizard event is always followed by a bolus event.
         // Usually the timestamp is the same, but sometimes the bolus timestamp
         // is a second later. Here we also check that the bolus event is at least
-        // within 5 seconds of the wizard event.
+        // within 30 seconds of the wizard event.
         var bolusTime = event.jsDate.valueOf();
         var wizardTime = currWizard.jsDate.valueOf();
-        if ( (bolusTime >= wizardTime) && ( bolusTime < (wizardTime + 5000)) ) {
+        if ( (bolusTime >= wizardTime) && ( bolusTime < (wizardTime + 30000)) ) {
           currWizard.bolus = _.clone(event);
           delete currWizard.bolus.jsDate;
           delete currWizard.bolus.index;


### PR DESCRIPTION
Currently we expect a bolus record to be within 5 seconds of its corresponding bolus wizard record to match them (usually they have the same timestamp, but not always). During alpha testing we discovered a bolus record that came 13 seconds (!) after the bolus wizard record. This PR changes the window to 30 seconds to make sure we can match these records.