### PR TITLE
Electron Uploader: handle upstream bug in HID disconnect on Windows

### DIFF
--- a/lib/drivers/bayer/bayerContourNext.js
+++ b/lib/drivers/bayer/bayerContourNext.js
@@ -625,8 +625,14 @@ module.exports = function (config) {
 
     disconnect: function (progress, data, cb) {
       debug('in disconnect');
-      progress(100);
-      cb(null, data);
+      cfg.deviceComms.removeListeners();
+      // Due to an upstream bug in HIDAPI on Windoze, we have to send a command
+      // to the device to ensure that the listeners are removed before we disconnect
+      // For more details, see https://github.com/node-hid/node-hid/issues/61
+      hidDevice.send(buildPacket([ASCII_CONTROL.EOT],1), function(err, result) {
+        progress(100);
+        cb(null, data);
+      });
     },
 
     cleanup: function (progress, data, cb) {

--- a/lib/hidDevice.js
+++ b/lib/hidDevice.js
@@ -94,6 +94,11 @@ module.exports = function(config) {
 
   }
 
+  function removeListeners() {
+    connection.removeAllListeners('data');
+    connection.removeAllListeners('error');
+  }
+
   function disconnect(deviceInfo, cb) {
     if (connection === null){
       return;
@@ -160,6 +165,7 @@ module.exports = function(config) {
   return {
     connect: connect,
     disconnect: disconnect,
+    removeListeners: removeListeners,
     discardBytes: discardBytes,
     receive: receive,
     send: send,


### PR DESCRIPTION
There is an upstream bug in the HIDAPI library used by the Node dependency `node-hid` (only on Windows 😡) that doesn't close the connection properly. To reproduce the bug, upload a Bayer meter and remove the device after a successful upload - for some reason I've only able to reproduce on Windows 7 and not Windows 10. The Electron app should crash (white screen). 

The workaround being the following:

- remove the listeners; and afterwards
- send another command to the device; and only then
- close the connection.

The workaround works on Mac and Windows, so we don't need OS-specific code 😌 A PR for the upstream bug has existed since January 2015, so I don't expect it to get fixed anytime soon.
 