### PR TITLE
MedT Direct: handle temp basal with schedule changes before automatic suspend/resume

### DIFF
--- a/lib/drivers/medtronic/medtronicSimulator.js
+++ b/lib/drivers/medtronic/medtronicSimulator.js
@@ -46,6 +46,7 @@ exports.make = function(config){
   var currTimestamp = null;
   var currPumpSettings = null;
   var suspendingEvent = null;
+  var resumingEvent = null;
   var currStatus = null;
   var prevBasal = null;
 
@@ -68,6 +69,10 @@ exports.make = function(config){
 
   function setSuspendingEvent(event) {
     suspendingEvent = event;
+  };
+
+  function setResumingEvent(event) {
+    resumingEvent = event;
   };
 
   function setCurrStatus(status) {
@@ -212,6 +217,8 @@ exports.make = function(config){
 
   return {
     basal: function(event) {
+      var resumedBasal = null;
+
       ensureTimestamp(event);
 
       if (currBasal != null) {
@@ -223,12 +230,24 @@ exports.make = function(config){
           if(duration > 0) {
             // suspending event did happen after the basal event
             currBasal.duration = duration;
+            checkForScheduleChanges();
+
+            if (resumingEvent != null) {
+              // this basal was automatically resumed
+              resumedBasal = _.clone(currBasal);
+            }
             common.truncateDuration(currBasal, 'medtronic');
             currBasal = currBasal.done();
             events.push(currBasal);
 
+            var resumeTime = null;
+            if(resumingEvent != null) {
+              resumeTime = resumingEvent.time;
+            } else {
+              resumeTime = event.time;
+            }
             // create suspended basal at time of alarm or reservoir change and set that as the current basal
-            var suspendedDuration = Date.parse(event.time) - Date.parse(suspendingEvent.time);
+            var suspendedDuration = Date.parse(resumeTime) - Date.parse(suspendingEvent.time);
             var suspendedBasal = config.builder.makeSuspendBasal()
               .with_deviceTime(suspendingEvent.deviceTime)
               .with_time(suspendingEvent.time)
@@ -236,6 +255,14 @@ exports.make = function(config){
               .with_conversionOffset(suspendingEvent.conversionOffset)
               .with_duration(suspendedDuration)
               .set('index', suspendingEvent.index);
+            suspendedBasal.suppressed = {
+              type: 'basal',
+              deliveryType: currBasal.deliveryType,
+              rate: currBasal.rate,
+            };
+            if (currBasal.suppressed) {
+              suspendedBasal.suppressed.suppressed = _.clone(currBasal.suppressed);
+            }
             setCurrBasal(suspendedBasal);
 
             var status = {
@@ -247,11 +274,17 @@ exports.make = function(config){
               duration: currBasal.duration,
               type: 'deviceEvent',
               subType: 'status',
-              status: 'suspended',
-              reason: {suspended: 'automatic', resumed: 'manual'},
+              status: 'suspended'
             };
-            if(suspendingEvent.alarmType) {
+            if (resumingEvent != null) {
+              status.reason = {suspended: 'automatic', resumed: 'automatic'};
+            } else {
+              status.reason = {suspended: 'automatic', resumed: 'manual'};
+            }
+            if (suspendingEvent.alarmType) {
               status.payload = {cause: suspendingEvent.alarmType};
+            } else if (suspendingEvent.subType) {
+              status.payload = {cause: suspendingEvent.subType};
             }
             annotate.annotateEvent(status, 'medtronic/status/fabricated-from-device-event');
 
@@ -260,6 +293,25 @@ exports.make = function(config){
           }
           events.push(suspendingEvent);
           setSuspendingEvent(null); //reset device event as not to re-use
+
+          if (resumingEvent != null && resumedBasal) {
+            checkForScheduleChanges();
+
+            // push suspended basal on stack
+            common.truncateDuration(currBasal, 'medtronic');
+            currBasal = currBasal.done();
+            events.push(currBasal);
+
+            // set resumed basal as current basal
+            resumedBasal.time = resumingEvent.time;
+            resumedBasal.deviceTime = resumingEvent.deviceTime;
+            resumedBasal.timezoneOffset = resumingEvent.timezoneOffset;
+            resumedBasal.conversionOffset = resumingEvent.conversionOffset;
+            resumedBasal.duration = Date.parse(event.time) - Date.parse(resumingEvent.time);
+
+            setCurrBasal(resumedBasal);
+            setResumingEvent(null); //reset device event as not to re-use
+          }
         }
 
         if(!currBasal.isAssigned('duration')) {
@@ -545,6 +597,9 @@ exports.make = function(config){
       }
     },
     prime: function(event) {
+      if(suspendingEvent != null) {
+        setResumingEvent(event);
+      }
       simpleSimulate(event);
     },
     rewind: function(event) {

--- a/manifest.json
+++ b/manifest.json
@@ -2,11 +2,7 @@
   "manifest_version": 2,
   "name": "Tidepool Uploader",
   "short_name": "Uploader",
-<<<<<<< HEAD
-  "version": "0.305.32",
-=======
   "version": "0.306.1",
->>>>>>> master
   "description": "The Tidepool Uploader helps you get your data from insulin pumps, CGMs and BG meters into Tidepool’s secure cloud platform.",
   "minimum_chrome_version": "38",
   "icons": {


### PR DESCRIPTION
When there is a temp basal with a reservoir change, we need to infer the resumption of the temp basal from the prime event. We also need to take into account any scheduled changes that took place before the suspend event.

@pazaan, would you mind verifying this with the affected alpha user's binary blob and look at the events that are created? I have done this, but it will be good for someone else to double-check.