### PR TITLE
fix reference to renamed message length field

### DIFF
--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -30,7 +30,7 @@ import * as actionSources from '../constants/actionSources';
 import { pages, pagesMap } from '../constants/otherConstants';
 
 import styles from '../../styles/components/Header.module.less';
-import logo from '../../images/Tidepool_Logo_light x2.png';
+import logo from '../../images/Tidepool_Logo_Light x2.png';
 
 export class Header extends Component {
   static propTypes = {

--- a/lib/drivers/bayer/bayerContourNext.js
+++ b/lib/drivers/bayer/bayerContourNext.js
@@ -89,7 +89,7 @@ module.exports = function (config) {
     }
 
     var astmMessage = extractPacketIntoMessage(buffer.bytes());
-    if (astmMessage.packet_len !== 0) {
+    if (astmMessage.messageLength !== 0) {
       // cleanup the buffer data
       buffer.discard(HID_PACKET_SIZE - discardCount);
     }


### PR DESCRIPTION
It seems the returned structure of "extractPacket" (now "extractPacketIntoFrame") used to have a field "packet_len".

This field was renamed first to "frame_len" in this commit:
https://github.com/tidepool-org/chrome-uploader/commit/8fafd23a4e7eb139bdaa6088f8695ab07e1fef8a#diff-faa8e43c937889d080484b85f6ab4115R68

and then to "messageLength" in this commit:
https://github.com/tidepool-org/chrome-uploader/commit/6c14f760abf56486801f4c91e96085cf00a04a6b#diff-faa8e43c937889d080484b85f6ab4115R64

But the check against it being 0 was never updated.
Thus, the referenced "packet_len" is now always "null", so the comparison will always return "true" (null !== 0).
This will lead to discarding of data, even when the "messageLength" is 0.