### PR TITLE
fix first char case of medtronic driver name

### DIFF
--- a/lib/core/device.js
+++ b/lib/core/device.js
@@ -39,7 +39,7 @@ var oneTouchVerioIQ = require('../drivers/onetouch/oneTouchVerioIQ');
 var abbottFreeStyleLite = require('../drivers/abbott/abbottFreeStyleLite');
 var bayerContourNext = require('../drivers/bayer/bayerContourNext');
 var animasDriver = require('../drivers/animas/animasDriver');
-var medtronicDriver = require('../drivers/medtronic/MedtronicDriver');
+var medtronicDriver = require('../drivers/medtronic/medtronicDriver');
 
 var device = {
   log: require('bows')('Device')


### PR DESCRIPTION
new driver is not found due to case sensitive filenames on Linux