### PR TITLE
Add more CBG types that can increment time

### DIFF
--- a/lib/drivers/medtronic/cli/compare_json.js
+++ b/lib/drivers/medtronic/cli/compare_json.js
@@ -49,7 +49,10 @@ function cleanup(record) {
     delete record.bgInput;
   }
   if(record.type === 'cbg') {
-    record.value -= record.value % 2; 
+    record.value -= record.value % 2; // CareLink only reports even values (!)
+    if(record.value === 40) {
+      record.value = 38; // difference between CL and TP implementation for BG low
+    }
   }
   if(record.type === 'basal') {
     // CareLink driver always uses expectedDuration as duration (which then gets modified by Jellyfish)

--- a/lib/drivers/medtronic/cli/compare_json.js
+++ b/lib/drivers/medtronic/cli/compare_json.js
@@ -8,7 +8,9 @@ var difflet = require('difflet')({ indent : 2, comment: true });
 var intro = 'Compare JSON CLI:';
 var file1, file2;
 
-var EXCLUDES = ['index','source','previous','payload','deviceId','annotations'];
+var EXCLUDES = ['index','source','previous','payload','deviceId','annotations',
+'_deduplicator', 'createdUserId', 'guid', 'id', 'uploadId','deviceSerialNumber', 'modifiedUserId'
+];
 /* reasons for exclusion:
    index - always different between CareLink and Medtronic drivers
    source - not used in Medtronic driver
@@ -45,6 +47,9 @@ function cleanup(record) {
   if(record.bgInput === 0) {
     // CareLink driver records zero bg values
     delete record.bgInput;
+  }
+  if(record.type === 'cbg') {
+    record.value -= record.value % 2; 
   }
   if(record.type === 'basal') {
     // CareLink driver always uses expectedDuration as duration (which then gets modified by Jellyfish)

--- a/lib/drivers/medtronic/processData.js
+++ b/lib/drivers/medtronic/processData.js
@@ -536,9 +536,18 @@ function buildCGMRecords(events) {
               postrecords.push(record);
             }
           } else {
-            if (descriptor === 2 && event.body[offset] === 0x02) {
+            var type = getType(event.body[offset],CBG_RECORD_TYPES);
+            // TODO: determine when CBG type is valid (), e.g.
+            // SENSOR_CALIBRATION_EVENT with descrptor 238 is valid,
+            // but with 0x22 is not
+            if(descriptor === 0 || descriptor === 2 || type === CBG_RECORD_TYPES.SENSOR_PACKET_EVENT) {
+              if(__DEBUG__) {
+                debug('CBG type:', type.name);
+              }
               recordsSinceTimestamp += 1;
-            }
+            } /* else {
+              console.log("DESCRIPTOR:", descriptor, "TYPE:",getType(event.body[offset],CBG_RECORD_TYPES).name)
+            } */
           }
 
           offset -= 1;

--- a/lib/drivers/medtronic/processData.js
+++ b/lib/drivers/medtronic/processData.js
@@ -537,17 +537,12 @@ function buildCGMRecords(events) {
             }
           } else {
             var type = getType(event.body[offset],CBG_RECORD_TYPES);
-            // TODO: determine when CBG type is valid (), e.g.
-            // SENSOR_CALIBRATION_EVENT with descrptor 238 is valid,
-            // but with 0x22 is not
-            if(descriptor === 0 || descriptor === 2 || type === CBG_RECORD_TYPES.SENSOR_PACKET_EVENT) {
+            if( (descriptor < 20 || descriptor > 200) && type != null) {
               if(__DEBUG__) {
                 debug('CBG type:', type.name);
               }
               recordsSinceTimestamp += 1;
-            } /* else {
-              console.log("DESCRIPTOR:", descriptor, "TYPE:",getType(event.body[offset],CBG_RECORD_TYPES).name)
-            } */
+            }
           }
 
           offset -= 1;


### PR DESCRIPTION
There are events like SENSOR_WEAK_SIGNAL and SENSOR_CALIBRATION_EVENT that sometimes increment the time with another 5 minutes. Prior to this PR we only took SENSOR_WEAK_SIGNAL into account, but there are others. A combination of the descriptor and the type have to be used to identify which ones are used.