### PR TITLE
Support for OneTouch Ultra2

### DIFF
--- a/docs/checklists/oneTouchUltra2.md
+++ b/docs/checklists/oneTouchUltra2.md
@@ -11,9 +11,9 @@
 ### Required if Present
 
 - `[x]` smbg values
-- `[ ]` units of smbg values (read from device, not hard-coded)
+- `[x]` units of smbg values (read from device, not hard-coded)
 - `[ ]` out-of-range values (LO or HI)
-- `[ ]` out-of-range value thresholds (e.g., often 20 for low and 600 for high on BGMs)
+- `*[ ]` out-of-range value thresholds (e.g., often 20 for low and 600 for high on BGMs)
 - `[ ]` date & time settings changes
 - `[ ]` blood ketone values
 - `[ ]` units of blood ketone values (read from device, not hard-coded)
@@ -22,9 +22,9 @@
 
 ### No Tidepool Data Model Yet
 
-- `[ ]` control (solution) tests (whether marked in UI or auto-detected) - until we have a data model, these should be discarded
+- `*[ ]` control (solution) tests (whether marked in UI or auto-detected) - until we have a data model, these should be discarded
 - `[ ]` device settings, other than date & time (e.g., target blood glucose range)
-- `[ ]` tag/note (e.g., pre- vs. post-meal)
+- `[-]` tag/note (e.g., pre- vs. post-meal)
 
 ### Tidepool ingestion API
 

--- a/docs/checklists/oneTouchUltra2.md
+++ b/docs/checklists/oneTouchUltra2.md
@@ -1,0 +1,38 @@
+## OneTouch Ultra2
+
+(Key:
+
+ - `[x]` available in data protocol/documented in spec and implemented
+ - `[-]` available in data protocol/documented in spec but *not* yet implemented
+ - `[?]` unknown whether available in data protocol/documented in spec; *not* yet implemented
+ - `*[ ]` TODO: needs implementation!
+ - `[ ]` unavailable in data protocol and/or not documented in spec and not yet implemented)
+
+### Required if Present
+
+- `[x]` smbg values
+- `[ ]` units of smbg values (read from device, not hard-coded)
+- `[ ]` out-of-range values (LO or HI)
+- `[ ]` out-of-range value thresholds (e.g., often 20 for low and 600 for high on BGMs)
+- `[ ]` date & time settings changes
+- `[ ]` blood ketone values
+- `[ ]` units of blood ketone values (read from device, not hard-coded)
+- `[ ]` ketone out-of-range values
+- `[ ]` ketone out-of-range value thresholds
+
+### No Tidepool Data Model Yet
+
+- `[ ]` control (solution) tests (whether marked in UI or auto-detected) - until we have a data model, these should be discarded
+- `[ ]` device settings, other than date & time (e.g., target blood glucose range)
+- `[ ]` tag/note (e.g., pre- vs. post-meal)
+
+### Tidepool ingestion API
+
+Choose one of the following:
+
+  - `[ ]` legacy "jellyfish" ingestion API
+  - `[ ]` platform ingestion API
+
+### Known implementation issues/TODOs
+
+*Use this space to describe device-specific known issues or implementation TODOs **not** contained in the above datatype-specific sections.*

--- a/docs/checklists/oneTouchUltra2.md
+++ b/docs/checklists/oneTouchUltra2.md
@@ -12,8 +12,8 @@
 
 - `[x]` smbg values
 - `[x]` units of smbg values (read from device, not hard-coded)
-- `[ ]` out-of-range values (LO or HI)
-- `*[ ]` out-of-range value thresholds (e.g., often 20 for low and 600 for high on BGMs)
+- `[x]` out-of-range values (LO or HI)
+- `[ ]` out-of-range value thresholds (e.g., often 20 for low and 600 for high on BGMs)
 - `[ ]` date & time settings changes
 - `[ ]` blood ketone values
 - `[ ]` units of blood ketone values (read from device, not hard-coded)
@@ -22,7 +22,7 @@
 
 ### No Tidepool Data Model Yet
 
-- `*[ ]` control (solution) tests (whether marked in UI or auto-detected) - until we have a data model, these should be discarded
+- `[x]` control (solution) tests (whether marked in UI or auto-detected) - until we have a data model, these should be discarded
 - `[ ]` device settings, other than date & time (e.g., target blood glucose range)
 - `[-]` tag/note (e.g., pre- vs. post-meal)
 
@@ -30,7 +30,7 @@
 
 Choose one of the following:
 
-  - `[ ]` legacy "jellyfish" ingestion API
+  - `[x]` legacy "jellyfish" ingestion API
   - `[ ]` platform ingestion API
 
 ### Known implementation issues/TODOs

--- a/lib/drivers/onetouch/oneTouchUltra2.js
+++ b/lib/drivers/onetouch/oneTouchUltra2.js
@@ -352,10 +352,6 @@ module.exports = function (config) {
           return cb(null, data);
         }
       });
-
-      progress(100);
-      data.cleanup = true;
-      cb(null, data);
     },
 
     disconnect: function (progress, data, cb) {

--- a/lib/drivers/onetouch/oneTouchUltra2.js
+++ b/lib/drivers/onetouch/oneTouchUltra2.js
@@ -126,7 +126,7 @@ module.exports = function (config) {
       clearInterval(listenTimer);
 
       callback(null, pkt);
-    }, 1000);     // spin on this one not so quickly
+    }, 2000);     // spin on this one not so quickly
   };
 
   var probe = function(cb){
@@ -138,13 +138,19 @@ module.exports = function (config) {
     var cmd = struct.packString(command);
     serialDevice.writeSerial(cmd, function () {
       listenForPacket(18000, function(err, pkt) {
-        callback(err, pkt);
+        if(err) {
+          return callback(err, null);
+        }
+        var error = null;
+        if(pkt.packet_len === 1 && pkt.bytes[0] === 0) {
+          error = new Error('Meter not plugged into cable');
+        }
+        callback(error, pkt);
       });
     });
   };
 
   var prepBGData = function (progress, data) {
-    cfg.builder.setDefaults({ deviceId: data.id });
     var dataToPost = [];
 
     // this is converting the data bytes array to a string
@@ -174,6 +180,7 @@ module.exports = function (config) {
     // set missing serial number and id
     data.serialNumber = serialno;
     data.id = 'OneTouchUltra2-' + serialno;
+    cfg.builder.setDefaults({ deviceId: data.id});
 
     oum = oum.toLowerCase();
     var len = oum.length - 1;
@@ -194,42 +201,71 @@ module.exports = function (config) {
     var dpattern = /P "(\w+)","(\d{2}\/\d{2}\/\d{2})","(\d{2}:\d{2}:\d{2})   ","..(\d{3}).","(.)","(\d{2})",\W00\W(.+)/;
     var index = 0;
     _.forEach(splites.slice(1), function(l){ // <-- jump the header
-        var ms = l.match(dpattern);
-        index += 1;
-        if(ms){
-            var dow = ms[1], // day of week
-                dor = ms[2], // date of reading
-                tor = ms[3], // time of reading
-                rf  = ms[4], // result
-                alv = ms[5], // alpha value
-                umc = ms[6], // numeric value for user meal comment
-                chk = ms[7], // checksum
-                createchk = 0;
+        if (l.length > 0) {
+          var ms = l.match(dpattern);
+          index += 1;
+          if(ms){
+              var dow = ms[1], // day of week
+                  dor = ms[2], // date of reading
+                  tor = ms[3], // time of reading
+                  rf  = ms[4], // result
+                  alv = ms[5], // alpha value
+                  umc = ms[6], // numeric value for user meal comment
+                  chk = ms[7], // checksum
+                  createchk = 0;
 
-            var st = l.substr(0, l.indexOf(chk) - 1);
+              var st = l.substr(0, l.indexOf(chk) - 1);
 
-            createchk = _.reduce(st, function (s1, e) {
-                return s1 + e.charCodeAt(0);
-            }, 0);
+              createchk = _.reduce(st, function (s1, e) {
+                  return s1 + e.charCodeAt(0);
+              }, 0);
 
-            if(createchk !== parseInt(chk, 16)){
-              debug('error...bad checksum in data lines', createchk, chk);
-              return null;
-            } else {
-              var jsDate = buildDateTime(dor, tor);
+              if(createchk !== parseInt(chk, 16)){
+                debug('error...bad checksum in data lines', createchk, chk);
+                return null;
+              } else {
+                var jsDate = buildDateTime(dor, tor);
+                var glucose = parseFloat(rf);
 
-              var smbg = cfg.builder.makeSMBG()
-                              .with_value(parseInt(rf))
-                              .with_deviceTime(sundial.formatDeviceTime(jsDate))
-                              .with_units(units)
-                              .set('index',index);
+                // Control solution tests start with C, so won't parse as a number
+                if (glucose === NaN) {
+                  debug(sundial.formatDeviceTime(jsDate), 'Control solution test, skipping..');
+                  return;
+                }
 
-              cfg.tzoUtil.fillInUTCInfo(smbg, jsDate);
-              delete smbg.index;
-              dataToPost.push(smbg.done());
-            }
-        }else{
-          debug('ERROR: no match in dpattern:', l);
+                var smbg = cfg.builder.makeSMBG()
+                                .with_value(glucose)
+                                .with_deviceTime(sundial.formatDeviceTime(jsDate))
+                                .with_units(units)
+                                .set('index',index);
+
+                cfg.tzoUtil.fillInUTCInfo(smbg, jsDate);
+                delete smbg.index;
+
+                var annotation = null;
+                if (glucose < 20) {
+                  annotation = {
+                    code: 'bg/out-of-range',
+                    value: 'low',
+                    threshold: 20
+                  };
+                } else if (glucose > 600) {
+                  annotation = {
+                    code: 'bg/out-of-range',
+                    value: 'high',
+                    threshold: 600
+                  };
+                }
+
+                if(annotation) {
+                  annotate.annotateEvent(smbg, annotation);
+                }
+
+                dataToPost.push(smbg.done());
+              }
+          }else{
+            debug('ERROR: no match in dpattern:', l);
+          }
         }
     });
 

--- a/lib/drivers/onetouch/oneTouchUltra2.js
+++ b/lib/drivers/onetouch/oneTouchUltra2.js
@@ -143,11 +143,6 @@ module.exports = function (config) {
     });
   };
 
-  var getSomeInfo = function (obj, cb) {
-      debug('DEBUG: on getSomeInfo');
-      cb();
-  };
-
   var prepBGData = function (progress, data) {
     cfg.builder.setDefaults({ deviceId: data.id });
     var dataToPost = [];
@@ -253,22 +248,12 @@ module.exports = function (config) {
     connect: function (progress, data, cb) {
       debug('in connect!');
 
-      //PV add some timeout - maybe there is a better place to set this
-      //on manifest is not working
-      data.deviceInfo.sendTimeout = 5000;
-      data.deviceInfo.receiveTimeout = 5000;
-
       cfg.deviceComms.connect(data.deviceInfo, otu2MessageHandler, probe, function(err) {
         if (err) {
           return cb(err);
         }
-
-        getSomeInfo({}, function (err, result) {
-          progress(100);
-          data.connect = true;
-          _.assign(data, result);
-          cb(null, data);
-        });
+        data.connect = true;
+        cb(null, data);
       });
     },
 
@@ -286,16 +271,13 @@ module.exports = function (config) {
 
       otu2CommandResponse(cmd, function(err, result){
           if (err) {
-              debug('Failure trying to talk to device.');
-              debug(err);
-              debug(result);
-              callback(err, null);
+            debug('Failure trying to talk to device.');
+            debug(err);
+            debug(result);
+            callback(err, null);
           } else {
-              //PV grow up the results
-              debug('fetchData otu2CommandResponse:', result);
-              var obj = {};
-              _.assign(obj, result);
-              callback(null, obj);
+            debug('fetchData otu2CommandResponse:', result);
+            callback(null, result);
           }
       });
     },

--- a/lib/drivers/onetouch/oneTouchUltra2.js
+++ b/lib/drivers/onetouch/oneTouchUltra2.js
@@ -32,6 +32,7 @@ var async = require('async');
 var sundial = require('sundial');
 var struct = require('../../struct.js')();
 var TZOUtil = require('../../TimezoneOffsetUtil');
+var annotate = require('../../eventAnnotations');
 
 var isBrowser = typeof window !== 'undefined';
 var debug = isBrowser ? require('../../bows')('Ultra2Driver') : debug;

--- a/lib/drivers/onetouch/oneTouchUltra2.js
+++ b/lib/drivers/onetouch/oneTouchUltra2.js
@@ -199,7 +199,7 @@ module.exports = function (config) {
      }
 
     // get data from lines
-    var dpattern = /P "(\w+)","(\d{2}\/\d{2}\/\d{2})","(\d{2}:\d{2}:\d{2})   ","(..\d{3}).","(.)","(\d{2})",\W00\W(.+)/;
+    var dpattern = /P "(\w+)","(\d{2}\/\d{2}\/\d{2})","(\d{2}:\d{2}:\d{2})   ","(..\d{3} )","(.)","(\d{2})",\W00\W(.+)/;
     var index = 0;
     _.forEach(splites.slice(1), function(l){ // <-- jump the header
         if (l.length > 0) {

--- a/lib/drivers/onetouch/oneTouchUltra2.js
+++ b/lib/drivers/onetouch/oneTouchUltra2.js
@@ -16,8 +16,6 @@
  */
 
 /**
- * IOET's code start here
- * pvalarezo@ioet.com
  *
  * The header is something like:
  * P 003,"GMF600DCY","MG/DL " 05A6
@@ -30,12 +28,10 @@
  */
 
 var _ = require('lodash');
-// asyncronous javscript
 var async = require('async');
-// Tidepool lib for ISO date handling
 var sundial = require('sundial');
-// Tidepool struct lib
 var struct = require('../../struct.js')();
+var TZOUtil = require('../../TimezoneOffsetUtil');
 
 var isBrowser = typeof window !== 'undefined';
 var debug = isBrowser ? require('../../bows')('Ultra2Driver') : debug;
@@ -44,6 +40,9 @@ module.exports = function (config) {
   var cfg = _.clone(config);
   cfg.deviceData = null;
   var serialDevice = config.deviceComms;
+  // With no date & time settings changes available,
+  // timezone is applied across-the-board
+  cfg.tzoUtil = new TZOUtil(cfg.timezone, new Date().toISOString(), []);
 
   //BYTE START DEFINITION HEX
   var DM = '\x11\x0d';
@@ -59,11 +58,7 @@ module.exports = function (config) {
   function buildDateTime(date, time) {
     var fmt = 'MM/DD/YY HH:mm:ss';
     var ddate = date + ' ' + time;
-    var parsed = sundial.parseFromFormat(ddate, fmt);
-    var dev = sundial.formatDeviceTime(parsed);
-    var utc = sundial.applyTimezone(dev, cfg.timezone).toISOString();
-    var offset = sundial.getOffsetFromZone(utc, cfg.timezone);
-    return { dev: dev, utc: utc, offset: offset };
+    return sundial.parseFromFormat(ddate, fmt);
   }
 
   var buildPacket = function (bytes) {
@@ -101,18 +96,6 @@ module.exports = function (config) {
     }
   };
 
-  var otu2ErrorHandler = function(info) {
-    // we don't care too much for timeout errors
-    if(info.error && info.error!=='timeout'){
-      debug('DEBUG OTU2ERROR:', info);
-    }
-    if (info.connectionId && info.error) {
-      if (info.error == 'timeout') {
-        debug('OTU2ERROR: ', info.error);
-      }
-    }
-  };
-
   var byteConcat = function (a, b){
       var aLength = a.length,
       result = new Uint8Array(aLength + b.length);
@@ -132,6 +115,7 @@ module.exports = function (config) {
       var wholebytes = new Uint8Array([0]), pkt;
 
       while(serialDevice.hasAvailablePacket()) {
+        clearInterval(listenTimer);
         pkt = serialDevice.nextPacket();
         wholebytes = byteConcat(wholebytes, pkt.bytes);
       }
@@ -146,7 +130,7 @@ module.exports = function (config) {
   };
 
   var probe = function(cb){
-    debug('attempting probe of oneTouch Ultra2');
+    debug('not attempting probe of oneTouch Ultra2');
     cb();
   };
 
@@ -154,14 +138,9 @@ module.exports = function (config) {
     var cmd = struct.packString(command);
     serialDevice.writeSerial(cmd, function () {
       listenForPacket(18000, function(err, pkt) {
-        if (err === 'TIMEOUT') {
-        } else {
-          callback(err, pkt);
-        }
+        callback(err, pkt);
       });
-
     });
-
   };
 
   var getSomeInfo = function (obj, cb) {
@@ -199,7 +178,11 @@ module.exports = function (config) {
 
     // set missing serial number and id
     data.serialNumber = serialno;
-    data.id = data.id + serialno;
+    data.id = 'OneTouchUltra2-' + serialno;
+
+    oum = oum.toLowerCase();
+    var len = oum.length - 1;
+    var units = oum.substring(0, len) + oum.substr(len).toUpperCase();
 
     var sth = header.substr(0, header.indexOf(checksum) - 1);
 
@@ -214,8 +197,10 @@ module.exports = function (config) {
 
     // get data from lines
     var dpattern = /P "(\w+)","(\d{2}\/\d{2}\/\d{2})","(\d{2}:\d{2}:\d{2})   ","..(\d{3}).","(.)","(\d{2})",\W00\W(.+)/;
+    var index = 0;
     _.forEach(splites.slice(1), function(l){ // <-- jump the header
         var ms = l.match(dpattern);
+        index += 1;
         if(ms){
             var dow = ms[1], // day of week
                 dor = ms[2], // date of reading
@@ -236,20 +221,20 @@ module.exports = function (config) {
               debug('error...bad checksum in data lines', createchk, chk);
               return null;
             } else {
-              var bdt = buildDateTime(dor, tor);
+              var jsDate = buildDateTime(dor, tor);
 
               var smbg = cfg.builder.makeSMBG()
-                              .with_deviceId('OneTouchUltra2 ' + serialno)
                               .with_value(parseInt(rf))
-                              .with_deviceTime(bdt.dev)
-                              .with_time(bdt.utc)
-                              .with_timezoneOffset(bdt.offset)
-                              .with_units('mg/dL')
-                              .done();
-              dataToPost.push(smbg);
+                              .with_deviceTime(sundial.formatDeviceTime(jsDate))
+                              .with_units(units)
+                              .set('index',index);
+
+              cfg.tzoUtil.fillInUTCInfo(smbg, jsDate);
+              delete smbg.index;
+              dataToPost.push(smbg.done());
             }
         }else{
-          debug('ERROR: no match in dpattern');
+          debug('ERROR: no match in dpattern:', l);
         }
     });
 
@@ -268,17 +253,12 @@ module.exports = function (config) {
     connect: function (progress, data, cb) {
       debug('in connect!');
 
-      var handlers = {
-        packetHandler: otu2MessageHandler,
-        errorHandler: otu2ErrorHandler
-      };
-
       //PV add some timeout - maybe there is a better place to set this
       //on manifest is not working
       data.deviceInfo.sendTimeout = 5000;
       data.deviceInfo.receiveTimeout = 5000;
 
-      cfg.deviceComms.connect(data.deviceInfo, handlers, probe, function(err) {
+      cfg.deviceComms.connect(data.deviceInfo, otu2MessageHandler, probe, function(err) {
         if (err) {
           return cb(err);
         }
@@ -321,6 +301,7 @@ module.exports = function (config) {
     },
 
     processData: function (progress, data, cb) {
+      debug('in processData');
       progress(0);
       data.post_records = prepBGData(progress, data);
       data.processData = true;
@@ -337,6 +318,7 @@ module.exports = function (config) {
         deviceSerialNumber: data.serialNumber,
         deviceId: data.id,
         start: sundial.utcDateString(),
+        timeProcessing: cfg.tzoUtil.type,
         tzName : cfg.timezone,
         version: cfg.version
       };

--- a/lib/drivers/onetouch/oneTouchUltra2.js
+++ b/lib/drivers/onetouch/oneTouchUltra2.js
@@ -105,29 +105,41 @@ module.exports = function (config) {
       return result;
   };
 
-  var listenForPacket = function (timeout, callback) {
+  var listenForPacket = function (timeout, progress, callback) {
     var abortTimer = setTimeout(function () {
       clearInterval(listenTimer);
       debug('TIMEOUT');
       callback('TIMEOUT', null);
     }, timeout);
 
+    var wholebytes = new Uint8Array([0]), pkt;
+    var percentage = 0;
+
     var listenTimer = setInterval(function () {
-      var wholebytes = new Uint8Array([0]), pkt;
 
-      while(serialDevice.hasAvailablePacket()) {
+      if (serialDevice.hasAvailablePacket()) {
+        percentage = Math.min(100, percentage + 1);
+        progress(percentage);
+
+        while(serialDevice.hasAvailablePacket()) {
+          pkt = serialDevice.nextPacket();
+          wholebytes = byteConcat(wholebytes, pkt.bytes);
+        }
+
+      } else if (wholebytes.length > 0) {
+        // if there are no bytes left in the buffer and we already have data,
+        // we're at the end of the packet stream
+
+        pkt = buildPacket(wholebytes);
+        var tostr = String.fromCharCode.apply(String, pkt.bytes);
+        debug('DEBUG OTU2 listenForPacket:', pkt, tostr);
+        clearTimeout(abortTimer);
         clearInterval(listenTimer);
-        pkt = serialDevice.nextPacket();
-        wholebytes = byteConcat(wholebytes, pkt.bytes);
-      }
-      pkt = buildPacket(wholebytes);
-      var tostr = String.fromCharCode.apply(String, pkt.bytes);
-      debug('DEBUG OTU2 listenForPacket:', pkt, tostr);
-      clearTimeout(abortTimer);
-      clearInterval(listenTimer);
 
-      callback(null, pkt);
-    }, 2000);     // spin on this one not so quickly
+        callback(null, pkt);
+      }
+
+    }, 500);     // spin on this one not so quickly
   };
 
   var probe = function(cb){
@@ -135,10 +147,10 @@ module.exports = function (config) {
     cb();
   };
 
-  var otu2CommandResponse = function (command, callback) {
+  var otu2CommandResponse = function (command, progress, callback) {
     var cmd = struct.packString(command);
     serialDevice.writeSerial(cmd, function () {
-      listenForPacket(18000, function(err, pkt) {
+      listenForPacket(18000, progress, function(err, pkt) {
         if(err) {
           return callback(err, null);
         }
@@ -305,7 +317,7 @@ module.exports = function (config) {
 
       var cmd = DMUpload;
 
-      otu2CommandResponse(cmd, function(err, result){
+      otu2CommandResponse(cmd, progress, function(err, result){
           if (err) {
             debug('Failure trying to talk to device.');
             debug(err);

--- a/lib/drivers/onetouch/oneTouchUltra2.js
+++ b/lib/drivers/onetouch/oneTouchUltra2.js
@@ -199,7 +199,7 @@ module.exports = function (config) {
      }
 
     // get data from lines
-    var dpattern = /P "(\w+)","(\d{2}\/\d{2}\/\d{2})","(\d{2}:\d{2}:\d{2})   ","..(\d{3}).","(.)","(\d{2})",\W00\W(.+)/;
+    var dpattern = /P "(\w+)","(\d{2}\/\d{2}\/\d{2})","(\d{2}:\d{2}:\d{2})   ","(..\d{3}).","(.)","(\d{2})",\W00\W(.+)/;
     var index = 0;
     _.forEach(splites.slice(1), function(l){ // <-- jump the header
         if (l.length > 0) {
@@ -226,13 +226,12 @@ module.exports = function (config) {
                 return null;
               } else {
                 var jsDate = buildDateTime(dor, tor);
-                var glucose = parseFloat(rf);
 
-                // Control solution tests start with C, so won't parse as a number
-                if (glucose === NaN) {
+                if(rf.charAt(0) === 'C') {
                   debug(sundial.formatDeviceTime(jsDate), 'Control solution test, skipping..');
                   return;
                 }
+                var glucose = parseFloat(rf);
 
                 var smbg = cfg.builder.makeSMBG()
                                 .with_value(glucose)

--- a/lib/redux/reducers/devices.js
+++ b/lib/redux/reducers/devices.js
@@ -120,6 +120,14 @@ const devices = {
     showDriverLink: {mac: true, win: true},
     source: {type: 'device', driverId: 'OneTouchVerioIQ'},
     enabled: {mac: true, win: true}
+  },
+  onetouchultra2: {
+    instructions: 'Plug in meter with cable',
+    name: 'OneTouch Ultra2',
+    key: 'onetouchultra2',
+    showDriverLink: {mac: true, win: true},
+    source: {type: 'device', driverId: 'OneTouchUltra2'},
+    enabled: {mac: true, win: true}
   }
 };
 

--- a/manifest.json
+++ b/manifest.json
@@ -83,7 +83,8 @@
           "mode": "FTDI",
           "vendorId": 1027,
           "productId": 24577,
-          "sendTimeout": 5000
+          "sendTimeout": 5000,
+          "receiveTimeout": 5000
         },
         {
           "deviceName": "OneTouchVerioIQ",


### PR DESCRIPTION
We've had the Ultra2 driver in the codebase for a while now, but it has always been disabled since it didn't have proper error handling and didn't adhere to the UTC bootstrapping time format.

This PR adds:
- TZOUtil across-the-the-board time
- units from meter, not hard-coded
- BGM checklist
- skipping control solution tests
- annotating HI/LOs
