### PR TITLE
Electron: Bayer fixes

### DIFF
--- a/lib/drivers/bayer/bayerContourNext.js
+++ b/lib/drivers/bayer/bayerContourNext.js
@@ -227,7 +227,10 @@ module.exports = function (config) {
   */
   var parseDataRecord = function (data, callback){
     // TODO - The NextLink 2.4 also includes seconds in its timestamp (14 digits)
-    var result = data.match(/^R\|(\d+)\|\^\^\^Glucose\|([0-9.]+)\|(\w+\/\w+).*\|{2}(.*)\|{2}(\d{12}).*/).slice(1,6);
+    var result = data.match(/^R\|(\d+)\|\^\^\^Glucose\|([0-9.]+)\|(\w+\/\w+).*\|{2}(.*)\|{2}(\d{12}).*/);
+    if (result != null) {
+      result = result.slice(1,6);
+    }
     callback(null, result);
   };
 

--- a/lib/drivers/bayer/bayerContourNext.js
+++ b/lib/drivers/bayer/bayerContourNext.js
@@ -202,7 +202,7 @@ module.exports = function (config) {
       message[message.length-2] === ASCII_CONTROL.CR &&
       message[message.length-1] === ASCII_CONTROL.LF ) &&
       message[0] !== ASCII_CONTROL.EOT ) {
-      throw(new Error('Malformed ASTM Message.'));
+      throw(new Error('Meter not ready. Please retry.'));
     }
 
     var frameLength = message.length - 6; // Would normally be - 5, but we'll unpack the sequence number directly


### PR DESCRIPTION
I think we used to skip non-glucose records, so this is likely a regression. The meter checklist indicates that carb/insulin records on meter will be implemented in future as it requires changes to the data model.

I also changed the error message for a malformed ASTM message, as it appears when you click Upload immediately after the meter is plugged in and not yet ready for comms.