### PR TITLE
Electron: Bayer error handling

### DIFF
--- a/lib/drivers/bayer/bayerContourNext.js
+++ b/lib/drivers/bayer/bayerContourNext.js
@@ -281,7 +281,7 @@ module.exports = function (config) {
       function (whilstCb) {
         bcnCommandResponse(cmd, function (err, record) {
           if (err) {
-            if (err.name === 'TIMEOUT') {
+            if (err.name === 'TIMEOUT' || err.name === 'TypeError') {
               return whilstCb(err, null);
             } else {
               retry++;
@@ -374,48 +374,48 @@ module.exports = function (config) {
     async.doWhilst(
       function (callback) {
         hidDevice.receive(function(raw) {
-          var packet = new Uint8Array(raw);
-          message = extractPacketIntoMessage(packet.slice(MAGIC_HEADER.length));
+          try {
+            var packet = new Uint8Array(raw);
+            message = extractPacketIntoMessage(packet.slice(MAGIC_HEADER.length));
 
-          // Only process if we get data
-          if ( packet.length === 0 ) {
-            return callback(false);
-          }
+            // Only process if we get data
+            if ( packet.length === 0 ) {
+              return callback(null, false);
+            }
 
-          var packetHead = struct.unpack(packet, 0, '3Z2b', ['HEADER', 'SIZE', 'BYTE1']);
+            var packetHead = struct.unpack(packet, 0, '3Z2b', ['HEADER', 'SIZE', 'BYTE1']);
 
-          if(packetHead['HEADER'] !== MAGIC_HEADER){
-            debug('Invalid packet from Contour device');
-            clearTimeout(abortTimer);
-            return callback(new Error('Invalid USB packet received.'));
-          }
-
-          // The tail of the packet starts 6 from the end, but because we haven't stripped the
-          // MAGIC_HEADER and length byte from packet, we're using SIZE - 2
-          var packetTail = struct.unpack(packet, parseInt(packetHead['SIZE']) - 2, '2b2Z2Z', ['CR', 'FRAME_TYPE', 'CHECKSUM', 'CRLF']);
-
-          // HID_PACKET_SIZE - 4, because we don't include the MAGIC_HEADER or the SIZE
-          if( packetHead['SIZE'] < ( HID_PACKET_SIZE - 4 ) ||
-              packetHead['BYTE1'] == ASCII_CONTROL.EOT ||
-              packetHead['BYTE1'] == ASCII_CONTROL.ENQ ||
-              packetTail['FRAME_TYPE'] == ASCII_CONTROL.ETX ||
-              packetTail['FRAME_TYPE'] == ASCII_CONTROL.ETB ) {
+            if(packetHead['HEADER'] !== MAGIC_HEADER){
+              debug('Invalid packet from Contour device');
               clearTimeout(abortTimer);
-              return callback(true);
+              return callback(new Error('Invalid USB packet received.'));
+            }
+
+            // The tail of the packet starts 6 from the end, but because we haven't stripped the
+            // MAGIC_HEADER and length byte from packet, we're using SIZE - 2
+            var packetTail = struct.unpack(packet, parseInt(packetHead['SIZE']) - 2, '2b2Z2Z', ['CR', 'FRAME_TYPE', 'CHECKSUM', 'CRLF']);
+
+            // HID_PACKET_SIZE - 4, because we don't include the MAGIC_HEADER or the SIZE
+            if( packetHead['SIZE'] < ( HID_PACKET_SIZE - 4 ) ||
+                packetHead['BYTE1'] == ASCII_CONTROL.EOT ||
+                packetHead['BYTE1'] == ASCII_CONTROL.ENQ ||
+                packetTail['FRAME_TYPE'] == ASCII_CONTROL.ETX ||
+                packetTail['FRAME_TYPE'] == ASCII_CONTROL.ETB ) {
+                clearTimeout(abortTimer);
+                return callback(null, true);
+            }
+            return callback(null, false);
+          } catch (err) {
+            return callback(err);
           }
-          return callback(false);
         });
       },
       function (valid) {
-        if(valid instanceof Error) {
-          return cb(valid,null);
-        }
         return (valid !== true);
       },
-      function () {
-        return cb(null, message);
+      function (err) {
+        return cb(err, message);
       });
-
   };
 
   var processReadings = function(readings) {

--- a/lib/hidDevice.js
+++ b/lib/hidDevice.js
@@ -65,7 +65,7 @@ module.exports = function(config) {
   function receive(cb){
     connection.read(function(err, data) {
       if(err) {
-        debug('Error:', err);
+        debug('HID Error:', err);
       }
       cb(data);
     });


### PR DESCRIPTION
This PR improves the handling of uncaught errors during sending/receiving Bayer meter data. This should reduce the chances of the Bayer driver crashing the renderer process and displaying a white screen instead of surfacing the error in the UI.