### PR TITLE
Electron: Fix permissions for kernel extensions

### DIFF
--- a/resources/pkg-scripts/postinstall
+++ b/resources/pkg-scripts/postinstall
@@ -13,9 +13,9 @@ sudo cp -R ./extensions/DexComUSB.kext /Library/Extensions/DexComUSB.kext
 sudo chown -R root:wheel /Library/Extensions/DexcomUSB.kext
 sudo kextload /Library/Extensions/DexComUSB.kext/
 
-sudo cp -R ./extensions/SiLabsUSBDRiver.kext /Library/Extensions/SiLabsUSBDRiver.kext
-sudo chown -R root:wheel /Library/Extensions/SiLabsUSBDRiver.kext
-sudo kextload /Library/Extensions/SiLabsUSBDRiver.kext/
+sudo cp -R ./extensions/SiLabsUSBDriver.kext /Library/Extensions/SiLabsUSBDriver.kext
+sudo chown -R root:wheel /Library/Extensions/SiLabsUSBDriver.kext
+sudo kextload /Library/Extensions/SiLabsUSBDriver.kext/
 
 sudo cp -R ./extensions/ProlificUsbSerial.kext /Library/Extensions/ProlificUsbSerial.kext
 sudo chown -R root:wheel /Library/Extensions/ProlificUsbSerial.kext

--- a/resources/pkg-scripts/postinstall
+++ b/resources/pkg-scripts/postinstall
@@ -10,12 +10,15 @@ sudo rm -rf /Library/Extensions/sweetspot.DexcomUSB.kext
 # install new extensions
 echo "Installing and loading new extensions..."
 sudo cp -R ./extensions/DexComUSB.kext /Library/Extensions/DexComUSB.kext
+sudo chown -R root:wheel /Library/Extensions/DexcomUSB.kext
 sudo kextload /Library/Extensions/DexComUSB.kext/
 
 sudo cp -R ./extensions/SiLabsUSBDRiver.kext /Library/Extensions/SiLabsUSBDRiver.kext
+sudo chown -R root:wheel /Library/Extensions/SiLabsUSBDRiver.kext
 sudo kextload /Library/Extensions/SiLabsUSBDRiver.kext/
 
 sudo cp -R ./extensions/ProlificUsbSerial.kext /Library/Extensions/ProlificUsbSerial.kext
+sudo chown -R root:wheel /Library/Extensions/ProlificUsbSerial.kext
 sudo kextload /Library/Extensions/ProlificUsbSerial.kext/
 
 file="/tmp/TidepoolUploader.cnt"


### PR DESCRIPTION
Animas USB driver installation (Prolific chipset) fails on macOS Sierra if the permissions are not set correctly.