### PR TITLE
Find record using pointer from error

### DIFF
--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -392,14 +392,16 @@ function addDataToDataset(data, datasetId, blockIndex, uploadType, callback) {
       if(status.meta) {
         err.requestTrace = status.meta.trace.request;
       }
+      api.log(JSON.stringify(status, null, '\t'));
       if(status.errors && status.errors.length > 0) {
-        var hpattern = /\/(\w+)\//;
-        var toMatch = hpattern.exec(status.errors[0].source.pointer);
-        if (toMatch[1]) {
-          api.log('Offending record:', JSON.stringify(data[parseInt(toMatch[1])], null, '\t'));
+        for (var i in status.errors) {
+          var hpattern = /\/(\w+)\//;
+          var toMatch = hpattern.exec(status.errors[i].source.pointer);
+          if (toMatch[1]) {
+            api.log('Offending record for error',i,':', JSON.stringify(data[parseInt(toMatch[1])], null, '\t'));
+          }
         }
       }
-      api.log(JSON.stringify(status));
       callback(err);
     }
   };

--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -395,10 +395,10 @@ function addDataToDataset(data, datasetId, blockIndex, uploadType, callback) {
       api.log(JSON.stringify(status, null, '\t'));
       if(status.errors && status.errors.length > 0) {
         for (var i in status.errors) {
-          var hpattern = /\/(\w+)\//;
+          var hpattern = /\/(\d+)\//;
           var toMatch = hpattern.exec(status.errors[i].source.pointer);
           if (toMatch[1]) {
-            api.log('Offending record for error',i,':', JSON.stringify(data[parseInt(toMatch[1])], null, '\t'));
+            api.log('Offending record for error', i, ':', JSON.stringify(data[parseInt(toMatch[1])], null, '\t'));
           }
         }
       }

--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -392,6 +392,13 @@ function addDataToDataset(data, datasetId, blockIndex, uploadType, callback) {
       if(status.meta) {
         err.requestTrace = status.meta.trace.request;
       }
+      if(status.errors && status.errors.length > 0) {
+        var hpattern = /\/(\w+)\//;
+        var toMatch = hpattern.exec(status.errors[0].source.pointer);
+        if (toMatch[1]) {
+          api.log('Offending record:', JSON.stringify(data[parseInt(toMatch[1])], null, '\t'));
+        }
+      }
       api.log(JSON.stringify(status));
       callback(err);
     }


### PR DESCRIPTION
When the platform returns an error, there is an index pointer to the specific record in the block sent during the API call. This PR finds that offending record using the pointer.