### PR TITLE
Update dialog state fix

### DIFF
--- a/app/components/UpdateModal.js
+++ b/app/components/UpdateModal.js
@@ -48,40 +48,57 @@ export class UpdateModal extends Component {
       sync
     } = this.props;
 
-    if ( checkingElectronUpdate ||
-      (
-        !(electronUpdateDownloaded && !electronUpdateAvailableDismissed) &&
-        !(electronUpdateManualChecked && (
-            !electronUpdateAvailableDismissed ||
-            electronUpdateDownloaded
-          )
-        )
-      )
-    ) {
+    let title, text, actions;
+
+    if(electronUpdateAvailableDismissed){
       return null;
     }
 
-    let title, text, actions;
-
-    if(electronUpdateAvailable) {
-      title = 'Update Available!';
-      text = 'After clicking Install, the uploader will restart to complete the installation.';
-      actions = [
-        <button key='dismiss' className={styles.buttonSecondary} onClick={sync.dismissUpdateAvailable}>
-          Dismiss
-        </button>,
-        <button key='install' className={styles.button} onClick={this.handleInstall}>
-          Install
-        </button>
-      ];
-    } else {
-      title = 'Uploader is up-to-date!';
-      text = `You are running version ${config.version}, the most recent one.`;
-      actions = (
-        <button className={styles.button} onClick={sync.dismissUpdateNotAvailable}>
-          Okay!
-        </button>
-      );
+    if (electronUpdateManualChecked) {
+      if (checkingElectronUpdate){
+        title = 'Checking for update...';
+      } else {
+        if (electronUpdateAvailable) {
+          title = 'Update Available!';
+          if (!electronUpdateDownloaded) {
+            text = 'Downloading update';
+          } else { // available and downloaded
+            text = 'After clicking Install, the uploader will restart to complete the installation.';
+            actions = [
+              <button key='dismiss' className={styles.buttonSecondary} onClick={sync.dismissUpdateAvailable}>
+                Dismiss
+              </button>,
+              <button key='install' className={styles.button} onClick={this.handleInstall}>
+                Install
+              </button>
+            ];
+          }
+        } else { // no update available
+          title = 'Uploader is up-to-date!';
+          text = `You are running version ${config.version}, the most recent one.`;
+          actions = (
+            <button className={styles.button} onClick={sync.dismissUpdateNotAvailable}>
+              Okay!
+            </button>
+          );
+        }
+      }
+    }
+    else { // automatic background check
+      if(electronUpdateAvailable && electronUpdateDownloaded){
+        title = 'Update Available!';
+        text = 'After clicking Install, the uploader will restart to complete the installation.';
+        actions = [
+          <button key='dismiss' className={styles.buttonSecondary} onClick={sync.dismissUpdateAvailable}>
+            Dismiss
+          </button>,
+          <button key='install' className={styles.button} onClick={this.handleInstall}>
+            Install
+          </button>
+        ];
+      } else {
+        return null;
+      }
     }
 
     return (

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName":  "tidepool-uploader",
-  "version": "0.310.0-alpha.11",
+  "version": "0.310.0-alpha.17",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.js",
   "author": {

--- a/app/reducers/misc.js
+++ b/app/reducers/misc.js
@@ -155,6 +155,8 @@ function uploading(state = false, action) {
 function checkingElectronUpdate(state = false, action) {
   switch (action.type) {
     case actionTypes.CHECKING_FOR_UPDATES:
+    case actionTypes.AUTO_UPDATE_CHECKING_FOR_UPDATES:
+    case actionTypes.MANUAL_UPDATE_CHECKING_FOR_UPDATES:
       return true;
     case actionTypes.UPDATE_AVAILABLE:
     case actionTypes.UPDATE_NOT_AVAILABLE:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "0.310.0-alpha.11",
+  "version": "0.310.0-alpha.17",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",


### PR DESCRIPTION
Unravels some of the deep logic involved in the update modal dialog display to make it (hopefully) a little more readable. Also revealed a reducer that wasn't reacting to a couple of update events that it should have been which was flashing incorrect messages temporarily in some circumstances.