### PR TITLE
Medtronic: Bugfixes

### DIFF
--- a/lib/drivers/medtronic/medtronicSimulator.js
+++ b/lib/drivers/medtronic/medtronicSimulator.js
@@ -223,7 +223,7 @@ exports.make = function(config){
 
       ensureTimestamp(event);
 
-      if(event.deliveryType === 'temp') {
+      if(event.deliveryType === 'temp' && currPumpSettings) {
 
         // assign suppressed basal based on basal schedule
         var currSchedule = currPumpSettings.basalSchedules[currPumpSettings.activeSchedule];

--- a/lib/drivers/medtronic/medtronicSimulator.js
+++ b/lib/drivers/medtronic/medtronicSimulator.js
@@ -233,7 +233,6 @@ exports.make = function(config){
         for (var i = 0; i < currSchedule.length; i++) {
           if(startTime >= currSchedule[i].start) {
             rate = currSchedule[i].rate;
-            break;
           }
         };
         if(rate) {

--- a/lib/drivers/medtronic/medtronicSimulator.js
+++ b/lib/drivers/medtronic/medtronicSimulator.js
@@ -240,7 +240,8 @@ exports.make = function(config){
           var newSuppressed = {
             type: 'basal',
             deliveryType: 'scheduled',
-            rate: rate
+            rate: rate,
+            scheduleName: currPumpSettings.activeSchedule
           };
           event.set('suppressed', newSuppressed);
         }

--- a/lib/drivers/medtronic/medtronicSimulator.js
+++ b/lib/drivers/medtronic/medtronicSimulator.js
@@ -68,7 +68,9 @@ exports.make = function(config){
   };
 
   function setSuspendingEvent(event) {
-    suspendingEvent = event;
+    if(currBasal.deliveryType !== 'suspend') {
+      suspendingEvent = event;
+    }
   };
 
   function setResumingEvent(event) {
@@ -114,7 +116,7 @@ exports.make = function(config){
       var currSchedule = currPumpSettings.basalSchedules[currPumpSettings.activeSchedule];
 
       var checkSchedules = function(startTime, endTime, durationBeforeMidnight) {
-        for(var i in currSchedule) {
+        for (var i in currSchedule) {
 
           if(cancelled) {
             // we should stop looking for schedule changes after a temp basal was cancelled
@@ -228,7 +230,7 @@ exports.make = function(config){
         var startTime = common.computeMillisInCurrentDay(event);
         var rate = null;
 
-        for(var i =0; i < currSchedule.length; i++) {
+        for (var i = 0; i < currSchedule.length; i++) {
           if(startTime >= currSchedule[i].start) {
             rate = currSchedule[i].rate;
             break;
@@ -604,7 +606,7 @@ exports.make = function(config){
             // set last basal to not be longer than scheduled duration
             var currSchedule = currPumpSettings.basalSchedules[currPumpSettings.activeSchedule];
             var startTime = common.computeMillisInCurrentDay(currBasal);
-            for(var i =0; i < currSchedule.length; i++) {
+            for (var i = 0; i < currSchedule.length; i++) {
 
               if((startTime >= currSchedule[i].start) && (currBasal.rate === currSchedule[i].rate)) {
                 if(currSchedule[i+1]) {

--- a/lib/drivers/medtronic/medtronicSimulator.js
+++ b/lib/drivers/medtronic/medtronicSimulator.js
@@ -221,6 +221,29 @@ exports.make = function(config){
 
       ensureTimestamp(event);
 
+      if(event.deliveryType === 'temp') {
+
+        // assign suppressed basal based on basal schedule
+        var currSchedule = currPumpSettings.basalSchedules[currPumpSettings.activeSchedule];
+        var startTime = common.computeMillisInCurrentDay(event);
+        var rate = null;
+
+        for(var i =0; i < currSchedule.length; i++) {
+          if(startTime >= currSchedule[i].start) {
+            rate = currSchedule[i].rate;
+            break;
+          }
+        };
+        if(rate) {
+          var newSuppressed = {
+            type: 'basal',
+            deliveryType: 'scheduled',
+            rate: rate
+          };
+          event.set('suppressed', newSuppressed);
+        }
+      }
+
       if (currBasal != null) {
 
         if (suspendingEvent != null) {


### PR DESCRIPTION
Considering the following scenario:
A scheduled basal is followed by a series of temp basals. We look at the first scheduled basal event to fill in the suppressed info of the subsequent temp basals. What happens when the first scheduled basal has rolled off the end of the pump history and only the temp basals remain? 

The fix is to always fill in the suppressed info of a temp basal using the basal schedule at the time temp basal starts.

This PR also checks that we don't auto-suspend (e.g. with no delivery alarm) if we're already suspended.