### PR TITLE
Electron: Remove old kernel extensions during installation

### DIFF
--- a/resources/pkg-scripts/postinstall
+++ b/resources/pkg-scripts/postinstall
@@ -3,9 +3,15 @@
 echo "Unloading and uninstalling old extensions..."
 # unload old extensions
 sudo kextunload /Library/Extensions/sweetspot.DexComUSB.kext
+sudo kextunload /Library/Extensions/DexcomUSB.kext
+sudo kextunload /Library/Extensions/SiLabsUSBDriver.kext
+sudo kextunload /Library/Extensions/ProlificUsbSerial.kext
 
 # delete old extensions
 sudo rm -rf /Library/Extensions/sweetspot.DexcomUSB.kext
+sudo rm -rf /Library/Extensions/DexcomUSB.kext
+sudo rm -rf /Library/Extensions/SiLabsUSBDriver.kext
+sudo rm -rf /Library/Extensions/ProlificUsbSerial.kext
 
 # install new extensions
 echo "Installing and loading new extensions..."


### PR DESCRIPTION
It seems macOS do not like when kernel extensions are updated by just copying over the new files - the old kernel extension should be completely removed before the new one is copied in place. 
