### PR TITLE
Restrict Mac install location to user-owned Applications

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName":  "tidepool-uploader",
-  "version": "0.310.0-alpha.17",
+  "version": "0.310.0-alpha.23.temp",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.js",
   "author": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName":  "tidepool-uploader",
-  "version": "0.310.0-alpha.23.temp",
+  "version": "0.310.0-alpha.17",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.js",
   "author": {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 os: unstable
 
+image: Visual Studio 2017
+
 environment:
   APPVEYOR_CACHE_ENTRY_ZIP_ARGS: -t7z
   matrix:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dev": "npm run hot-server -- --start-hot",
     "prepare-qa-build": "node -r babel-register scripts/prepare-qa-build.js",
     "package": "npm run build && build -p onTagOrDraft",
-    "package-dev": "npm run build-dev && build -p onTagOrDraft --config.artifactName='${productName}-${version}-dev.${ext}' --config.nsis.artifactName='${productName}-Setup-${version}-dev.${ext}'",
+    "package-dev": "npm run build-dev && build -p onTagOrDraft --config.artifactName='tidepool-uploader-${version}-${arch}-${os}-dev.${ext}' --config.nsis.artifactName='tidepool-uploader-setup-${version}-dev.${ext}' --config.pkg.artifactName='tidepool-uploader-${version}-dev.${ext}'",
     "package-win": "npm run build && build --win --x64",
     "package-mac": "npm run build && build --mac",
     "package-linux": "npm run build && build --linux",
@@ -68,6 +68,7 @@
   "browserslist": "electron 1.6",
   "build": {
     "productName": "Tidepool Uploader",
+    "artifactName": "tidepool-uploader-${version}-${arch}-${os}.${ext}",
     "appId": "org.tidepool.TidepoolUploader",
     "directories": {
       "buildResources": "resources",
@@ -91,7 +92,8 @@
     "nsis": {
       "oneClick": false,
       "perMachine": true,
-      "allowElevation": true
+      "allowElevation": true,
+      "artifactName": "tidepool-uploader-setup-${version}.${ext}"
     },
     "files": [
       "dist/",
@@ -149,6 +151,7 @@
       ]
     },
     "pkg": {
+      "artifactName": "tidepool-uploader-${version}.${ext}",
       "allowAnywhere": false,
       "allowRootDirectory": false
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "0.310.0-alpha.17",
+  "version": "0.310.0-alpha.23.temp",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dev": "npm run hot-server -- --start-hot",
     "prepare-qa-build": "node -r babel-register scripts/prepare-qa-build.js",
     "package": "npm run build && build -p onTagOrDraft",
-    "package-dev": "npm run build-dev && build -p onTagOrDraft --config.artifactName='${productName}-${version}-dev.${ext}' --config.nsis.artifactName='${productName}-Setup-${version}-dev.${ext}' --extraMetadata.name='tidepool-uploader-dev'",
+    "package-dev": "npm run build-dev && build -p onTagOrDraft --config.artifactName='${productName}-${version}-dev.${ext}' --config.nsis.artifactName='${productName}-Setup-${version}-dev.${ext}'",
     "package-win": "npm run build && build --win --x64",
     "package-mac": "npm run build && build --mac",
     "package-linux": "npm run build && build --linux",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dev": "npm run hot-server -- --start-hot",
     "prepare-qa-build": "node -r babel-register scripts/prepare-qa-build.js",
     "package": "npm run build && build -p onTagOrDraft",
-    "package-dev": "npm run build-dev && build -p onTagOrDraft --config.artifactName='tidepool-uploader-${version}-${arch}-${os}-dev.${ext}' --config.nsis.artifactName='tidepool-uploader-setup-${version}-dev.${ext}' --config.pkg.artifactName='tidepool-uploader-${version}-dev.${ext}'",
+    "package-dev": "npm run build-dev && build -p onTagOrDraft --config.artifactName='tidepool-uploader-${version}-${arch}-${os}-dev.${ext}' --config.nsis.artifactName='tidepool-uploader-setup-${version}-dev.${ext}' --config.pkg.artifactName='tidepool-uploader-${version}-dev.${ext}' --extraMetadata.name='tidepool-uploader-dev'",
     "package-win": "npm run build && build --win --x64",
     "package-mac": "npm run build && build --mac",
     "package-linux": "npm run build && build --linux",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build-dev": "npm run build-main-dev && npm run build-renderer-dev",
     "start": "cross-env NODE_ENV=production electron ./app/",
     "start-hot": "cross-env HOT=1 NODE_ENV=development electron -r babel-register -r babel-polyfill ./app/main.development",
-    "postinstall": "concurrently \"install-app-deps\" \"node node_modules/fbjs-scripts/node/check-dev-engines.js package.json\" && electron-rebuild --force --module-dir app",
+    "postinstall": "concurrently \"electron-builder install-app-deps\" \"node node_modules/fbjs-scripts/node/check-dev-engines.js package.json\" && electron-rebuild --force --module-dir app",
     "dev": "npm run hot-server -- --start-hot",
     "prepare-qa-build": "node -r babel-register scripts/prepare-qa-build.js",
     "package": "npm run build && build -p onTagOrDraft",
@@ -147,6 +147,10 @@
         },
         "dir"
       ]
+    },
+    "pkg": {
+      "allowAnywhere": false,
+      "allowRootDirectory": false
     }
   },
   "bin": {
@@ -182,7 +186,7 @@
     "devtron": "1.4.0",
     "difflet": "1.0.1",
     "electron": "1.6.2",
-    "electron-builder": "18.3.5",
+    "electron-builder": "19.19.1",
     "electron-devtools-installer": "2.2.0",
     "electron-mocha": "3.4.0",
     "electron-rebuild": "1.5.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "0.310.0-alpha.23.temp",
+  "version": "0.310.0-alpha.17",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -92,12 +92,12 @@ ajv@^4.7.0, ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.1.5:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.0.tgz#c1735024c5da2ef75cc190713073d44f098bf486"
+ajv@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.2.tgz#47c68d69e86f5d953103b0074a9430dc63da5e39"
   dependencies:
     co "^4.6.0"
-    fast-deep-equal "^0.1.0"
+    fast-deep-equal "^1.0.0"
     json-schema-traverse "^0.3.0"
     json-stable-stringify "^1.0.1"
 
@@ -301,6 +301,13 @@ arrify@^1.0.0:
 asap@^2.0.0, asap@~2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.5.tgz#522765b50c3510490e52d7dcfe085ef9ba96958f"
+
+asar-integrity@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/asar-integrity/-/asar-integrity-0.1.1.tgz#1a709dd78443707fc260f7ce363d9569983caf76"
+  dependencies:
+    bluebird-lst "^1.0.2"
+    fs-extra-p "^4.3.0"
 
 asar@0.13.0:
   version "0.13.0"
@@ -2837,16 +2844,13 @@ ejs@~2.5.6:
   version "2.5.6"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.6.tgz#479636bfa3fe3b1debd52087f0acb204b4f19c88"
 
-electron-builder-core@17.2.0:
-  version "17.2.0"
-  resolved "https://registry.yarnpkg.com/electron-builder-core/-/electron-builder-core-17.2.0.tgz#e235d11aae64bffbad36b601ac58173f9377f619"
-
-electron-builder-http@18.3.0, electron-builder-http@~18.3.0:
-  version "18.3.0"
-  resolved "https://registry.yarnpkg.com/electron-builder-http/-/electron-builder-http-18.3.0.tgz#01cf7445996b09475515b55006b6b80d75a0360e"
+electron-builder-http@19.19.0, electron-builder-http@~19.19.0:
+  version "19.19.0"
+  resolved "https://registry.yarnpkg.com/electron-builder-http/-/electron-builder-http-19.19.0.tgz#20f908fcd1bbe202fd44a9623abd9e4d7bc98825"
   dependencies:
-    debug "2.6.8"
-    fs-extra-p "^4.3.0"
+    bluebird-lst "^1.0.2"
+    debug "^2.6.8"
+    fs-extra-p "^4.4.0"
 
 electron-builder-http@~17.0.3:
   version "17.0.3"
@@ -2855,57 +2859,58 @@ electron-builder-http@~17.0.3:
     debug "2.6.4"
     fs-extra-p "^4.1.0"
 
-electron-builder-util@18.3.5, electron-builder-util@~18.3.5:
-  version "18.3.5"
-  resolved "https://registry.yarnpkg.com/electron-builder-util/-/electron-builder-util-18.3.5.tgz#f0ae9c5c960efbc36da0210c37f999c2aa14cba4"
+electron-builder-util@19.19.0, electron-builder-util@~19.19.0:
+  version "19.19.0"
+  resolved "https://registry.yarnpkg.com/electron-builder-util/-/electron-builder-util-19.19.0.tgz#96082aff13bfda8f40a62739f10718c9c42f6d4c"
   dependencies:
     "7zip-bin" "^2.1.0"
     bluebird-lst "^1.0.2"
-    chalk "^1.1.3"
-    debug "2.6.8"
-    electron-builder-http "~18.3.0"
-    fs-extra-p "^4.3.0"
+    chalk "^2.0.1"
+    debug "^2.6.8"
+    electron-builder-http "~19.19.0"
+    fcopy-pre-bundled "0.3.4"
+    fs-extra-p "^4.4.0"
     ini "^1.3.4"
     is-ci "^1.0.10"
-    node-emoji "^1.5.1"
+    node-emoji "^1.8.1"
+    semver "^5.4.1"
     source-map-support "^0.4.15"
     stat-mode "^0.2.2"
     tunnel-agent "^0.6.0"
 
-electron-builder@18.3.5:
-  version "18.3.5"
-  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-18.3.5.tgz#9781dbdca932d80754e23773213b9c939fe79d6f"
+electron-builder@19.19.1:
+  version "19.19.1"
+  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-19.19.1.tgz#213ccda0afc1d1c75ba0fc1aa355ea7023d35769"
   dependencies:
     "7zip-bin" "^2.1.0"
-    ajv "^5.1.5"
+    ajv "^5.2.2"
     ajv-keywords "^2.1.0"
+    asar-integrity "0.1.1"
     bluebird-lst "^1.0.2"
-    chalk "^1.1.3"
+    chalk "^2.0.1"
     chromium-pickle-js "^0.2.0"
     cuint "^0.2.2"
-    debug "2.6.8"
-    electron-builder-core "17.2.0"
-    electron-builder-http "18.3.0"
-    electron-builder-util "18.3.5"
+    debug "^2.6.8"
+    electron-builder-http "19.19.0"
+    electron-builder-util "19.19.0"
     electron-download-tf "4.3.1"
-    electron-osx-sign "0.4.5"
-    electron-publish "18.3.5"
-    fs-extra-p "^4.3.0"
-    hosted-git-info "^2.4.2"
+    electron-osx-sign "0.4.6"
+    electron-publish "19.19.1"
+    fs-extra-p "^4.4.0"
+    hosted-git-info "^2.5.0"
     is-ci "^1.0.10"
     isbinaryfile "^3.0.2"
-    js-yaml "^3.8.4"
-    json5 "^0.5.1"
+    js-yaml "^3.9.1"
     minimatch "^3.0.4"
-    node-forge "^0.7.1"
-    normalize-package-data "^2.3.8"
+    normalize-package-data "^2.4.0"
     parse-color "^1.0.0"
     plist "^2.1.0"
+    read-config-file "^0.1.3"
     sanitize-filename "^1.6.1"
-    semver "^5.3.0"
-    update-notifier "^2.1.0"
+    semver "^5.4.1"
+    update-notifier "^2.2.0"
     uuid-1345 "^0.99.6"
-    yargs "^8.0.1"
+    yargs "^8.0.2"
 
 electron-chromedriver@~1.4.0:
   version "1.4.1"
@@ -2976,9 +2981,9 @@ electron-mocha@3.4.0:
     mocha "^3.0.0"
     which "^1.1.1"
 
-electron-osx-sign@0.4.5:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/electron-osx-sign/-/electron-osx-sign-0.4.5.tgz#59037cae6ac05ba9e802f76d9bb772b31a8c75c7"
+electron-osx-sign@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/electron-osx-sign/-/electron-osx-sign-0.4.6.tgz#2398e2d7cab5c1d8c3eeabb1cd490376528ec39a"
   dependencies:
     bluebird "^3.4.7"
     compare-version "^0.1.2"
@@ -2988,15 +2993,15 @@ electron-osx-sign@0.4.5:
     plist "^2.0.1"
     tempfile "^1.1.1"
 
-electron-publish@18.3.5:
-  version "18.3.5"
-  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-18.3.5.tgz#2689b387e63d57816e545327adf319a7560e4be9"
+electron-publish@19.19.1:
+  version "19.19.1"
+  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-19.19.1.tgz#ae53ccf9a90f77184c2add3d74b8b60850378b76"
   dependencies:
     bluebird-lst "^1.0.2"
-    chalk "^1.1.3"
-    electron-builder-http "~18.3.0"
-    electron-builder-util "~18.3.5"
-    fs-extra-p "^4.3.0"
+    chalk "^2.0.1"
+    electron-builder-http "~19.19.0"
+    electron-builder-util "~19.19.0"
+    fs-extra-p "^4.4.0"
     mime "^1.3.6"
 
 electron-rebuild@1.5.7:
@@ -3402,6 +3407,10 @@ esprima@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
+esprima@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+
 esquery@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.0.tgz#cfba8b57d7fba93f17298a8a006a04cda13d80fa"
@@ -3586,9 +3595,9 @@ fancy-log@^1.1.0:
     chalk "^1.1.1"
     time-stamp "^1.0.0"
 
-fast-deep-equal@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-0.1.0.tgz#5c6f4599aba6b333ee3342e2ed978672f1001f8d"
+fast-deep-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -3634,6 +3643,10 @@ fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.9:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
+
+fcopy-pre-bundled@0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/fcopy-pre-bundled/-/fcopy-pre-bundled-0.3.4.tgz#7ff1a1c339e877baa86b0856bebb33621cd5620b"
 
 fd-slicer@~1.0.1:
   version "1.0.1"
@@ -3841,6 +3854,13 @@ fs-extra-p@^4.1.0, fs-extra-p@^4.3.0:
     bluebird-lst "^1.0.2"
     fs-extra "^3.0.1"
 
+fs-extra-p@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/fs-extra-p/-/fs-extra-p-4.4.0.tgz#729c601c4f4c701328921adc7cfe9b236f100660"
+  dependencies:
+    bluebird-lst "^1.0.2"
+    fs-extra "^4.0.0"
+
 fs-extra@0.26.5:
   version "0.26.5"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.26.5.tgz#53ac74667ca083fd2dc1712c813039ca32d69a7f"
@@ -3889,6 +3909,14 @@ fs-extra@^2.1.2:
 fs-extra@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^3.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.1.tgz#7fc0c6c8957f983f57f306a24e5b9ddd8d0dd880"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^3.0.0"
@@ -4390,7 +4418,7 @@ homedir-polyfill@^1.0.0:
   dependencies:
     parse-passwd "^1.0.0"
 
-hosted-git-info@^2.1.4, hosted-git-info@^2.4.2:
+hosted-git-info@^2.1.4, hosted-git-info@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
@@ -4931,12 +4959,19 @@ js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.5.1, js-yaml@^3.8.3, js-yaml@^3.8.4:
+js-yaml@^3.5.1, js-yaml@^3.8.3:
   version "3.8.4"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.4.tgz#520b4564f86573ba96662af85a8cafa7b4b5a6f6"
   dependencies:
     argparse "^1.0.7"
     esprima "^3.1.1"
+
+js-yaml@^3.9.0, js-yaml@^3.9.1:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.1.tgz#08775cebdfdd359209f0d2acd383c8f86a6904a0"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
 
 js-yaml@~3.7.0:
   version "3.7.0"
@@ -5456,6 +5491,10 @@ lodash.templatesettings@^3.0.0:
     lodash._reinterpolate "^3.0.0"
     lodash.escape "^3.0.0"
 
+lodash.toarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
+
 lodash.union@~4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.2.1.tgz#6871017b9b1ff71952c1e2bb2e25b1046a7e2842"
@@ -5865,11 +5904,11 @@ node-abi@^1.0.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-1.3.3.tgz#0f06f2815deba26107959d2213b36ce97437e6e2"
 
-node-emoji@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.5.1.tgz#fd918e412769bf8c448051238233840b2aff16a1"
+node-emoji@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.8.1.tgz#6eec6bfb07421e2148c75c6bba72421f8530a826"
   dependencies:
-    string.prototype.codepointat "^0.2.0"
+    lodash.toarray "^4.4.0"
 
 node-fetch@^1.0.1:
   version "1.7.1"
@@ -5877,10 +5916,6 @@ node-fetch@^1.0.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
-
-node-forge@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.1.tgz#9da611ea08982f4b94206b3beb4cc9665f20c300"
 
 node-gyp@^3.4.0, node-gyp@^3.5.0, node-gyp@~3.6.0:
   version "3.6.2"
@@ -6033,7 +6068,7 @@ normalize-git-url@~3.0.1, normalize-git-url@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/normalize-git-url/-/normalize-git-url-3.0.2.tgz#8e5f14be0bdaedb73e07200310aa416c27350fc4"
 
-normalize-package-data@^2.0.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.8, "normalize-package-data@~1.0.1 || ^2.0.0":
+normalize-package-data@^2.0.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.4.0, "normalize-package-data@~1.0.1 || ^2.0.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
   dependencies:
@@ -7317,6 +7352,15 @@ read-cmd-shim@~1.0.1:
   dependencies:
     graceful-fs "^4.1.2"
 
+read-config-file@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/read-config-file/-/read-config-file-0.1.3.tgz#10f72ad95159864c78def8c749b226f80c998b61"
+  dependencies:
+    bluebird-lst "^1.0.2"
+    fs-extra-p "^4.4.0"
+    js-yaml "^3.9.0"
+    json5 "^0.5.1"
+
 read-installed@~4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/read-installed/-/read-installed-4.0.3.tgz#ff9b8b67f187d1e4c29b9feb31f6b223acd19067"
@@ -7928,6 +7972,10 @@ semver@^4.1.0:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
 
+semver@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
+
 send@0.15.1:
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.15.1.tgz#8a02354c26e6f5cca700065f5f0cdeba90ec7b5f"
@@ -8313,10 +8361,6 @@ string-width@^2.0.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
-
-string.prototype.codepointat@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz#6b26e9bd3afcaa7be3b4269b526de1b82000ac78"
 
 string_decoder@^0.10.25, string_decoder@~0.10.x:
   version "0.10.31"
@@ -8810,7 +8854,7 @@ unzip-response@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
 
-update-notifier@^2.1.0:
+update-notifier@^2.1.0, update-notifier@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.2.0.tgz#1b5837cf90c0736d88627732b661c138f86de72f"
   dependencies:
@@ -9335,7 +9379,7 @@ yargs@4.7.1:
     y18n "^3.2.1"
     yargs-parser "^2.4.0"
 
-yargs@^8.0.1:
+yargs@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
   dependencies:


### PR DESCRIPTION
In order to avoid the issue where a user can't apply an automatic update to an App in a directory that they don't have user-level write access to (https://github.com/Squirrel/Squirrel.Mac/pull/207 which hasn't as of yet been applied/released through stable Electron), we need to restrict the user to installing the App to their $HOME/Applications directory instead of the system /Applications. This also involved upgrading `electron-builder`, which _almost_ resolved the artifact naming issue we have with multiple sets of releases (`dev` vs production) on GitHub, except that their GitHub artifactName still completely renames the system distributed artifactName. *sigh*