### PR TITLE
set three main rows of layout to not shrink

### DIFF
--- a/styles/components/App.module.less
+++ b/styles/components/App.module.less
@@ -39,6 +39,7 @@
 
 .mainWrap {
   composes: flexColumn from '../core/layout.module.less';
+  flex-shrink: 0;
 }
 
 .changePerson {

--- a/styles/components/Footer.module.less
+++ b/styles/components/Footer.module.less
@@ -15,6 +15,7 @@
 
 .footer {
   composes: flexColumn from '../core/layout.module.less';
+  flex-shrink: 0;
   margin-top: auto;
   margin-bottom: 30px;
 }

--- a/styles/components/Header.module.less
+++ b/styles/components/Header.module.less
@@ -15,6 +15,7 @@
 
 .header {
   composes: flexColumn from '../core/layout.module.less';
+  flex-shrink: 0;
   padding-bottom: 10px;
   width: 100%;
   max-width: 550px;


### PR DESCRIPTION
During testing a number of users experienced having the 'See data' button being squished out of existence. This is mostly noticeable on Windows machines with relatively small vertical resolutions. By setting the `flex-shrink` to `0` for the three major rows of the app, we can ensure that nothing important gets squished.