### PR TITLE
enforces that carelink shows up last

### DIFF
--- a/app/components/DeviceSelection.js
+++ b/app/components/DeviceSelection.js
@@ -91,7 +91,11 @@ var DeviceSelection = React.createClass({
         </div>
       );
     });
-
+    // ensure that carelink is last
+    var carelink = _.remove(items, {'key': 'carelink'});
+    if(!_.isEmpty(items)){
+      items = items.concat(carelink);
+    }
 
     // TODO: when this gets the ES6 treatment, use computed property syntax
     var formClassesObject = {};

--- a/app/containers/MainPage.js
+++ b/app/containers/MainPage.js
@@ -206,6 +206,11 @@ export default connect(
           (upload.successful ? {progress: {percentage: 100}} : {});
         activeUploads.push(_.assign({}, device, upload, progress));
       });
+      // ensure that carelink is last
+      const carelink = _.remove(activeUploads, {'key': 'carelink'});
+      if(!_.isEmpty(carelink)){
+        activeUploads = activeUploads.concat(carelink);
+      }
       return activeUploads;
     }
     function shouldShowUserSelectionDropdown(state) {


### PR DESCRIPTION
What it says on the tin, just pulls out carelink from a given list and tacks it on the end. Turns out we don't enforce any sort of sorting on either place (just mapping over object keys which has no guaranteed order). 