### PR TITLE
Change permissions for .app on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,10 +147,6 @@
         },
         "dir"
       ]
-    },
-    "pkg": {
-      "allowAnywhere": false,
-      "allowRootDirectory": false
     }
   },
   "bin": {

--- a/resources/pkg-scripts/postinstall
+++ b/resources/pkg-scripts/postinstall
@@ -27,6 +27,12 @@ sudo cp -R ./extensions/ProlificUsbSerial.kext /Library/Extensions/ProlificUsbSe
 sudo chown -R root:wheel /Library/Extensions/ProlificUsbSerial.kext
 sudo kextload /Library/Extensions/ProlificUsbSerial.kext/
 
+echo User: $USER
+echo Home: $HOME
+echo Folder: "$2/Tidepool Uploader.app"
+
+sudo chown -R $USER:staff "$2/Tidepool Uploader.app"
+
 file="/tmp/TidepoolUploader.cnt"
 
 if [ -e ${file} ]; then


### PR DESCRIPTION
We change the permissions on `Tidepool Uploader.app` to that of the active user, so that the auto-update mechanism doesn't try to do anything with root permissions (e.g. using `/var/root/Library/Caches` instead of `~/Library/Caches`).