### PR TITLE
Medtronic Direct: Bugfix for timestamps out of order.

### DIFF
--- a/lib/drivers/medtronic/medtronicSimulator.js
+++ b/lib/drivers/medtronic/medtronicSimulator.js
@@ -551,7 +551,7 @@ exports.make = function(config){
           }
 
           currWizard = currWizard.done();
-          simpleSimulate(currWizard);
+          events.push(currWizard);
         } else {
           debug('Could not find matching bolus for wizard:' + JSON.stringify(currWizard,null,4));
           simpleSimulate(event); // run the bolus, as it's not going to be embedded in a wizard

--- a/lib/drivers/medtronic/medtronicSimulator.js
+++ b/lib/drivers/medtronic/medtronicSimulator.js
@@ -528,6 +528,7 @@ exports.make = function(config){
       setCurrBasal(event);
     },
     bolus: function(event) {
+      ensureTimestamp(event);
       if(currWizard != null ) {
         // A wizard event is always followed by a bolus event.
         // Usually the timestamp is the same, but sometimes the bolus timestamp

--- a/lib/redux/reducers/devices.js
+++ b/lib/redux/reducers/devices.js
@@ -121,6 +121,7 @@ const devices = {
     source: {type: 'device', driverId: 'OneTouchVerioIQ'},
     enabled: {mac: true, win: true}
   },
+  /* TODO: re-enable these after Electron is on production
   onetouchultramini: {
     instructions: 'Plug in meter with cable',
     name: 'OneTouch Ultra Mini',
@@ -137,6 +138,7 @@ const devices = {
     source: {type: 'device', driverId: 'OneTouchUltra2'},
     enabled: {mac: true, win: true}
   }
+  */
 };
 
 export default devices;

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Tidepool Uploader",
   "short_name": "Uploader",
-  "version": "0.310.0",
+  "version": "0.311.0",
   "description": "The Tidepool Uploader helps you get your data from insulin pumps, CGMs and BG meters into Tidepool’s secure cloud platform.",
   "minimum_chrome_version": "38",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "0.310.0",
+  "version": "0.311.0",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",


### PR DESCRIPTION
Fixes #470.

Usually bolus records and their associated wizard records have the same timestamp, but sometimes the bolus record occurs a couple of seconds later. If something else happens in between (like a low reservoir alarm), the wizard record will have an earlier timestamp than the current timestamp, so we cannot use `simpleSimulate`. We can, however, still ensure that the bolus timestamp is in sequence.