### PR TITLE
Fix TZOUtil test: use parseFromFormat instead of Date constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "mocha test/node/ && mocha test/node/**/*.js && ./node_modules/karma/bin/karma start",
     "browser-tests": "./node_modules/karma/bin/karma start --browsers PhantomJS,Chrome",
     "node-tests": "mocha test/node/ && mocha test/node/**/*.js",
-    "test-watch": "./node_modules/karma/bin/karma start --no-single-run",
+    "test-watch": "./node_modules/karma/bin/karma start --browsers PhantomJS,Chrome --no-single-run",
     "prestart": "rm -rf _book/",
     "start": "bash ./scripts/config.sh && webpack -d --progress --colors --watch",
     "start-hot": "npm run prestart && bash ./scripts/config.sh && webpack-dev-server --hot --inline --progress --colors",

--- a/test/browser/testTimezoneOffsetUtil.js
+++ b/test/browser/testTimezoneOffsetUtil.js
@@ -1,15 +1,15 @@
 /*
  * == BSD2 LICENSE ==
  * Copyright (c) 2014, Tidepool Project
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the associated License, which is identical to the BSD 2-Clause
  * License as published by the Open Source Initiative at opensource.org.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the License for more details.
- * 
+ *
  * You should have received a copy of the License along with this program; if
  * not, you can obtain one from Tidepool Project at tidepool.org.
  * == BSD2 LICENSE ==
@@ -23,6 +23,7 @@ var expect = chai.expect;
 
 var builder = require('../../lib/objectBuilder')();
 var TZOUtil = require('../../lib/TimezoneOffsetUtil');
+var sundial = require('sundial');
 
 describe('TimezoneOffsetUtil.js', function(){
   it('exports a function', function(){
@@ -51,7 +52,7 @@ describe('TimezoneOffsetUtil.js', function(){
 
   it('defaults to across-the-board timezone application if no `changes` provided as third param', function(){
     var util = new TZOUtil('US/Eastern', '2015-06-01T00:00:00.000Z', []);
-    expect(util.lookup(new Date('2015-04-01T00:00:00'))).to.deep.equal({
+    expect(util.lookup(sundial.parseFromFormat('201504010000', 'YYYYMMDDHHmm'))).to.deep.equal({
       time: '2015-04-01T04:00:00.000Z',
       timezoneOffset: -240,
       clockDriftOffset: 0,
@@ -650,7 +651,7 @@ describe('TimezoneOffsetUtil in practice', function(){
     expect(offsets.length).to.equal(2);
     expect(offsets).to.deep.equal([-420, -360]);
   });
-  
+
   it('applies the offsets inferred from `changes`, resulting in no gaps or overlaps', function(done){
     this.timeout(5000);
     setTimeout(function() {

--- a/test/browser/testTimezoneOffsetUtil.js
+++ b/test/browser/testTimezoneOffsetUtil.js
@@ -52,7 +52,7 @@ describe('TimezoneOffsetUtil.js', function(){
 
   it('defaults to across-the-board timezone application if no `changes` provided as third param', function(){
     var util = new TZOUtil('US/Eastern', '2015-06-01T00:00:00.000Z', []);
-    expect(util.lookup(sundial.parseFromFormat('201504010000', 'YYYYMMDDHHmm'))).to.deep.equal({
+    expect(util.lookup(sundial.parseFromFormat('2015-04-01T00:00:00'))).to.deep.equal({
       time: '2015-04-01T04:00:00.000Z',
       timezoneOffset: -240,
       clockDriftOffset: 0,
@@ -69,7 +69,7 @@ describe('TimezoneOffsetUtil.js', function(){
         to: '2015-03-08T13:00:00',
       })
       .with_deviceTime('2015-03-08T12:01:21')
-      .set('jsDate', new Date('2015-03-08T12:01:21'))
+      .set('jsDate', sundial.parseFromFormat('2015-03-08T12:01:21'))
       .set('index', 10);
     var bootstrapUtil = new TZOUtil('US/Eastern', '2015-06-01T00:00:00.000Z', [belatedDST]);
     expect(bootstrapUtil.type).to.equal('utc-bootstrapping');
@@ -83,7 +83,7 @@ describe('TimezoneOffsetUtil.js', function(){
           to: '2015-03-08T13:00:00',
         })
         .with_deviceTime('2015-03-08T12:01:21')
-        .set('jsDate', new Date('2015-03-08T13:00:00'))
+        .set('jsDate', sundial.parseFromFormat('2015-03-08T13:00:00'))
         .set('index', 10);
       var travel = builder.makeDeviceEventTimeChange()
         .with_change({
@@ -91,7 +91,7 @@ describe('TimezoneOffsetUtil.js', function(){
           to: '2015-04-01T14:35:00'
         })
         .with_deviceTime('2015-04-01T15:33:24')
-        .set('jsDate', new Date('2015-04-01T14:35:00'))
+        .set('jsDate', sundial.parseFromFormat('2015-04-01T14:35:00'))
         .set('index', 100);
       var wrongMonth = builder.makeDeviceEventTimeChange()
         .with_change({
@@ -99,7 +99,7 @@ describe('TimezoneOffsetUtil.js', function(){
           to: '2015-05-10T16:05:00'
         })
         .with_deviceTime('2015-04-10T16:05:10')
-        .set('jsDate', new Date('2015-05-10T16:05:00'))
+        .set('jsDate', sundial.parseFromFormat('2015-05-10T16:05:00'))
         .set('index', 200);
       var util = new TZOUtil('US/Central', '2015-06-01T00:00:00.000Z', [belatedDST, travel, wrongMonth]);
       expect(_.map(util.records, function(rec) { return _.omit(rec, ['payload', 'index']); })).to.deep.equal([
@@ -150,7 +150,7 @@ describe('TimezoneOffsetUtil.js', function(){
           to: '2015-03-08T13:00:00',
         })
         .with_deviceTime('2015-03-08T12:01:21')
-        .set('jsDate', new Date('2015-03-08T12:01:21'))
+        .set('jsDate', sundial.parseFromFormat('2015-03-08T12:01:21'))
         .set('index', 10);
       var travel = builder.makeDeviceEventTimeChange()
         .with_change({
@@ -158,7 +158,7 @@ describe('TimezoneOffsetUtil.js', function(){
           to: '2015-04-01T14:35:00'
         })
         .with_deviceTime('2015-04-01T15:33:24')
-        .set('jsDate', new Date('2015-04-01T15:33:24'))
+        .set('jsDate', sundial.parseFromFormat('2015-04-01T15:33:24'))
         .set('index', 100);
       var util = new TZOUtil('US/Central', '2015-06-01T00:00:00.000Z', [belatedDST, travel]);
       expect(Array.isArray(util.records)).to.be.true;
@@ -258,16 +258,16 @@ describe('TimezoneOffsetUtil.js', function(){
             to: '2015-03-01T12:00:00'
           })
           .with_deviceTime('2015-03-01T12:02:05')
-          .set('jsDate', new Date('2015-03-01T12:02:05'))
+          .set('jsDate', sundial.parseFromFormat('2015-03-01T12:02:05'))
           .set('index', 50);
         var util = new TZOUtil('US/Eastern', '2015-06-01T00:00:00.000Z', [clockDriftAdjust]);
-        expect(util.lookup(new Date('2015-02-01T00:00:00'))).to.deep.equal({
+        expect(util.lookup(sundial.parseFromFormat('2015-02-01T00:00:00'))).to.deep.equal({
           time: '2015-02-01T04:00:00.000Z',
           timezoneOffset: -240,
           clockDriftOffset: 125000,
           conversionOffset: 0
         });
-        expect(util.lookup(new Date('2015-04-01T00:00:00'))).to.deep.equal({
+        expect(util.lookup(sundial.parseFromFormat('2015-04-01T00:00:00'))).to.deep.equal({
           time: '2015-04-01T04:00:00.000Z',
           timezoneOffset: -240,
           clockDriftOffset: 0,
@@ -283,16 +283,16 @@ describe('TimezoneOffsetUtil.js', function(){
             to: '2015-03-08T13:00:00',
           })
           .with_deviceTime('2015-03-08T12:01:21')
-          .set('jsDate', new Date('2015-03-08T12:01:21'))
+          .set('jsDate', sundial.parseFromFormat('2015-03-08T12:01:21'))
           .set('index', 10);
         var util = new TZOUtil('US/Eastern', '2015-06-01T00:00:00.000Z', [belatedDST]);
-        expect(util.lookup(new Date('2015-04-01T00:00:00'))).to.deep.equal({
+        expect(util.lookup(sundial.parseFromFormat('2015-04-01T00:00:00'))).to.deep.equal({
           time: '2015-04-01T04:00:00.000Z',
           timezoneOffset: -240,
           clockDriftOffset: 0,
           conversionOffset: 0
         });
-        expect(util.lookup(new Date('2015-03-01T00:00:00'))).to.deep.equal({
+        expect(util.lookup(sundial.parseFromFormat('2015-03-01T00:00:00'))).to.deep.equal({
           time: '2015-03-01T05:00:00.000Z',
           timezoneOffset: -300,
           clockDriftOffset: 81000,
@@ -307,7 +307,7 @@ describe('TimezoneOffsetUtil.js', function(){
             to: '2015-03-01T12:00:00'
           })
           .with_deviceTime('2015-03-01T12:02:05')
-          .set('jsDate', new Date('2015-03-01T12:02:05'))
+          .set('jsDate', sundial.parseFromFormat('2015-03-01T12:02:05'))
           .set('index', 10);
         var belatedDST = builder.makeDeviceEventTimeChange()
           .with_change({
@@ -315,7 +315,7 @@ describe('TimezoneOffsetUtil.js', function(){
             to: '2015-03-08T13:00:00',
           })
           .with_deviceTime('2015-03-08T12:01:21')
-          .set('jsDate', new Date('2015-03-08T12:01:21'))
+          .set('jsDate', sundial.parseFromFormat('2015-03-08T12:01:21'))
           .set('index', 50);
         var clockDriftAdjust2 = builder.makeDeviceEventTimeChange()
           .with_change({
@@ -323,7 +323,7 @@ describe('TimezoneOffsetUtil.js', function(){
             to: '2015-03-15T12:00:00'
           })
           .with_deviceTime('2015-03-15T12:02:05')
-          .set('jsDate', new Date('2015-03-15T12:02:05'))
+          .set('jsDate', sundial.parseFromFormat('2015-03-15T12:02:05'))
           .set('index', 100);
         var justAChange = builder.makeDeviceEventTimeChange()
           .with_change({
@@ -331,7 +331,7 @@ describe('TimezoneOffsetUtil.js', function(){
             to: '2015-04-01T13:30:00'
           })
           .with_deviceTime('2015-04-01T15:31:22')
-          .set('jsDate', new Date('2015-04-01T15:31:22'))
+          .set('jsDate', sundial.parseFromFormat('2015-04-01T15:31:22'))
           .set('index', 120);
         var changeBack = builder.makeDeviceEventTimeChange()
           .with_change({
@@ -339,7 +339,7 @@ describe('TimezoneOffsetUtil.js', function(){
             to: '2015-04-08T11:03:00'
           })
           .with_deviceTime('2015-04-08T09:04:02')
-          .set('jsDate', new Date('2015-04-08T09:04:02'))
+          .set('jsDate', sundial.parseFromFormat('2015-04-08T09:04:02'))
           .set('index', 150);
         var util = new TZOUtil('US/Central', '2015-06-01T00:00:00.000Z', [
           clockDriftAdjust1,
@@ -348,25 +348,25 @@ describe('TimezoneOffsetUtil.js', function(){
           justAChange,
           changeBack
         ]);
-        expect(util.lookup(new Date('2015-03-05T12:00:00'))).to.deep.equal({
+        expect(util.lookup(sundial.parseFromFormat('2015-03-05T12:00:00'))).to.deep.equal({
           time: '2015-03-05T18:00:00.000Z',
           timezoneOffset: -360,
           clockDriftOffset: 350000,
           conversionOffset: 0
         });
-        expect(util.lookup(new Date('2015-03-10T12:00:00'))).to.deep.equal({
+        expect(util.lookup(sundial.parseFromFormat('2015-03-10T12:00:00'))).to.deep.equal({
           time: '2015-03-10T17:00:00.000Z',
           timezoneOffset: -300,
           clockDriftOffset: 269000,
           conversionOffset: 0
         });
-        expect(util.lookup(new Date('2015-03-20T12:00:00'))).to.deep.equal({
+        expect(util.lookup(sundial.parseFromFormat('2015-03-20T12:00:00'))).to.deep.equal({
           time: '2015-03-20T17:00:00.000Z',
           timezoneOffset: -300,
           clockDriftOffset: 144000,
           conversionOffset: 0
         });
-        expect(util.lookup(new Date('2015-04-02T12:00:00'))).to.deep.equal({
+        expect(util.lookup(sundial.parseFromFormat('2015-04-02T12:00:00'))).to.deep.equal({
           time: '2015-04-02T19:00:00.000Z',
           timezoneOffset: -420,
           clockDriftOffset: 62000,
@@ -381,16 +381,16 @@ describe('TimezoneOffsetUtil.js', function(){
             to: '2015-11-01T01:00:00'
           })
           .with_deviceTime('2015-11-01T02:00:00')
-          .set('jsDate', new Date('2015-11-01T02:00:00'))
+          .set('jsDate', sundial.parseFromFormat('2015-11-01T02:00:00'))
           .set('index', 10);
         var util = new TZOUtil('US/Eastern', '2016-01-01T00:00:00.000Z', [onTimeDST]);
-        expect(util.lookup(new Date('2015-11-05T00:00:00'))).to.deep.equal({
+        expect(util.lookup(sundial.parseFromFormat('2015-11-05T00:00:00'))).to.deep.equal({
           time: '2015-11-05T05:00:00.000Z',
           timezoneOffset: -300,
           clockDriftOffset: 0,
           conversionOffset: 0
         });
-        expect(util.lookup(new Date('2015-10-05T00:00:00'))).to.deep.equal({
+        expect(util.lookup(sundial.parseFromFormat('2015-10-05T00:00:00'))).to.deep.equal({
           time: '2015-10-05T04:00:00.000Z',
           timezoneOffset: -240,
           clockDriftOffset: 0,
@@ -406,16 +406,16 @@ describe('TimezoneOffsetUtil.js', function(){
             to: '2015-04-02T12:26:00'
           })
           .with_deviceTime('2015-04-03T08:25:00')
-          .set('jsDate', new Date('2015-04-03T08:25:00'))
+          .set('jsDate', sundial.parseFromFormat('2015-04-03T08:25:00'))
           .set('index', 10);
         var util = new TZOUtil('US/Pacific', '2015-06-01T00:00:00.000Z', [fromNZ]);
-        expect(util.lookup(new Date('2015-04-10T00:00:00'))).to.deep.equal({
+        expect(util.lookup(sundial.parseFromFormat('2015-04-10T00:00:00'))).to.deep.equal({
           time: '2015-04-10T07:00:00.000Z',
           timezoneOffset: -420,
           clockDriftOffset: 0,
           conversionOffset: 0
         });
-        expect(util.lookup(new Date('2015-03-10T00:00:00'))).to.deep.equal({
+        expect(util.lookup(sundial.parseFromFormat('2015-03-10T00:00:00'))).to.deep.equal({
           time: '2015-03-09T11:00:00.000Z',
           timezoneOffset: 780,
           clockDriftOffset: -60000,
@@ -431,16 +431,16 @@ describe('TimezoneOffsetUtil.js', function(){
             to: '2015-03-26T08:25:00'
           })
           .with_deviceTime('2015-03-25T12:26:00')
-          .set('jsDate', new Date('2015-03-25T12:26:00'))
+          .set('jsDate', sundial.parseFromFormat('2015-03-25T12:26:00'))
           .set('index', 10);
         var util = new TZOUtil('Pacific/Auckland', '2015-04-01T00:00:00.000Z', [toNZ]);
-        expect(util.lookup(new Date('2015-03-31T00:00:00'))).to.deep.equal({
+        expect(util.lookup(sundial.parseFromFormat('2015-03-31T00:00:00'))).to.deep.equal({
           time: '2015-03-30T11:00:00.000Z',
           timezoneOffset: 780,
           clockDriftOffset: 0,
           conversionOffset: 0
         });
-        expect(util.lookup(new Date('2015-03-15T00:00:00'))).to.deep.equal({
+        expect(util.lookup(sundial.parseFromFormat('2015-03-15T00:00:00'))).to.deep.equal({
           time: '2015-03-15T07:00:00.000Z',
           timezoneOffset: -420,
           clockDriftOffset: 60000,
@@ -457,16 +457,16 @@ describe('TimezoneOffsetUtil.js', function(){
             to: '2014-12-15T15:00:00'
           })
           .with_deviceTime('2013-12-15T15:00:00')
-          .set('jsDate', new Date('2013-12-15T15:00:00'))
+          .set('jsDate', sundial.parseFromFormat('2013-12-15T15:00:00'))
           .set('index', 10);
         var util = new TZOUtil('US/Eastern', '2015-01-01T00:00:00.000Z', [wrongYear]);
-        expect(util.lookup(new Date('2014-12-25T00:00:00'), 15)).to.deep.equal({
+        expect(util.lookup(sundial.parseFromFormat('2014-12-25T00:00:00'), 15)).to.deep.equal({
           time: '2014-12-25T05:00:00.000Z',
           timezoneOffset: -300,
           clockDriftOffset: 0,
           conversionOffset: 0
         });
-        expect(util.lookup(new Date('2013-12-10T00:00:00'), 5)).to.deep.equal({
+        expect(util.lookup(sundial.parseFromFormat('2013-12-10T00:00:00'), 5)).to.deep.equal({
           time: '2014-12-10T05:00:00.000Z',
           timezoneOffset: -300,
           clockDriftOffset: 0,
@@ -478,16 +478,16 @@ describe('TimezoneOffsetUtil.js', function(){
             to: '2014-12-15T15:00:00'
           })
           .with_deviceTime('2014-11-15T15:00:00')
-          .set('jsDate', new Date('2014-11-15T15:00:00'))
+          .set('jsDate', sundial.parseFromFormat('2014-11-15T15:00:00'))
           .set('index', 10);
         var util2 = new TZOUtil('US/Eastern', '2015-01-01T00:00:00.000Z', [wrongMonth]);
-        expect(util2.lookup(new Date('2014-12-25T00:00:00'), 15)).to.deep.equal({
+        expect(util2.lookup(sundial.parseFromFormat('2014-12-25T00:00:00'), 15)).to.deep.equal({
           time: '2014-12-25T05:00:00.000Z',
           timezoneOffset: -300,
           clockDriftOffset: 0,
           conversionOffset: 0
         });
-        expect(util2.lookup(new Date('2014-11-10T00:00:00'), 5)).to.deep.equal({
+        expect(util2.lookup(sundial.parseFromFormat('2014-11-10T00:00:00'), 5)).to.deep.equal({
           time: '2014-12-10T05:00:00.000Z',
           timezoneOffset: -300,
           clockDriftOffset: 0,
@@ -503,22 +503,22 @@ describe('TimezoneOffsetUtil.js', function(){
             to: '2015-04-01T07:00:00'
           })
           .with_deviceTime('2015-04-01T19:00:00')
-          .set('jsDate', new Date('2015-04-01T19:00:00'))
+          .set('jsDate', sundial.parseFromFormat('2015-04-01T19:00:00'))
           .set('index', 50);
         var util = new TZOUtil('US/Mountain', '2015-05-01T00:00:00.000Z', [amNotPM]);
-        expect(util.lookup(new Date(ambiguousDeviceTime), 51)).to.deep.equal({
+        expect(util.lookup(sundial.parseFromFormat(ambiguousDeviceTime), 51)).to.deep.equal({
           time: '2015-04-01T18:00:00.000Z',
           timezoneOffset: -360,
           clockDriftOffset: 0,
           conversionOffset: 0
         });
-        expect(util.lookup(new Date(ambiguousDeviceTime), 49)).to.deep.equal({
+        expect(util.lookup(sundial.parseFromFormat(ambiguousDeviceTime), 49)).to.deep.equal({
           time: '2015-04-01T06:00:00.000Z',
           timezoneOffset: 360,
           clockDriftOffset: 0,
           conversionOffset: 0
         });
-        expect(util.lookup(new Date(ambiguousDeviceTime))).to.deep.equal({
+        expect(util.lookup(sundial.parseFromFormat(ambiguousDeviceTime))).to.deep.equal({
           time: '2015-04-01T06:00:00.000Z',
           timezoneOffset: 360,
           clockDriftOffset: 0,
@@ -557,7 +557,7 @@ describe('TimezoneOffsetUtil.js', function(){
         type: 'foo',
         index: 0
       };
-      var dt = new Date('2015-04-03T11:30:00');
+      var dt = sundial.parseFromFormat('2015-04-03T11:30:00');
       expect(stubLookup.callCount).to.equal(0);
       noChangesUtil.fillInUTCInfo(obj, dt);
       expect(stubLookup.callCount).to.equal(1);
@@ -569,7 +569,7 @@ describe('TimezoneOffsetUtil.js', function(){
         type: 'foo',
         index: 10
       };
-      var dt = new Date('2015-04-03T11:30:00');
+      var dt = sundial.parseFromFormat('2015-04-03T11:30:00');
       var expectedRes = _.assign({}, obj, {
         time: '2015-04-02T22:30:00.000Z',
         timezoneOffset: 780,
@@ -584,7 +584,7 @@ describe('TimezoneOffsetUtil.js', function(){
         type: 'deviceEvent',
         subType: 'alarm'
       };
-      var dt = new Date('2015-04-03T11:30:00');
+      var dt = sundial.parseFromFormat('2015-04-03T11:30:00');
       var expectedRes = _.assign({}, obj, {
         time: '2015-04-02T22:30:00.000Z',
         timezoneOffset: 780,
@@ -604,7 +604,7 @@ describe('TimezoneOffsetUtil.js', function(){
             to: '2015-05-01T06:00:00'
           })
           .with_deviceTime('2015-04-01T06:00:00')
-          .set('jsDate', new Date('2015-04-01T06:00:00'))
+          .set('jsDate', sundial.parseFromFormat('2015-04-01T06:00:00'))
           .set('index', 50);
         var clockDrift = builder.makeDeviceEventTimeChange()
           .with_change({
@@ -612,11 +612,11 @@ describe('TimezoneOffsetUtil.js', function(){
             to: '2015-05-15T00:00:00',
           })
           .with_deviceTime('2015-05-15T00:03:00')
-          .set('jsDate', new Date('2015-05-15T00:03:00'))
+          .set('jsDate', sundial.parseFromFormat('2015-05-15T00:03:00'))
           .set('index', 75);
         var util = new TZOUtil('US/Mountain', '2015-06-01T00:00:00.000Z', [wrongMonth, clockDrift]);
         const obj = { index: null };
-        util.fillInUTCInfo(obj, new Date(ambiguousDeviceTime));
+        util.fillInUTCInfo(obj, sundial.parseFromFormat(ambiguousDeviceTime));
         expect(obj.time).to.be.undefined;
         expect(obj.timezoneOffset).to.be.undefined;
         expect(obj.clockDriftOffset).to.be.undefined;
@@ -628,7 +628,7 @@ describe('TimezoneOffsetUtil.js', function(){
 describe('TimezoneOffsetUtil in practice', function(){
   it('applies a timezone across-the-board when no `changes` provided', function(){
     var data = _.map(_.range(0,100), function(d) { return {value: d, type: 'foo'}; });
-    var dates = d3.time.day.range(new Date('2015-02-01T00:00:00'), new Date('2015-05-12T00:00:00'));
+    var dates = d3.time.day.range(sundial.parseFromFormat('2015-02-01T00:00:00'), sundial.parseFromFormat('2015-05-12T00:00:00'));
     // Hawaii doesn't use Daylight Savings Time
     var util = new TZOUtil('Pacific/Honolulu', '2015-06-01T00:00:00.000Z', []);
     for (var i = 0; i < data.length; ++i) {
@@ -640,7 +640,7 @@ describe('TimezoneOffsetUtil in practice', function(){
 
   it('applies a timezone across-the-board (including offset changes b/c of DST) when no `changes` provided', function(){
     var data = _.map(_.range(0,100), function(d) { return {value: d, type: 'foo'}; });
-    var dates = d3.time.day.range(new Date('2015-02-01T00:00:00'), new Date('2015-05-12T00:00:00'));
+    var dates = d3.time.day.range(sundial.parseFromFormat('2015-02-01T00:00:00'), sundial.parseFromFormat('2015-05-12T00:00:00'));
     // US/Mountain *does* use Daylight Savings Time
     var util = new TZOUtil('US/Mountain', '2015-06-01T00:00:00.000Z', []);
     for (var i = 0; i < data.length; ++i) {
@@ -657,18 +657,18 @@ describe('TimezoneOffsetUtil in practice', function(){
     setTimeout(function() {
       var data = [], index = 0;
       var datetimesHomeAgain = d3.time.minute.utc.range(
-        new Date('2015-04-19T05:05:00'),
-        new Date('2015-05-01T00:00:00'),
+        sundial.parseFromFormat('2015-04-19T05:05:00'),
+        sundial.parseFromFormat('2015-05-01T00:00:00'),
         5
       );
       var datetimesInNZ = d3.time.minute.utc.range(
-        new Date('2015-04-10T19:05:00'),
-        new Date('2015-04-20T00:05:00'),
+        sundial.parseFromFormat('2015-04-10T19:05:00'),
+        sundial.parseFromFormat('2015-04-20T00:05:00'),
         5
       );
       var datetimesBeforeTrip = d3.time.minute.utc.range(
-        new Date('2015-04-01T00:00:00'),
-        new Date('2015-04-10T00:05:00'),
+        sundial.parseFromFormat('2015-04-01T00:00:00'),
+        sundial.parseFromFormat('2015-04-10T00:05:00'),
         5
       );
       var datetimes = _.flatten([datetimesBeforeTrip, datetimesInNZ, datetimesHomeAgain]);
@@ -686,7 +686,7 @@ describe('TimezoneOffsetUtil in practice', function(){
           to: '2015-04-19T05:03:00'
         })
         .with_deviceTime('2015-04-20T00:00:00')
-        .set('jsDate', new Date('2015-04-20T00:00:00'))
+        .set('jsDate', sundial.parseFromFormat('2015-04-20T00:00:00'))
         .set('index', 10489);
       var toNZ = builder.makeDeviceEventTimeChange()
         .with_change({
@@ -694,7 +694,7 @@ describe('TimezoneOffsetUtil in practice', function(){
           to: '2015-04-10T19:02:00'
         })
         .with_deviceTime('2015-04-10T00:02:30')
-        .set('jsDate', new Date('2015-04-10T00:02:30'))
+        .set('jsDate', sundial.parseFromFormat('2015-04-10T00:02:30'))
         .set('index', 5185);
       var util = new TZOUtil('US/Pacific', '2015-06-01T00:00:00.000Z', [toNZ, fromNZ]);
       for (var i = 0; i < data.length; ++i) {


### PR DESCRIPTION
While working on the Electron app, @krystophv discovered that Chrome 58+ changes the way they handle `Date`s to be ES6 compliant. To quote http://codeofmatt.com/2015/06/17/javascript-date-parsing-changes-in-es6/:
 
> So, to make this align with the ISO 8601 spec, this line was changed in the ES6 specification (in section 20.3.1.16). It now says:
>
>... If the time zone offset is absent, the date-time is interpreted as a local time.
>
>That's great for compliance and spec alignment. But it's a serious issue for backward compatibility. Any code that expects the Date constructor to parse a date as UTC will need to be updated.

This has potential effects on our current production codebase.

This PR fixes a unit test for TZOUtil that calls the Date constructor with a timestamp without timezone info, so it got double-adjusted. I've gone through our uploader code and I can't find any instances of where we're trying to parse non-UTC timestamps apart from the unit test itself. We use `sundial.parseFromFormat` for non-UTC timestamps, which uses Moment instead to parse it into UTC. 

Other uses of  the Date constructor in our codebase are to get current date/time and to parse "UTC" Unix timestamps. We also use the Date constructor to parse dates where we calculate the difference between two dates, which is fine if they're both local instead of UTC.