### PR TITLE
Fix regression: clearing the suspending event after use

### DIFF
--- a/lib/drivers/medtronic/medtronicSimulator.js
+++ b/lib/drivers/medtronic/medtronicSimulator.js
@@ -68,8 +68,10 @@ exports.make = function(config){
   };
 
   function setSuspendingEvent(event) {
-    if(currBasal.deliveryType !== 'suspend') {
+    if (currBasal.deliveryType !== 'suspend') {
       suspendingEvent = event;
+    } else if (event === null) {
+      suspendingEvent = null;
     }
   };
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Tidepool Uploader",
   "short_name": "Uploader",
-  "version": "0.311.0",
+  "version": "0.312.0",
   "description": "The Tidepool Uploader helps you get your data from insulin pumps, CGMs and BG meters into Tidepool’s secure cloud platform.",
   "minimum_chrome_version": "38",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "0.311.0",
+  "version": "0.312.0",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",

--- a/test/node/medtronic/testMedtronicSimulator.js
+++ b/test/node/medtronic/testMedtronicSimulator.js
@@ -1681,6 +1681,14 @@ describe('medtronicSimulator.js', function() {
         .with_rate(1.2);
       basal2.deviceId = 'medtronic12345';
 
+      var basal3 = builder.makeScheduledBasal()
+        .with_time('2014-09-25T04:00:00.000Z')
+        .with_deviceTime('2014-09-25T04:00:00')
+        .with_timezoneOffset(0)
+        .with_conversionOffset(0)
+        .with_rate(2);
+      basal3.deviceId = 'medtronic12345';
+
       var expectedSuspendResume = {
         time: '2014-09-25T02:00:00.000Z',
         deviceTime: '2014-09-25T02:00:00',
@@ -1699,6 +1707,7 @@ describe('medtronicSimulator.js', function() {
       simulator.basal(basal1);
       simulator.alarm(alarm);
       simulator.basal(basal2);
+      simulator.basal(basal3);
 
       var expectedBasal = builder.makeSuspendBasal()
         .with_time('2014-09-25T02:00:00.000Z')
@@ -1719,7 +1728,8 @@ describe('medtronicSimulator.js', function() {
       expect(simulator.getEvents()).deep.equals([
         basal1.done(),
         expectedAlarm,
-        expectedBasal
+        expectedBasal,
+        basal2.done() // checks that the suspending event has been cleared
       ]);
     });
   });


### PR DESCRIPTION
An issue reported by a user was reproduced using Eric's 530G. Using Eric's binary blob, I went back through the versions and it is a regression that was introduced in the most recent version: v0.309.0.

Basically, if a "suspending event", like an auto-off alarm occurred, there's a chance it may have been used to generate a suspended basal more than once, which was then caught by the platform validation. This PR makes sure we always clear the suspending event after use.