### PR TITLE
Enable Tandem, Dexcom, Contour Next USB, and Omnipod on ChromeOS

### DIFF
--- a/lib/core/device.js
+++ b/lib/core/device.js
@@ -278,7 +278,7 @@ device.detectUsb = function(driverId, cb) {
         } else {
           return (p.vendorId === driverManifest.vendorId) &&
           (p.productId === driverManifest.productId) &&
-          p.path.match('/dev/cu.+');
+          (p.path.match('/dev/cu.+') || p.path.match('/dev/ttyACM.+'));
         }
       });
     }

--- a/lib/redux/reducers/devices.js
+++ b/lib/redux/reducers/devices.js
@@ -29,17 +29,17 @@ const devices = {
     instructions: 'Plug in PDM with mini-USB and choose .ibf file from PDM',
     key: 'omnipod',
     name: 'Insulet OmniPod',
-    showDriverLink: {mac: false, win: false},
+    showDriverLink: {cros: false, mac: false, win: false},
     source: {type: 'block', driverId: 'InsuletOmniPod', extension: '.ibf'},
-    enabled: {mac: true, win: true}
+    enabled: {cros: true, mac: true, win: true}
   },
   dexcom: {
     instructions: 'Plug in receiver with micro-USB',
     key: 'dexcom',
     name: 'Dexcom',
-    showDriverLink: {mac: true, win: true},
+    showDriverLink: {cros: false, mac: true, win: true},
     source: {type: 'device', driverId: 'Dexcom'},
-    enabled: {mac: true, win: true}
+    enabled: {cros: true, mac: true, win: true}
   },
   precisionxtra: {
     instructions: 'Plug in meter with cable',
@@ -53,9 +53,9 @@ const devices = {
     instructions: 'Plug in pump with micro-USB',
     key: 'tandem',
     name: 'Tandem',
-    showDriverLink: {mac: false, win: true},
+    showDriverLink: {cros: false, mac: false, win: true},
     source: {type: 'device', driverId: 'Tandem'},
-    enabled: {mac: true, win: true}
+    enabled: {cros: true, mac: true, win: true}
   },
   abbottfreestylelite: {
     instructions: 'Plug in meter with cable',
@@ -85,9 +85,9 @@ const devices = {
     instructions: 'Plug meter into USB port',
     key: 'bayercontournextusb',
     name: 'Bayer Contour Next USB',
-    showDriverLink: {mac: false, win: false},
+    showDriverLink: {cros: false, mac: false, win: false},
     source: {type: 'device', driverId: 'BayerContourNextUsb'},
-    enabled: {mac: true, win: true}
+    enabled: {cros: true, mac: true, win: true}
   },
   bayercontourusb: {
     instructions: 'Plug meter into USB port',


### PR DESCRIPTION
Adds cros to the enabled map for these devices, and Supports serial ports named /dev/ttyACM.+
