### PR TITLE
merge bayercontour* meters into bayercontournext

### DIFF
--- a/app/reducers/users.js
+++ b/app/reducers/users.js
@@ -157,11 +157,14 @@ export function targetDevices(state = {}, action) {
       _.each(memberships, (membership) => {
         if (isPwd(membership)) {
           let targetDevices = _.get(membership, ['profile', 'patient', 'targetDevices'], []);
-          // collapse all bayercontour devices into bayercontournext
+          // collapse all bayercontour* devices into bayercontournext
           targetDevices = _.uniq(_.map(targetDevices, function(device) {
-            if (device.startsWith('bayercontour')) {
+            if (device.startsWith('bayercontour') && device.length > 12) {
               return 'bayercontournext';
-            };
+            }
+            if (device === 'abbottfreestylefreedomlite') {
+              return 'abbottfreestylelite';
+            }
             return device;
           }));
           newState[membership.userid] = targetDevices;
@@ -188,11 +191,14 @@ export function targetDevices(state = {}, action) {
       _.forOwn(targets, (targetsArray, userId) => {
         if (newState[userId] != null) {
           let targetDevices = _.pluck(targetsArray, 'key');
-          // collapse all bayercontour devices into bayercontournext
+          // collapse all bayercontour* devices into bayercontournext
           targetDevices = _.uniq(_.map(targetDevices, function(device) {
-            if (device.startsWith('bayercontour')) {
+            if (device.startsWith('bayercontour') && device.length > 12) {
               return 'bayercontournext';
-            };
+            }
+            if (device === 'abbottfreestylefreedomlite') {
+              return 'abbottfreestylelite';
+            }
             return device;
           }));
           newState = update(

--- a/app/reducers/users.js
+++ b/app/reducers/users.js
@@ -156,7 +156,15 @@ export function targetDevices(state = {}, action) {
       let newState = {};
       _.each(memberships, (membership) => {
         if (isPwd(membership)) {
-          newState[membership.userid] = _.get(membership, ['profile', 'patient', 'targetDevices'], []);
+          let targetDevices = _.get(membership, ['profile', 'patient', 'targetDevices'], []);
+          // collapse all bayercontour devices into bayercontournext
+          targetDevices = _.uniq(_.map(targetDevices, function(device) {
+            if (device.startsWith('bayercontour')) {
+              return 'bayercontournext';
+            };
+            return device;
+          }));
+          newState[membership.userid] = targetDevices;
         }
       });
       return newState;
@@ -179,7 +187,14 @@ export function targetDevices(state = {}, action) {
       let newState = state;
       _.forOwn(targets, (targetsArray, userId) => {
         if (newState[userId] != null) {
-          const targetDevices = _.pluck(targetsArray, 'key');
+          let targetDevices = _.pluck(targetsArray, 'key');
+          // collapse all bayercontour devices into bayercontournext
+          targetDevices = _.uniq(_.map(targetDevices, function(device) {
+            if (device.startsWith('bayercontour')) {
+              return 'bayercontournext';
+            };
+            return device;
+          }));
           newState = update(
             newState,
             {[userId]: {$set: targetDevices}}

--- a/test/app/reducers/users.test.js
+++ b/test/app/reducers/users.test.js
@@ -319,6 +319,27 @@ describe('users', () => {
       });
     });
 
+    it('should handle LOGIN_SUCCESS and collapse bayer meters', () => {
+      expect(users.targetDevices(undefined, {
+        type: actionTypes.LOGIN_SUCCESS,
+        payload: { memberships: [
+          {userid: 'a1b2c3', profile: {foo: 'bar'}},
+          {userid: 'd4e5f6',
+            profile: {
+              patient: {
+                a: 1,
+                targetDevices: ['bayercontourusb', 'bayercontournextlink', 'bayercontournextusb', 'a_cgm']
+              }
+            }
+          },
+          {userid: 'g7h8i0', profile: {patient: {b: 2}}}
+        ]}
+      })).to.deep.equal({
+        d4e5f6: ['bayercontournext', 'a_cgm'],
+        g7h8i0: []
+      });
+    });
+
     it('should handle LOGOUT_REQUEST', () => {
       let initialState = {
         d4e5f6: ['a_meter', 'another_pump'],
@@ -383,6 +404,26 @@ describe('users', () => {
       expect(initialState === result).to.be.false;
       expect(initialState.d4e5f6 === result.d4e5f6).to.be.false;
       expect(initialState.g7h8i0 === result.g7h8i0).to.be.false;
+    });
+
+    it('should handle SET_USERS_TARGETS and collapse bayer meters', () => {
+      let initialState = {
+        d4e5f6: [],
+        g7h8i0: []
+      };
+      const targets = {
+        d4e5f6: [{key: 'bayercontourusb'}],
+        g7h8i0: [{key: 'bayercontournextlink'}, {key: 'bayercontournextusb'}],
+        j1k2l3: [{key: 'another_pump'}]
+      };
+      let result = users.targetDevices(initialState, {
+        type: actionTypes.SET_USERS_TARGETS,
+        payload: { targets }
+      });
+      expect(result).to.deep.equal({
+        d4e5f6: ['bayercontournext'],
+        g7h8i0: ['bayercontournext']
+      });
     });
 
     it('should handle STORING_USERS_TARGETS (by clearing noUserSelected devices)', () => {

--- a/test/app/reducers/users.test.js
+++ b/test/app/reducers/users.test.js
@@ -319,24 +319,21 @@ describe('users', () => {
       });
     });
 
-    it('should handle LOGIN_SUCCESS and collapse bayer meters', () => {
+    it('should handle LOGIN_SUCCESS and collapse bayer meters and abbottfreestylefreedomlite', () => {
       expect(users.targetDevices(undefined, {
         type: actionTypes.LOGIN_SUCCESS,
         payload: { memberships: [
           {userid: 'a1b2c3', profile: {foo: 'bar'}},
-          {userid: 'd4e5f6',
-            profile: {
-              patient: {
-                a: 1,
-                targetDevices: ['bayercontourusb', 'bayercontournextlink', 'bayercontournextusb', 'a_cgm']
-              }
-            }
-          },
-          {userid: 'g7h8i0', profile: {patient: {b: 2}}}
+          {userid: 'd4e5f6', profile: { patient: { a: 1, targetDevices: [
+            'bayercontourusb', 'bayercontournextlink', 'bayercontournextusb', 'a_cgm'
+          ]}}},
+          {userid: 'g7h8i0', profile: { patient: {b: 2, targetDevices: ['abbottfreestylefreedomlite']}}},
+          {userid: 'j9k1l2', profile: { patient: {c: 3, targetDevices: ['bayercontour']}}}
         ]}
       })).to.deep.equal({
         d4e5f6: ['bayercontournext', 'a_cgm'],
-        g7h8i0: []
+        g7h8i0: ['abbottfreestylelite'],
+        j9k1l2: ['bayercontour']
       });
     });
 


### PR DESCRIPTION
Redux reducer modifications to take any existing `bayercontour*` device selections and collapse them down to `bayercontournext`.