### PR TITLE
Bugfix: Pump errors lead to unexpected data

### DIFF
--- a/app/utils/debugMode.js
+++ b/app/utils/debugMode.js
@@ -14,7 +14,7 @@
  * not, you can obtain one from Tidepool Project at tidepool.org.
  * == BSD2 LICENSE ==
  */
-
+import isElectron from 'is-electron';
 import { ipcRenderer, ipcMain } from 'electron';
 let isRenderer = (process && process.type === 'renderer');
 
@@ -35,9 +35,11 @@ if (isRenderer) {
 } else {
   let isDebug = process.env.DEBUG_ERROR || false;
 
-  ipcMain.on('setDebug', (event, arg) => {
-    debugMode.isDebug = arg;
-  });
+  if (isElectron()) {
+    ipcMain.on('setDebug', (event, arg) => {
+      debugMode.isDebug = arg;
+    });
+  }
 
   const debugMode = module.exports = {
     isDebug,

--- a/lib/drivers/medtronic/cli/blob_loader.js
+++ b/lib/drivers/medtronic/cli/blob_loader.js
@@ -103,7 +103,7 @@ if(program.file && program.username && program.password) {
     });
   }else{
     console.log(intro + ' file at [%s] not found', program.medtronic);
-    return;
+    program.exit();
   }
 }else{
   program.help();

--- a/lib/drivers/medtronic/medtronicSimulator.js
+++ b/lib/drivers/medtronic/medtronicSimulator.js
@@ -68,7 +68,7 @@ exports.make = function(config){
   };
 
   function setSuspendingEvent(event) {
-    if (currBasal.deliveryType !== 'suspend') {
+    if (currBasal && currBasal.deliveryType !== 'suspend') {
       suspendingEvent = event;
     } else if (event === null) {
       suspendingEvent = null;

--- a/lib/drivers/medtronic/medtronicSimulator.js
+++ b/lib/drivers/medtronic/medtronicSimulator.js
@@ -72,6 +72,9 @@ exports.make = function(config){
       suspendingEvent = event;
     } else if (event === null) {
       suspendingEvent = null;
+    } else {
+      // not a suspending event, so add it
+      simpleSimulate(event);
     }
   };
 

--- a/lib/drivers/medtronic/processData.js
+++ b/lib/drivers/medtronic/processData.js
@@ -778,6 +778,12 @@ function buildSettings(records) {
       var startTime = schedule.offset * 30 * sundial.MIN_TO_MSEC;
       schedules.push( { start: startTime, rate: schedule.rate / settings.strokesPerUnit} );
     };
+
+    if (schedules.length === 0) {
+      // schedules were cleared after pump error
+      schedules = [{ start: 0, rate: 0 }];
+    }
+
     return schedules;
   };
 


### PR DESCRIPTION
This PR includes the following bugfixes:

- fixes the new debug mode so that it works with CLI tools like `blob_loader`
- checks that there is a basal event on the pump before trying to set a suspending event
- handles cleared basal schedules after a pump error