### PR TITLE
Handle bogus time change events

### DIFF
--- a/lib/drivers/medtronic600/NGPHistoryParser.js
+++ b/lib/drivers/medtronic600/NGPHistoryParser.js
@@ -160,7 +160,7 @@ class NGPHistoryEvent {
     return this.eventData[0];
   }
 
-  // TODO - make this a static factory (passing in eventData).
+  // TODO: - make this a static factory (passing in eventData).
   // Doing it this way causes double-initialisation
   eventInstance() {
     /* eslint-disable no-use-before-define */
@@ -185,8 +185,12 @@ class NGPHistoryEvent {
         return new NewBasalPatternEvent(this.eventData);
       case NGPHistoryEvent.EVENT_TYPE.BASAL_PATTERN_SELECTED:
         return new BasalPatternSelectedEvent(this.eventData);
+      case NGPHistoryEvent.EVENT_TYPE.TIME_RESET:
+        return new TimeChangeEvent(this.eventData);
       case NGPHistoryEvent.EVENT_TYPE.USER_TIME_DATE_CHANGE:
-        return new UserTimeDateEvent(this.eventData);
+        return new TimeChangeEvent(this.eventData);
+      case NGPHistoryEvent.EVENT_TYPE.ALARM_NOTIFICATION:
+        return new AlarmNotificationEvent(this.eventData);
       case NGPHistoryEvent.EVENT_TYPE.LOW_RESERVOIR:
         return new LowReservoirEvent(this.eventData);
       case NGPHistoryEvent.EVENT_TYPE.SENSOR_GLUCOSE_READINGS_EXTENDED:
@@ -231,9 +235,33 @@ class NGPHistoryEvent {
   }
 }
 
-class UserTimeDateEvent extends NGPHistoryEvent {
+class TimeChangeEvent extends NGPHistoryEvent {
   get newTimestamp() {
     return NGPUtil.NGPTimestamp.fromBuffer(this.eventData.slice(0x0B, 0x13));
+  }
+}
+
+class AlarmNotificationEvent extends NGPHistoryEvent {
+  get notificationMode() {
+    return this.eventData[0x11];
+  }
+
+  get faultNumber() {
+    return this.eventData.readUInt16BE(0x0B);
+  }
+
+  get extraData() {
+    // eslint-disable-next-line no-bitwise
+    return this.eventData[0x12] & 2;
+  }
+
+  get alarmHistory() {
+    // eslint-disable-next-line no-bitwise
+    return this.eventData[0x12] & 4;
+  }
+
+  get alarmData() {
+    return this.eventData.slice(0x13, 0x1c).toString('hex');
   }
 }
 
@@ -292,7 +320,7 @@ class SensorGlucoseReadingsEvent extends NGPHistoryEvent {
       const noisyData = sensorStatus === 1;
       const discardData = sensorStatus === 2;
       const sensorError = sensorStatus === 3;
-      // TODO - handle all the error states where sg >= 769 (see ParseCGM.js)?
+      // TODO: - handle all the error states where sg >= 769 (see ParseCGM.js)?
 
       pos += 9;
 
@@ -798,10 +826,23 @@ class NGPHistoryParser {
   }
 
   processPages(pages) {
+    let skipTimeChange = false;
     // Consume the pages as we process them to save on memory.
     while (pages.length > 0) {
       const page = pages.shift();
       for (const event of NGPHistoryParser.eventsFromPageString(page)) {
+        if (event.eventType === NGPHistoryEvent.EVENT_TYPE.TIME_RESET) {
+          debug('TIME_RESET detected. Ignoring next USER_TIME_DATE_CHANGE.');
+          skipTimeChange = true;
+        }
+
+        if (event.eventType === NGPHistoryEvent.EVENT_TYPE.USER_TIME_DATE_CHANGE &&
+          skipTimeChange) {
+          skipTimeChange = false;
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+
         this.events.push(event.eventInstance());
       }
     }
@@ -1041,7 +1082,7 @@ class NGPHistoryParser {
           debug('Unexpected settings change type', event.eventType);
           throw new Error('Unexpected settings change');
       }
-      // TODO - set the correct time on the settingsChange.
+      // TODO: - set the correct time on the settingsChange.
       settingsChange
         .with_time(event.timestamp.toDate().toISOString());
       this.addTimeFields(settingsChange, event.timestamp);
@@ -1281,7 +1322,7 @@ class NGPHistoryParser {
       this.addTimeFields(bolus, event.timestamp);
 
       if (event.bolusSource === NGPUtil.NGPConstants.BOLUS_SOURCE.BOLUS_WIZARD) {
-        // TODO - do we want to treat an unmatching BOLUS_WIZARD record as a normal bolus?
+        // TODO: - do we want to treat an unmatching BOLUS_WIZARD record as a normal bolus?
         const completeBolus = bolus.done();
         try {
           const wizardEvent = this.findWizardForBolus(event, event.programmedAmount);
@@ -1315,7 +1356,7 @@ class NGPHistoryParser {
       this.addTimeFields(bolus, beginTimestamp);
 
       if (event.bolusSource === NGPUtil.NGPConstants.BOLUS_SOURCE.BOLUS_WIZARD) {
-        // TODO - do we want to treat an unmatching BOLUS_WIZARD record as a normal bolus?
+        // TODO: - do we want to treat an unmatching BOLUS_WIZARD record as a normal bolus?
         const completeBolus = bolus.done();
         try {
           const wizardEvent = this.findWizardForBolus(event, event.programmedAmount);


### PR DESCRIPTION
* If an NGPHistoryEvent.EVENT_TYPE.TIME_RESET event is found, skip the next NGPHistoryEvent.EVENT_TYPE.USER_TIME_DATE_CHANGE. This can occur if the pump runs out of battery, and the user sets the correct time when a new battery is installed. It is NOT a valid time change due to crossing timezones, clock drift, or DST changes
* Formatting of TODOs to make plugins happy
* Add parsing of Alarm events