### PR TITLE
Fix 600-series deduplication

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName":  "tidepool-uploader",
-  "version": "2.0.4-qa.5",
+  "version": "2.0.4-qa.6",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.js",
   "author": {

--- a/lib/drivers/medtronic600/NGPHistoryParser.js
+++ b/lib/drivers/medtronic600/NGPHistoryParser.js
@@ -836,6 +836,7 @@ class NGPHistoryParser {
           skipTimeChange = true;
         }
 
+        // TODO: Skip all events up to the USER_TIME_DATE_CHANGE?
         if (event.eventType === NGPHistoryEvent.EVENT_TYPE.USER_TIME_DATE_CHANGE &&
           skipTimeChange) {
           skipTimeChange = false;

--- a/lib/drivers/medtronic600/medtronic600Driver.js
+++ b/lib/drivers/medtronic600/medtronic600Driver.js
@@ -1870,7 +1870,7 @@ module.exports = (config) => {
         deviceManufacturers: ['Medtronic'],
         deviceModel: data.settings.pumpModel.replace('MMT-', ''),
         deviceSerialNumber: data.settings.pumpSerial,
-        deviceId: data.settings.pumpSerial,
+        deviceId: `${data.settings.pumpModel}:${data.settings.pumpSerial}`,
         start: sundial.utcDateString(),
         timeProcessing: cfg.tzoUtil.type,
         tzName: cfg.timezone,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.0.4-qa.5",
+  "version": "2.0.4-qa.6",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",


### PR DESCRIPTION
Change `deviceId` in `sessionInfo` to a string that the `platform` deduplicator seems to respect.

I have tried the following (which won't dedupe correctly):
`MedT-<model number>-<serial string>`
`MedT-<model number>-<serial number>`
`MedT-<model number>:<serial number>`
`<model number>:<serial string>`