### PR TITLE
fix hanging uploader when device not connected

### DIFF
--- a/lib/drivers/abbott/abbottFreeStyleLite.js
+++ b/lib/drivers/abbott/abbottFreeStyleLite.js
@@ -421,6 +421,9 @@ module.exports = function (config) {
       debug('in fetchData');
       getAllData({}, function (err, result) {
         progress(100);
+        if (err) {
+          return cb(err, data);
+        }
         data.connect = true;
         debug(result);
         _.extend(data, _.pick(result, 'serialNumber', 'softwareVersion', 'deviceTime'));


### PR DESCRIPTION
Abbott FreeStyle Lite driver is missing an error check in fetchData to detect when the device is not connected to the USB serial cable.
Currently the uploader just hangs forever at 70%...