### PR TITLE
Remove "beta" and "unsupported" labels from Libre

### DIFF
--- a/app/reducers/devices.js
+++ b/app/reducers/devices.js
@@ -60,9 +60,9 @@ const devices = {
     enabled: {mac: false, win: true}
   },
   abbottfreestylelibre: {
-    instructions: '(Unsupported) Plug in meter with micro-USB cable',
+    instructions: 'Plug in meter with micro-USB cable',
     key: 'abbottfreestylelibre',
-    name: 'Abbott FreeStyle Libre (Beta)',
+    name: 'Abbott FreeStyle Libre',
     showDriverLink: {linux: false, mac: false, win: false},
     source: {type: 'device', driverId: 'AbbottFreeStyleLibre'},
     enabled: {linux: true, mac: true, win: true}


### PR DESCRIPTION
What it says on the tin. This PR has no associated Trello card, as it's just changing two labels, and can go out with the next release.