### PR TITLE
Skip zero-fill prime events

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.2.5-600series-qa.14",
+  "version": "2.2.5-600series-qa.15",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.js",
   "author": {

--- a/lib/drivers/medtronic600/NGPHistoryParser.js
+++ b/lib/drivers/medtronic600/NGPHistoryParser.js
@@ -1564,18 +1564,17 @@ class NGPHistoryParser {
     for (const event of this.eventsOfType(NGPHistoryEvent.EVENT_TYPE.CANNULA_FILL_DELIVERED)) {
       // If the user skips a prime in the pump UI, the pump history still contains the fill
       // event, but with an amount of zero. We skip those.
-      if (event.amount === 0) {
+      if (event.amount !== 0) {
+        const prime = this.cfg.builder.makeDeviceEventPrime()
+          .with_primeTarget(event.type === NGPUtil.NGPConstants.CANNULA_FILL_TYPE.TUBING_FILL ? 'tubing' : 'cannula')
+          .with_volume(event.amount);
+
+        this.addTimeFields(prime, event.timestamp);
+
+        events.push(prime.done());
+      } else {
         debug('Skipping zero-fill prime event');
-        continue;
       }
-
-      const prime = this.cfg.builder.makeDeviceEventPrime()
-        .with_primeTarget(event.type === NGPUtil.NGPConstants.CANNULA_FILL_TYPE.TUBING_FILL ? 'tubing' : 'cannula')
-        .with_volume(event.amount);
-
-      this.addTimeFields(prime, event.timestamp);
-
-      events.push(prime.done());
     }
 
     return this;

--- a/lib/drivers/medtronic600/NGPHistoryParser.js
+++ b/lib/drivers/medtronic600/NGPHistoryParser.js
@@ -1562,6 +1562,13 @@ class NGPHistoryParser {
 
   buildPrimeRecords(events) {
     for (const event of this.eventsOfType(NGPHistoryEvent.EVENT_TYPE.CANNULA_FILL_DELIVERED)) {
+      // If the user skips a prime in the pump UI, the pump history still contains the fill
+      // event, but with an amount of zero. We skip those.
+      if (event.amount === 0) {
+        debug('Skipping zero-fill prime event');
+        continue;
+      }
+
       const prime = this.cfg.builder.makeDeviceEventPrime()
         .with_primeTarget(event.type === NGPUtil.NGPConstants.CANNULA_FILL_TYPE.TUBING_FILL ? 'tubing' : 'cannula')
         .with_volume(event.amount);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.2.5-600series-qa.14",
+  "version": "2.2.5-600series-qa.15",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",


### PR DESCRIPTION
If the user skips a prime in the pump UI, the pump history will still
contain a fill event, but with an amount of zero. We skip these
zero-fill events.
- Fixes https://trello.com/c/GiWmPRw2