### PR TITLE
Disambiguate 670G SMBGs

### DIFF
--- a/lib/drivers/medtronic600/NGPHistoryParser.js
+++ b/lib/drivers/medtronic600/NGPHistoryParser.js
@@ -1,5 +1,4 @@
 /*
-
  * == BSD2 LICENSE ==
  * Copyright (c) 2017, Tidepool Project
  *
@@ -942,6 +941,23 @@ class NGPHistoryParser {
     }
   }
 
+  findMatchingClosedLoopBGReadings(bgReadingEvent) {
+    // Find all of the ClosedLoopBloodGlucoseReadingEvents with the same BG value that
+    // occurred within 15 minutes of the BG_READING_RECEIVED.
+    const matchingReadings = [];
+    let eventIndex = _.findIndex(this.events, event => event === bgReadingEvent) + 1;
+    while (this.events[eventIndex].timestamp.rtc < bgReadingEvent.timestamp.rtc + 900) {
+      if (this.events[eventIndex].eventType ===
+        NGPHistoryEvent.EVENT_TYPE.CLOSED_LOOP_BG_READING &&
+        this.events[eventIndex].bgValue === bgReadingEvent.bgValue
+      ) {
+        matchingReadings.push(this.events[eventIndex]);
+      }
+      eventIndex += 1;
+    }
+    return matchingReadings;
+  }
+
   // This is here because a Temp Basal with a percentage requires the suppressed basal
   // to determine the rate. Though this could also be done in the simulator, we do it here
   // because the event is incomplete without the rate.
@@ -1247,6 +1263,37 @@ class NGPHistoryParser {
           .with_units('mg/dL')
           .with_subType('calibration')
           .with_value(event.bgValue);
+      } else if (event instanceof ClosedLoopBloodGlucoseReadingEvent) {
+        // If it's a ClosedLoopBloodGlucoseReadingEvent, we only create an SMBG based on the
+        // BG_READING_RECEIVED event, putting all of the matching historic events into the
+        // annotations and payload.
+        if (event.bgReadingOrigin === NGPUtil.NGPConstants.BG_ORIGIN.RECEIVED_FROM_RF &&
+            event.bgReadingContext === NGPUtil.NGPConstants.BG_CONTEXT.BG_READING_RECEIVED) {
+          reading = this.cfg.builder.makeSMBG()
+            .with_units('mg/dL')
+            .with_subType(event.bgLinked ? 'linked' : 'manual')
+            .with_value(event.bgValue);
+
+          // Add annotations for the different contexts
+          const bgContexts = {};
+          for (const matchedBgReading of this.findMatchingClosedLoopBGReadings(event)) {
+            const annotationText = _.chain(NGPUtil.NGPConstants.BG_CONTEXT)
+              .findKey(o => o === matchedBgReading.bgReadingContext).lowerCase()
+              .replace(/ /g, '-')
+              .value();
+            // Don't annotate Guardian Transmitter (GST) Signal Integrity (SI) contexts
+            if (matchedBgReading.bgReadingContext !==
+                NGPUtil.NGPConstants.BG_CONTEXT.BG_SI_PASS_RESULT_RECD_FRM_GST &&
+                matchedBgReading.bgReadingContext !==
+                NGPUtil.NGPConstants.BG_CONTEXT.BG_SI_FAIL_RESULT_RECD_FRM_GST) {
+              annotate.annotateEvent(reading, `medtronic600/smbg/${annotationText}`);
+            }
+            bgContexts[annotationText] = matchedBgReading.timestamp.toDate();
+          }
+          reading.with_payload({
+            bgContexts,
+          });
+        }
       } else {
         reading = this.cfg.builder.makeSMBG()
           .with_units('mg/dL')
@@ -1254,20 +1301,16 @@ class NGPHistoryParser {
           .with_value(event.bgValue);
       }
 
-      reading.with_payload({
-        readingContext: _.chain(NGPUtil.NGPConstants.BG_CONTEXT)
-          .findKey(o => o === event.bgReadingContext).lowerCase().value(),
-      });
-
       if (event.bgLinked && event.eventType === NGPHistoryEvent.EVENT_TYPE.BG_READING) {
         reading.with_payload({
           meterSerial: event.meterSerialNumber,
         });
       }
 
-      this.addTimeFields(reading, event.timestamp);
-
-      events.push(reading.done());
+      if (reading !== null) {
+        this.addTimeFields(reading, event.timestamp);
+        events.push(reading.done());
+      }
     }
 
     return this;

--- a/lib/drivers/medtronic600/NGPHistoryParser.js
+++ b/lib/drivers/medtronic600/NGPHistoryParser.js
@@ -1264,19 +1264,22 @@ class NGPHistoryParser {
           .with_subType('calibration')
           .with_value(event.bgValue);
       } else if (event instanceof ClosedLoopBloodGlucoseReadingEvent) {
-        // If it's a ClosedLoopBloodGlucoseReadingEvent, we only create an SMBG based on the
-        // BG_READING_RECEIVED event, putting all of the matching historic events into the
-        // annotations and payload.
-        if (event.bgReadingOrigin === NGPUtil.NGPConstants.BG_ORIGIN.RECEIVED_FROM_RF &&
-            event.bgReadingContext === NGPUtil.NGPConstants.BG_CONTEXT.BG_READING_RECEIVED) {
+        // If it's a ClosedLoopBloodGlucoseReadingEvent that has been RECEIVED_FROM_RF,
+        // we only create an SMBG based on the BG_READING_RECEIVED event, putting all
+        // of the matching historic events into the annotations and payload.
+        // If its MANUALLY_ENTERED, create the SMBG, since they only have single contexts.
+        if ((event.bgReadingOrigin === NGPUtil.NGPConstants.BG_ORIGIN.RECEIVED_FROM_RF &&
+            event.bgReadingContext === NGPUtil.NGPConstants.BG_CONTEXT.BG_READING_RECEIVED) ||
+            event.bgReadingOrigin === NGPUtil.NGPConstants.BG_ORIGIN.MANUALLY_ENTERED) {
           reading = this.cfg.builder.makeSMBG()
             .with_units('mg/dL')
             .with_subType(event.bgLinked ? 'linked' : 'manual')
             .with_value(event.bgValue);
 
           // Add annotations for the different contexts
+          // This will only be the event itself if MANUALLY_ENTERED
           const bgContexts = {};
-          for (const matchedBgReading of this.findMatchingClosedLoopBGReadings(event)) {
+          for (const matchedBgReading of [...this.findMatchingClosedLoopBGReadings(event), event]) {
             const annotationText = _.chain(NGPUtil.NGPConstants.BG_CONTEXT)
               .findKey(o => o === matchedBgReading.bgReadingContext).lowerCase()
               .replace(/ /g, '-')

--- a/lib/drivers/medtronic600/NGPHistoryParser.js
+++ b/lib/drivers/medtronic600/NGPHistoryParser.js
@@ -946,7 +946,8 @@ class NGPHistoryParser {
     // occurred within 15 minutes of the BG_READING_RECEIVED.
     const matchingReadings = [];
     let eventIndex = _.findIndex(this.events, event => event === bgReadingEvent) + 1;
-    while (this.events[eventIndex].timestamp.rtc < bgReadingEvent.timestamp.rtc + 900) {
+    while (this.events.length <= eventIndex + 1 &&
+      this.events[eventIndex].timestamp.rtc < bgReadingEvent.timestamp.rtc + 900) {
       if (this.events[eventIndex].eventType ===
         NGPHistoryEvent.EVENT_TYPE.CLOSED_LOOP_BG_READING &&
         this.events[eventIndex].bgValue === bgReadingEvent.bgValue

--- a/lib/drivers/medtronic600/NGPUtil.js
+++ b/lib/drivers/medtronic600/NGPUtil.js
@@ -52,6 +52,7 @@ class NGPTimestamp {
 }
 
 class NGPConstants {
+  // Pump state is returned as a 1-byte bitfield.
   static get PUMP_STATE_FLAGS() {
     return {
       SUSPENDED: 1,
@@ -98,8 +99,8 @@ class NGPConstants {
       USER_ACCEPTED_REMOTE_BG: 1,
       USER_REJECTED_REMOTE_BG: 2,
       REMOTE_BG_ACCEPTANCE_SCREEN_TIMEOUT: 3,
-      BG_SI_PASS_RESULT_RECD_FRM_GST: 4,
-      BG_SI_FAIL_RESULT_RECD_FRM_GST: 5,
+      BG_SI_PASS_RESULT_RECD_FRM_GST: 4, // Signal Integrity pass from Guardian Transmitter
+      BG_SI_FAIL_RESULT_RECD_FRM_GST: 5, // Signal Integrity fail from Guardian Transmitter
       BG_SENT_FOR_CALIB: 6,
       USER_REJECTED_SENSOR_CALIB: 7,
       ENTERED_IN_BG_ENTRY: 8,


### PR DESCRIPTION
The 670G uses a history event called ClosedLoopBloodGlucoseReadingEvent
for SMBGs. This event is logged multiple times, with
a different context for each event.
This branch/commit consolidates all of the separate events into
a single SMBG event with multiple annotations and payload
entries.
- Fixes https://trello.com/c/jnkv0yVy