### PR TITLE
Add support for the new automated deliveryType

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.2.5-600series-qa.15",
+  "version": "2.2.5-600series-qa.16",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.js",
   "author": {

--- a/lib/drivers/medtronic600/NGPHistoryParser.js
+++ b/lib/drivers/medtronic600/NGPHistoryParser.js
@@ -1363,9 +1363,7 @@ class NGPHistoryParser {
     // Add Closed Loop micro boluses
     for (const event of this.eventsOfType(NGPHistoryEvent.EVENT_TYPE.NORMAL_BOLUS_DELIVERED)) {
       if (event.bolusSource === NGPUtil.NGPConstants.BOLUS_SOURCE.CLOSED_LOOP_MICRO_BOLUS) {
-        // TODO: create a `makeAutoBasal` (with `deliveryType` of `auto`)?
-        // This would be an addition to the data model
-        const basal = this.cfg.builder.makeScheduledBasal()
+        const basal = this.cfg.builder.makeAutomatedBasal()
           // We assume that the microbolus delivery covers a 5 minute period.
           // Multiply by 12 to make it an hourly value.
           .with_rate(parseFloat((event.deliveredAmount * 12).toFixed(3)))
@@ -1374,7 +1372,6 @@ class NGPHistoryParser {
             microbolusAmount: event.deliveredAmount,
           });
 
-        annotate.annotateEvent(basal, 'basal/auto');
         this.addTimeFields(basal, event.timestamp);
 
         events.push(basal);

--- a/lib/drivers/medtronic600/cli/blob_loader.js
+++ b/lib/drivers/medtronic600/cli/blob_loader.js
@@ -23,7 +23,7 @@ function processMedtronic(driverMgr) {
       console.log(err.stack);
       process.exit();
     }
-    console.log(`${intro} All good! Uploaded [%s] events - check in blip :)`, result.postRecords.length);
+    console.log(`${intro} All good! Uploaded [%s] events - check in Tidepool for Web :)`, result.postRecords.length);
     process.exit();
   });
 }
@@ -49,7 +49,7 @@ function loadFile(filePath, tz, userid) {
         filename: filePath,
         fileData: json,
         timezone: tz,
-        version: `${pkg.name} ${pkg.version}`,
+        version: `${pkg.version}`,
         groupId: userid,
         builder,
         api,

--- a/lib/drivers/medtronic600/medtronic600Simulator.js
+++ b/lib/drivers/medtronic600/medtronic600Simulator.js
@@ -135,7 +135,7 @@ class Medtronic600Simulator {
       );
 
       // Back-fill Auto-Basal gaps
-      if (this.currBasal.scheduleName === 'Auto-Basal') {
+      if (this.currBasal.deliveryType === 'automated') {
         const autoBasalDifference = Date.parse(event.time).valueOf() -
           Date.parse(this.currBasal.time).valueOf();
         // Auto-basal microboluses occur roughly every 5 minutes, but no more than 6 minutes apart.
@@ -156,7 +156,7 @@ class Medtronic600Simulator {
           );
           /* eslint-enable function-paren-newline */
 
-          const insertedBasal = this.config.builder.makeScheduledBasal()
+          const insertedBasal = this.config.builder.makeAutomatedBasal()
             .with_deviceTime(sundial.formatDeviceTime(newDeviceTimestamp.toDate()))
             .with_rate(0)
             .with_scheduleName('Auto-Basal')
@@ -165,7 +165,6 @@ class Medtronic600Simulator {
             .set('jsDate', newDeviceTimestamp.toDate())
             .set('basalEndTime', event.time);
           this.config.tzoUtil.fillInUTCInfo(insertedBasal, newDeviceTimestamp.toDate());
-          annotate.annotateEvent(insertedBasal, 'basal/auto');
           this.currBasal = insertedBasal;
         }
       }

--- a/lib/objectBuilder.js
+++ b/lib/objectBuilder.js
@@ -131,6 +131,21 @@ module.exports = function () {
     };
   }
 
+  function makeAutomatedBasal() {
+    var rec = _.assign(_createObject(), deviceInfo, {
+      type: 'basal',
+      deliveryType: 'automated',
+      scheduleName: OPTIONAL,
+      rate: REQUIRED,
+      duration: REQUIRED,
+      previous: OPTIONAL,
+      payload: OPTIONAL,
+      expectedDuration: OPTIONAL
+    });
+    rec._bindProps();
+    return rec;
+  }
+
   function makeBloodKetone() {
     var rec = _.assign(_createObject(), deviceInfo, {
       type: 'bloodKetone',
@@ -471,6 +486,7 @@ module.exports = function () {
   }
 
   return {
+    makeAutomatedBasal: makeAutomatedBasal,
     makeBloodKetone: makeBloodKetone,
     makeCBG: makeCBG,
     makeCGMSettings: makeCGMSettings,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.2.5-600series-qa.15",
+  "version": "2.2.5-600series-qa.16",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",

--- a/test/node/medtronic600/testMedtronic600Simulator.js
+++ b/test/node/medtronic600/testMedtronic600Simulator.js
@@ -1151,14 +1151,14 @@ describe('medtronic600Simulator.js', function() {
 
     describe('Auto-Mode basal', function() {
       it('should add a gap between two Auto-Mode basals that are more than six minutes apart', function() {
-        const basal1 = simulator.config.builder.makeScheduledBasal()
+        const basal1 = simulator.config.builder.makeAutomatedBasal()
           .with_time('2017-02-09T13:11:41.000Z')
           .with_deviceTime('2017-02-09T13:11:41')
           .with_timezoneOffset(0)
           .with_conversionOffset(0)
           .with_scheduleName('Auto-Basal')
           .with_rate(0.75);
-        const basal2 = simulator.config.builder.makeScheduledBasal()
+        const basal2 = simulator.config.builder.makeAutomatedBasal()
           .with_time('2017-02-09T13:18:41.000Z')
           .with_deviceTime('2017-02-09T13:18:41')
           .with_timezoneOffset(0)
@@ -1170,7 +1170,7 @@ describe('medtronic600Simulator.js', function() {
         const expectedFirstBasal = _.cloneDeep(basal1);
         expectedFirstBasal
           .set('duration', 300000);
-        const expectedSecondBasal = simulator.config.builder.makeScheduledBasal()
+        const expectedSecondBasal = simulator.config.builder.makeAutomatedBasal()
           .with_time('2017-02-09T13:16:41.000Z')
           .with_deviceTime('2017-02-09T13:16:41')
           .with_timezoneOffset(0)
@@ -1182,10 +1182,7 @@ describe('medtronic600Simulator.js', function() {
         expectedSecondBasal
           .set('payload', {
             logIndices: [2183956651],
-          })
-          .set('annotations', [{
-            code: 'basal/auto',
-          }]);
+          });
         const expectedThirdBasal = _.cloneDeep(basal2);
         expectedThirdBasal
           .set('duration', 300000);


### PR DESCRIPTION
- Add a function in the `objectBuilder` to support the Tidepool data
  model's new 'automated' deliveryType.
- Change the 600-series Auto Mode basals to use the new
  makeAutomatedBasal function.
deliveryType.
- Adds feature requested in https://trello.com/c/SmmJ2c2W