### PR TITLE
Bug fix: Libre fails to decompress data

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -14,10 +14,7 @@
     "development": {
       "plugins": [
         "transform-class-properties",
-        "transform-es2015-classes",
-        ["transform-define", {
-          "__VERSION_SHA__": "abcd",
-        }]
+        "transform-es2015-classes"
       ],
       "presets": ["react-hmre"]
     },

--- a/.babelrc
+++ b/.babelrc
@@ -14,7 +14,10 @@
     "development": {
       "plugins": [
         "transform-class-properties",
-        "transform-es2015-classes"
+        "transform-es2015-classes",
+        ["transform-define", {
+          "__VERSION_SHA__": "abcd",
+        }]
       ],
       "presets": ["react-hmre"]
     },

--- a/app/actions/sync.js
+++ b/app/actions/sync.js
@@ -288,14 +288,16 @@ export function loginSuccess(results) {
   const { user, profile, memberships } = results;
   const isClinicAccount = personUtils.userHasRole(user, 'clinic');
   // the rewire plugin messes with default export in tests
-  rollbar.configure && rollbar.configure({
-    payload: {
-      person: {
-        id: user.userid,
-        username: user.username,
+  if (rollbar) {
+    rollbar.configure && rollbar.configure({
+      payload: {
+        person: {
+          id: user.userid,
+          username: user.username,
+        }
       }
-    }
-  });
+    });
+  }
   return {
     type: actionTypes.LOGIN_SUCCESS,
     payload: { user, profile, memberships },

--- a/app/components/Upload.js
+++ b/app/components/Upload.js
@@ -258,16 +258,13 @@ export default class Upload extends Component {
     }
 
     let binary_link = null;
-    if(_.isArray(data.pages)) {
+    if(_.isArray(data.pages || data.aapPackets)) {
+      /*
+        we currently support binary blobs for Medtronic (.pages) and
+        Libre (.aapPackets)
+      */
       let filenameBinary = 'binary-blob.json';
-      let blob = { settings:data.settings, pages:data.pages };
-      if(_.isArray(data.cbg_pages)) {
-        blob.cbg_pages = data.cbg_pages;
-      }
-      if(_.isArray(data.isig_pages)) {
-        blob.isig_pages = data.isig_pages;
-      }
-      let jsonDataBinary = JSON.stringify(blob, undefined, 4);
+      let jsonDataBinary = JSON.stringify(data, undefined, 4);
       let blobBinary = new Blob([jsonDataBinary], {type: 'text/json'});
       let dataHrefBinary = URL.createObjectURL(blobBinary);
       binary_link = (

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.5.3",
+  "version": "2.5.3-libre-decompress-bug.1",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.js",
   "author": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.5.3-libre-decompress-bug.2",
+  "version": "2.5.4",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.js",
   "author": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.5.3-libre-decompress-bug.1",
+  "version": "2.5.3-libre-decompress-bug.2",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.js",
   "author": {

--- a/app/utils/rollbar.js
+++ b/app/utils/rollbar.js
@@ -1,34 +1,38 @@
 /* global  __VERSION_SHA__ */
-
 import Rollbar from 'rollbar/dist/rollbar.umd';
 
-let rollbar = new Rollbar({
-    accessToken: '1843589282464f4facd43f794c8201a8',
-    captureUncaught: true,
-    enabled: process.env.NODE_ENV === 'production',
-    payload: {
-        environment: 'electron_renderer',
-        client: {
-          javascript: {
-            code_version: __VERSION_SHA__,
-            guess_uncaught_frames: true
+let rollbar;
+
+if (process.env.NODE_ENV === 'production') {
+
+  rollbar = new Rollbar({
+      accessToken: '1843589282464f4facd43f794c8201a8',
+      captureUncaught: true,
+      enabled: process.env.NODE_ENV === 'production',
+      payload: {
+          environment: 'electron_renderer',
+          client: {
+            javascript: {
+              code_version: __VERSION_SHA__,
+              guess_uncaught_frames: true
+            }
           }
-        }
-    },
-    // to deal with URI's as local filesystem paths, we use the "many domain" transform:
-    // https://rollbar.com/docs/source-maps/#using-source-maps-on-many-domains
-    transform: function(payload) {
-      var trace = payload.body.trace;
-      if (trace && trace.frames) {
-        for (var i = 0; i < trace.frames.length; i++) {
-          var filename = trace.frames[i].filename;
-          if (filename) {
-            trace.frames[i].filename = 'http://dynamichost/dist/bundle.js';
+      },
+      // to deal with URI's as local filesystem paths, we use the "many domain" transform:
+      // https://rollbar.com/docs/source-maps/#using-source-maps-on-many-domains
+      transform: function(payload) {
+        var trace = payload.body.trace;
+        if (trace && trace.frames) {
+          for (var i = 0; i < trace.frames.length; i++) {
+            var filename = trace.frames[i].filename;
+            if (filename) {
+              trace.frames[i].filename = 'http://dynamichost/dist/bundle.js';
+            }
           }
         }
       }
     }
-  }
-);
+  );
+};
 
 export default rollbar;

--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -637,7 +637,10 @@ api.errors = {};
 
 api.errors.log = function(error, message, properties) {
   api.log('GET /errors');
-  rollbar.error(error, error.debug);
+
+  if (rollbar) {
+    rollbar.error(error, error.debug);
+  }
   return tidepool.logAppError(error.debug, message, properties);
 };
 

--- a/lib/drivers/abbott/freeStyleLibreData.js
+++ b/lib/drivers/abbott/freeStyleLibreData.js
@@ -38,6 +38,7 @@ import {
   GLUCOSE_LO,
   CRC16_TABLE,
 } from './freeStyleLibreConstants';
+import FreeStyleLibreProtocol from './freeStyleLibreProtocol';
 
 const struct = structJs();
 
@@ -334,14 +335,15 @@ export default class FreeStyleLibreData {
   }
 
   handleCompressedDatabase(aapPacket) {
-    let decompressedBuffer = Buffer.alloc(1);
+    let decompressedBuffer = Buffer.alloc(0);
     let compressedOffset = 0;
 
-    // copy table ID
-    decompressedBuffer[0] = aapPacket.data[compressedOffset];
+    // get table ID
+    const tableId = aapPacket.data[compressedOffset];
     compressedOffset += 1;
 
-    while (compressedOffset < aapPacket.dataLength) {
+    const CRC32_LENGTH = 4;
+    while (compressedOffset < aapPacket.dataLength - CRC32_LENGTH) {
       const blockType = aapPacket.data[compressedOffset];
       compressedOffset += 1;
 
@@ -361,17 +363,24 @@ export default class FreeStyleLibreData {
         compressedOffset += blockLength;
       } else if (blockType === COMPRESSION_TYPE.ZERO_COMPRESSED) {
         decompressedBuffer = Buffer.concat([decompressedBuffer, Buffer.alloc(blockLength)]);
-        compressedOffset += blockLength;
       } else {
         debug('handleCompressedDatabase: failed to decompress!');
         return;
       }
     }
 
+    // validate CRC32 of uncompressed data
+    const readCrc32 = aapPacket.data.readUInt32LE(compressedOffset);
+    const calcCrc32 = FreeStyleLibreProtocol.calcCrc32(decompressedBuffer);
+    if (readCrc32 !== calcCrc32) {
+      debug('handleCompressedDatabase: invalid CRC32!');
+      return;
+    }
+
     // build decompressed AAP packet to process
     const decompressedAapPacket = {
       packetLength: (aapPacket.packetLength - aapPacket.dataLength) + decompressedBuffer.length,
-      data: decompressedBuffer,
+      data: Buffer.concat([Buffer.from([tableId]), decompressedBuffer]),
       dataLength: decompressedBuffer.length,
       opCode: OP_CODE.GET_DATABASE,
     };

--- a/lib/drivers/abbott/freeStyleLibreData.js
+++ b/lib/drivers/abbott/freeStyleLibreData.js
@@ -365,7 +365,7 @@ export default class FreeStyleLibreData {
         decompressedBuffer = Buffer.concat([decompressedBuffer, Buffer.alloc(blockLength)]);
       } else {
         debug('handleCompressedDatabase: failed to decompress!');
-        return;
+        throw new Error('Failed to decompress.');
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.5.3-libre-decompress-bug.1",
+  "version": "2.5.3-libre-decompress-bug.2",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.5.3",
+  "version": "2.5.3-libre-decompress-bug.1",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.5.3-libre-decompress-bug.2",
+  "version": "2.5.4",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",


### PR DESCRIPTION
I added the capability to save binary blobs for Libre and fixed the CLI tools not uploading due to Rollbar changes. @DorianScholz fixed the bug for an edge case that causes Libre driver to fail while decompressing data.