### PR TITLE
Fix bugs in extended boluses

### DIFF
--- a/lib/drivers/medtronic600/NGPHistoryParser.js
+++ b/lib/drivers/medtronic600/NGPHistoryParser.js
@@ -1521,13 +1521,13 @@ class NGPHistoryParser {
         event.timestamp.offset,
       );
       const bolus = this.cfg.builder.makeSquareBolus()
-        .with_duration(event.deliveredDuration * 1000)
+        .with_duration(event.deliveredDuration * sundial.SEC_TO_MSEC)
         .with_extended(event.deliveredAmount);
 
       if (event.programmedAmount !== event.deliveredAmount ||
         event.programmedDuration !== event.deliveredDuration) {
         bolus.with_expectedExtended(event.programmedAmount)
-          .with_expectedDuration(event.programmedDuration * 1000);
+          .with_expectedDuration(event.programmedDuration * sundial.SEC_TO_MSEC);
       }
 
       this.addTimeFields(bolus, beginTimestamp);
@@ -1557,7 +1557,7 @@ class NGPHistoryParser {
         const bolus = this.cfg.builder.makeDualBolus()
           .with_normal(event.deliveredAmount)
           .with_extended(matchingBolus.deliveredAmount)
-          .with_duration(matchingBolus.deliveredDuration * 1000);
+          .with_duration(matchingBolus.deliveredDuration * sundial.SEC_TO_MSEC);
 
         if (event.normalProgrammedAmount !== event.deliveredAmount) {
           bolus
@@ -1568,7 +1568,7 @@ class NGPHistoryParser {
           matchingBolus.programmedDuration !== matchingBolus.deliveredDuration) {
           bolus
             .with_expectedExtended(matchingBolus.squareProgrammedAmount)
-            .with_expectedDuration(matchingBolus.programmedDuration * 1000);
+            .with_expectedDuration(matchingBolus.programmedDuration * sundial.SEC_TO_MSEC);
         }
 
         this.addTimeFields(bolus, event.timestamp);

--- a/lib/drivers/medtronic600/NGPHistoryParser.js
+++ b/lib/drivers/medtronic600/NGPHistoryParser.js
@@ -558,11 +558,11 @@ class SquareBolusDeliveredEvent extends BolusDeliveredEvent {
   }
 
   get deliveredDuration() {
-    return this.eventData.readUInt16BE(0x18);
+    return this.eventData.readUInt16BE(0x18) * 60;
   }
 
   get programmedDuration() {
-    return this.eventData.readUInt16BE(0x16);
+    return this.eventData.readUInt16BE(0x16) * 60;
   }
 }
 
@@ -582,11 +582,11 @@ class DualBolusPartDeliveredEvent extends BolusDeliveredEvent {
   }
 
   get deliveredDuration() {
-    return this.eventData.readUInt16BE(0x1D);
+    return this.eventData.readUInt16BE(0x1D) * 60;
   }
 
   get programmedDuration() {
-    return this.eventData.readUInt16BE(0x1B);
+    return this.eventData.readUInt16BE(0x1B) * 60;
   }
 
   // See NGPUtil.NGPConstants.DUAL_BOLUS_PART
@@ -1521,13 +1521,13 @@ class NGPHistoryParser {
         event.timestamp.offset,
       );
       const bolus = this.cfg.builder.makeSquareBolus()
-        .with_duration(event.deliveredDuration * sundial.MIN_TO_MSEC)
+        .with_duration(event.deliveredDuration * 1000)
         .with_extended(event.deliveredAmount);
 
       if (event.programmedAmount !== event.deliveredAmount ||
         event.programmedDuration !== event.deliveredDuration) {
         bolus.with_expectedExtended(event.programmedAmount)
-          .with_expectedDuration(event.programmedDuration * sundial.MIN_TO_MSEC);
+          .with_expectedDuration(event.programmedDuration * 1000);
       }
 
       this.addTimeFields(bolus, beginTimestamp);
@@ -1557,7 +1557,7 @@ class NGPHistoryParser {
         const bolus = this.cfg.builder.makeDualBolus()
           .with_normal(event.deliveredAmount)
           .with_extended(matchingBolus.deliveredAmount)
-          .with_duration(matchingBolus.deliveredDuration * sundial.MIN_TO_MSEC);
+          .with_duration(matchingBolus.deliveredDuration * 1000);
 
         if (event.normalProgrammedAmount !== event.deliveredAmount) {
           bolus
@@ -1568,7 +1568,7 @@ class NGPHistoryParser {
           matchingBolus.programmedDuration !== matchingBolus.deliveredDuration) {
           bolus
             .with_expectedExtended(matchingBolus.squareProgrammedAmount)
-            .with_expectedDuration(matchingBolus.programmedDuration * sundial.MIN_TO_MSEC);
+            .with_expectedDuration(matchingBolus.programmedDuration * 1000);
         }
 
         this.addTimeFields(bolus, event.timestamp);

--- a/lib/drivers/medtronic600/NGPUtil.js
+++ b/lib/drivers/medtronic600/NGPUtil.js
@@ -35,7 +35,8 @@ class NGPTimestamp {
 
   toDate(timezone) {
     return sundial.applyTimezone(
-      new Date(NGPTimestamp.pumpBaseTimeMS + (this.rtc * 1000) + (this.offset * 1000)),
+      new Date(NGPTimestamp.pumpBaseTimeMS + (this.rtc * sundial.SEC_TO_MSEC) +
+      (this.offset * sundial.SEC_TO_MSEC)),
       timezone,
     );
   }


### PR DESCRIPTION
The code was previously returning extended bolus durations in minutes,
rather than seconds. Because we were using end events, rather than
begin events, this was causing errors in the recalculation of the event
start time.
Change the durations to be reported in seconds.
- Fixes https://trello.com/c/hZSvQjMZ