### PR TITLE
Fixes for 600-series calibrations

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.2.5-600series-qa.18",
+  "version": "2.2.5-600series-qa.19",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.js",
   "author": {

--- a/lib/drivers/medtronic600/NGPHistoryParser.js
+++ b/lib/drivers/medtronic600/NGPHistoryParser.js
@@ -423,10 +423,7 @@ class ClosedLoopBloodGlucoseReadingEvent extends NGPHistoryEvent {
   }
 
   get isCalibration() {
-    return (
-      this.bgReadingContext === NGPUtil.NGPConstants.BG_CONTEXT.BG_SENT_FOR_CALIB ||
-      this.bgReadingContext === NGPUtil.NGPConstants.BG_CONTEXT.ENTERED_IN_SENSOR_CALIB
-    );
+    return this.bgReadingContext === NGPUtil.NGPConstants.BG_CONTEXT.BG_SENT_FOR_CALIB;
   }
 }
 
@@ -1295,15 +1292,19 @@ class NGPHistoryParser {
       /* eslint-enable indent */
       let reading = null;
       if (event.isCalibration) {
-        reading = this.cfg.builder.makeDeviceEventCalibration()
+        const calibrationRecord = this.cfg.builder.makeDeviceEventCalibration()
           .with_units('mg/dL')
           .with_subType('calibration')
           .with_value(event.bgValue);
-      } else if (event instanceof ClosedLoopBloodGlucoseReadingEvent) {
+        this.addTimeFields(calibrationRecord, event.timestamp);
+        events.push(calibrationRecord.done());
+      }
+
+      if (event instanceof ClosedLoopBloodGlucoseReadingEvent) {
         // If it's a ClosedLoopBloodGlucoseReadingEvent that has been RECEIVED_FROM_RF,
         // we only create an SMBG based on the BG_READING_RECEIVED event, putting all
         // of the matching historic events into the annotations and payload.
-        // If its MANUALLY_ENTERED, create the SMBG, since they only have single contexts.
+        // If its MANUALLY_ENTERED, match the annotations off any of the ENTERED_* contexts
         if ((event.bgReadingOrigin === NGPUtil.NGPConstants.BG_ORIGIN.RECEIVED_FROM_RF &&
              event.bgReadingContext === NGPUtil.NGPConstants.BG_CONTEXT.BG_READING_RECEIVED) ||
             (event.bgReadingOrigin === NGPUtil.NGPConstants.BG_ORIGIN.MANUALLY_ENTERED &&
@@ -1314,7 +1315,6 @@ class NGPHistoryParser {
             .with_value(event.bgValue);
 
           // Add annotations for the different contexts
-          // This will only be the event itself if MANUALLY_ENTERED
           const bgContexts = {};
           for (const matchedBgReading of [...this.findMatchingClosedLoopBGReadings(event), event]) {
             const annotationText = _.chain(NGPUtil.NGPConstants.BG_CONTEXT)
@@ -1341,13 +1341,13 @@ class NGPHistoryParser {
           .with_value(event.bgValue);
       }
 
-      if (event.bgLinked && event.eventType === NGPHistoryEvent.EVENT_TYPE.BG_READING) {
-        reading.with_payload({
-          meterSerial: event.meterSerialNumber,
-        });
-      }
-
       if (reading !== null) {
+        if (event.bgLinked && event.eventType === NGPHistoryEvent.EVENT_TYPE.BG_READING) {
+          reading.with_payload({
+            meterSerial: event.meterSerialNumber,
+          });
+        }
+
         this.addTimeFields(reading, event.timestamp);
         events.push(reading.done());
       }

--- a/lib/drivers/medtronic600/NGPHistoryParser.js
+++ b/lib/drivers/medtronic600/NGPHistoryParser.js
@@ -999,10 +999,10 @@ class NGPHistoryParser {
   // This is here rather than in the simulator because the boluses both share a bolusNumber
   // as an identifier.
   findMatchingDualBolusEvent(bolus) {
-    const matchingBasalIndex = _.findIndex(this.events, event => event === bolus);
+    const matchingBolusIndex = _.findIndex(this.events, event => event === bolus);
 
     // It would be nice to use _.find here, but lodash 3.10.1 doesn't support fromIndex
-    for (let i = matchingBasalIndex; i < this.events.length; i++) {
+    for (let i = matchingBolusIndex; i < this.events.length; i++) {
       const event = this.events[i];
       if (event.eventType === NGPHistoryEvent.EVENT_TYPE.DUAL_BOLUS_PART_DELIVERED &&
         event.bolusPart === NGPUtil.NGPConstants.DUAL_BOLUS_PART.SQUARE_WAVE &&

--- a/lib/drivers/medtronic600/NGPHistoryParser.js
+++ b/lib/drivers/medtronic600/NGPHistoryParser.js
@@ -226,6 +226,8 @@ class NGPHistoryEvent {
         return new InsulinDeliveryStoppedEvent(this.eventData);
       case NGPHistoryEvent.EVENT_TYPE.INSULIN_DELIVERY_RESTARTED:
         return new InsulinDeliveryRestartedEvent(this.eventData);
+      case NGPHistoryEvent.EVENT_TYPE.CALIBRATION_COMPLETE:
+        return new CalibrationCompleteEvent(this.eventData);
       default:
         // Return a default NGPHistoryEvent
         return this;
@@ -349,6 +351,17 @@ class SensorGlucoseReadingsEvent extends NGPHistoryEvent {
   }
 }
 
+class CalibrationCompleteEvent extends NGPHistoryEvent {
+  get bgValue() {
+    // bgValue is always in mg/dL.
+    return this.eventData.readUInt16BE(0x0D);
+  }
+
+  get calFactor() {
+    return this.eventData.readUInt16BE(0x0B) / 100.0;
+  }
+}
+
 class BloodGlucoseReadingEvent extends NGPHistoryEvent {
   // Why is this string back to front, and space padded? ¯\_(ツ)_/¯
   get meterSerialNumber() {
@@ -385,10 +398,6 @@ class BloodGlucoseReadingEvent extends NGPHistoryEvent {
   get bgLinked() {
     return this.meterSerialNumber !== '';
   }
-
-  get isCalibration() {
-    return (this.bgSource === NGPUtil.NGPConstants.BG_SOURCE.SENSOR_CAL || this.calibrationFlag);
-  }
 }
 
 class ClosedLoopBloodGlucoseReadingEvent extends NGPHistoryEvent {
@@ -422,8 +431,11 @@ class ClosedLoopBloodGlucoseReadingEvent extends NGPHistoryEvent {
     return this.bgReadingOrigin === NGPUtil.NGPConstants.BG_ORIGIN.RECEIVED_FROM_RF;
   }
 
-  get isCalibration() {
-    return this.bgReadingContext === NGPUtil.NGPConstants.BG_CONTEXT.BG_SENT_FOR_CALIB;
+  isFirstReading() {
+    return (this.bgReadingOrigin === NGPUtil.NGPConstants.BG_ORIGIN.RECEIVED_FROM_RF &&
+          this.bgReadingContext === NGPUtil.NGPConstants.BG_CONTEXT.BG_READING_RECEIVED) ||
+        (this.bgReadingOrigin === NGPUtil.NGPConstants.BG_ORIGIN.MANUALLY_ENTERED &&
+          this.bgReadingContext >= NGPUtil.NGPConstants.BG_CONTEXT.ENTERED_IN_BG_ENTRY);
   }
 }
 
@@ -976,6 +988,18 @@ class NGPHistoryParser {
     return matchingReadings;
   }
 
+  findSmbgForCalibration(calibrationEvent) {
+    const calibrationIndex = _.findIndex(this.events, event => event === calibrationEvent);
+
+    return _.findLast(
+      this.events, item => (item.eventType === NGPHistoryEvent.EVENT_TYPE.BG_READING ||
+        (item.eventType === NGPHistoryEvent.EVENT_TYPE.CLOSED_LOOP_BG_READING &&
+          item.isFirstReading())) &&
+        item.bgValue === calibrationEvent.bgValue
+      , calibrationIndex,
+    );
+  }
+
   // This is here because a Temp Basal with a percentage requires the suppressed basal
   // to determine the rate. Though this could also be done in the simulator, we do it here
   // because the event is incomplete without the rate.
@@ -1284,6 +1308,23 @@ class NGPHistoryParser {
     return this;
   }
 
+  buildCalibrationRecords(events) {
+    for (const event of this.eventsOfType(NGPHistoryEvent.EVENT_TYPE.CALIBRATION_COMPLETE)) {
+      // In the Tidepool data model, calibration event timestamps match against the SMBG timestamp.
+      // The CALIBRATION_COMPLETE event tells us when the calibration was accepted.
+      // We need to find the matching SMBG to correctly set the timestamp.
+      const matchingSmbg = this.findSmbgForCalibration(event);
+      if (!_.isUndefined(matchingSmbg)) {
+        const calibrationRecord = this.cfg.builder.makeDeviceEventCalibration()
+          .with_units('mg/dL')
+          .with_subType('calibration')
+          .with_value(event.bgValue);
+        this.addTimeFields(calibrationRecord, matchingSmbg.timestamp);
+        events.push(calibrationRecord.done());
+      }
+    }
+  }
+
   buildBGRecords(events) {
     /* eslint-disable indent, eslint gets sad about the spread element */
     for (const event of [...this.eventsOfType(NGPHistoryEvent.EVENT_TYPE.BG_READING),
@@ -1291,24 +1332,13 @@ class NGPHistoryParser {
       ]) {
       /* eslint-enable indent */
       let reading = null;
-      if (event.isCalibration) {
-        const calibrationRecord = this.cfg.builder.makeDeviceEventCalibration()
-          .with_units('mg/dL')
-          .with_subType('calibration')
-          .with_value(event.bgValue);
-        this.addTimeFields(calibrationRecord, event.timestamp);
-        events.push(calibrationRecord.done());
-      }
 
       if (event instanceof ClosedLoopBloodGlucoseReadingEvent) {
         // If it's a ClosedLoopBloodGlucoseReadingEvent that has been RECEIVED_FROM_RF,
         // we only create an SMBG based on the BG_READING_RECEIVED event, putting all
         // of the matching historic events into the annotations and payload.
         // If its MANUALLY_ENTERED, match the annotations off any of the ENTERED_* contexts
-        if ((event.bgReadingOrigin === NGPUtil.NGPConstants.BG_ORIGIN.RECEIVED_FROM_RF &&
-             event.bgReadingContext === NGPUtil.NGPConstants.BG_CONTEXT.BG_READING_RECEIVED) ||
-            (event.bgReadingOrigin === NGPUtil.NGPConstants.BG_ORIGIN.MANUALLY_ENTERED &&
-             event.bgReadingContext >= NGPUtil.NGPConstants.BG_CONTEXT.ENTERED_IN_BG_ENTRY)) {
+        if (event.isFirstReading()) {
           reading = this.cfg.builder.makeSMBG()
             .with_units('mg/dL')
             .with_subType(event.bgLinked ? 'linked' : 'manual')

--- a/lib/drivers/medtronic600/medtronic600Driver.js
+++ b/lib/drivers/medtronic600/medtronic600Driver.js
@@ -2020,7 +2020,8 @@ module.exports = (config) => {
           .buildRewindRecords(events)
           .buildPrimeRecords(events)
           .buildCGMRecords(events)
-          .buildBGRecords(events);
+          .buildBGRecords(events)
+          .buildCalibrationRecords(events);
 
         events = _.sortBy(events, datum => datum.time);
 

--- a/lib/drivers/medtronic600/medtronic600Driver.js
+++ b/lib/drivers/medtronic600/medtronic600Driver.js
@@ -2050,7 +2050,7 @@ module.exports = (config) => {
 
       const sessionInfo = {
         delta: cfg.delta,
-        deviceTags: ['insulin-pump'],
+        deviceTags: ['insulin-pump', 'cgm'],
         deviceManufacturers: ['Medtronic'],
         deviceModel: _.replace(data.settings.pumpModel, 'MMT-', ''),
         deviceSerialNumber: data.settings.pumpSerial,

--- a/lib/drivers/medtronic600/medtronic600Driver.js
+++ b/lib/drivers/medtronic600/medtronic600Driver.js
@@ -1792,6 +1792,8 @@ module.exports = (config) => {
   const cfg = _.clone(config);
   const driver = new MM600SeriesDriver(cfg.deviceComms);
 
+  cfg.deviceTags = ['insulin-pump', 'cgm'];
+
   // REVIEW - discuss http://eslint.org/docs/rules/no-param-reassign...
   /* eslint no-param-reassign: [2, { props: false }] */
   /* eslint-disable no-unused-vars */
@@ -2050,7 +2052,7 @@ module.exports = (config) => {
 
       const sessionInfo = {
         delta: cfg.delta,
-        deviceTags: ['insulin-pump', 'cgm'],
+        deviceTags: cfg.deviceTags,
         deviceManufacturers: ['Medtronic'],
         deviceModel: _.replace(data.settings.pumpModel, 'MMT-', ''),
         deviceSerialNumber: data.settings.pumpSerial,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.2.5-600series-qa.18",
+  "version": "2.2.5-600series-qa.19",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",


### PR DESCRIPTION
The code was previously using flags in SMBG readings to determine if the
event is a calibration. However, these flags only indicated an _intent_
to calibrate, and not whether the calibration was successful or not,
leading to discrepancies with CareLink reports.
Now using the CALIBRATION_COMPLETE event to register `deviceEvent`s of
subType `calibration`.