### PR TITLE
[WIP] Comms error handling bug fix

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.2.5-600series-qa.20",
+  "version": "2.2.5-600series-qa.21",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.js",
   "author": {

--- a/lib/drivers/medtronic600/medtronic600Driver.js
+++ b/lib/drivers/medtronic600/medtronic600Driver.js
@@ -761,6 +761,9 @@ class MultipacketSession {
 
   addSegment(segment) {
     debug(`*** Got a Multipacket Segment: ${segment.packetNumber + 1} of ${this.packetsToFetch}, count: ${this.segmentsFilled + 1}`);
+    if (this.packetsToFetch === this.segmentsFilled) {
+      throw new InvalidStateError('Segments already filled. Should not be getting duplicates.');
+    }
 
     if (segment.segmentPayload != null) {
       // multiByteSegments don't always come back in a consecutive order.
@@ -988,6 +991,14 @@ class TransmitPacketRequest extends NGPRequest {
           this.ngpRetries += 1;
         }
         debug(`Multipacket retry: ${this.ngpRetries}`);
+        if (err instanceof TimeoutError) {
+          debug(`Got timeout waiting for message. On retry ${this.ngpRetries}`);
+        } else if (err instanceof InvalidMessageError) {
+          debug('Invalid Message');
+        } else {
+          debug('Unknown error occurred while reading Multipacket message.');
+          throw new InvalidStateError('Software Error. Contact Tidepool support.');
+        }
 
         if (this.ngpRetries > NGPRequest.MAX_RETRIES) {
           throw new RetryError('Exceeded retries for TransmitPacketRequest');
@@ -998,6 +1009,7 @@ class TransmitPacketRequest extends NGPRequest {
             if (nextMissingSegment !== undefined) {
               fetchMoreData = true;
               debug('Requesting missing packets');
+              this.ngpRetries = 0;
               await Timer.wait(TransmitPacketRequest.MULTIPACKET_ACK_DELAY_MS);
               await new MultipacketResendPacketsCommand(
                 this.pumpSession,
@@ -1008,15 +1020,6 @@ class TransmitPacketRequest extends NGPRequest {
               throw new InvalidStateError('Software Error. Contact Tidepool support.');
             }
           }
-        }
-
-        if (err instanceof TimeoutError) {
-          debug(`Got timeout waiting for message. On retry ${this.ngpRetries}`);
-        } else if (err instanceof InvalidMessageError) {
-          debug('Invalid Message');
-        } else {
-          debug('Unknown error occurred while reading Multipacket message.');
-          debug(err);
         }
       }
     }

--- a/lib/drivers/medtronic600/medtronic600Driver.js
+++ b/lib/drivers/medtronic600/medtronic600Driver.js
@@ -992,7 +992,7 @@ class TransmitPacketRequest extends NGPRequest {
         }
         debug(`Multipacket retry: ${this.ngpRetries}`);
         if (err instanceof TimeoutError) {
-          debug(`Got timeout waiting for message. On retry ${this.ngpRetries}`);
+          debug('Got timeout waiting for message.');
         } else if (err instanceof InvalidMessageError) {
           debug('Invalid Message');
         } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.2.5-600series-qa.20",
+  "version": "2.2.5-600series-qa.21",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",


### PR DESCRIPTION
Sets retries back to zero after issuing a "ResendPacketsCommand"
so that we don't spam the output command queue on the USB stick
with requests.
Doing so causes the stick to get buffer issues, and also means that we
double up on getting packets that we already had requested.

Also throw an InvalidStateError if we get packets we already received,
to make it really obvious that something is still not quite right.