### PR TITLE
Remove exact duplicate SMBGs

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.2.5-600series-qa.21",
+  "version": "2.2.5-600series-qa.22",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.js",
   "author": {

--- a/lib/drivers/medtronic600/medtronic600Simulator.js
+++ b/lib/drivers/medtronic600/medtronic600Simulator.js
@@ -282,12 +282,15 @@ class Medtronic600Simulator {
 
   smbg(event) {
     if (this.currSMBG != null && this.currSMBG.value === event.value) {
-      debug(
-        'Duplicate SMBG value (', event.value, ')', this.currSMBG.subType, this.currSMBG.time,
-        '/', event.subType, event.time,
-      );
+      debug(`Duplicate SMBG value (${event.value}) ${this.currSMBG.subType}: ${this.currSMBG.time} / ${event.subType}: ${event.time}`);
       const duration = Date.parse(event.time) - Date.parse(this.currSMBG.time);
-      if ((duration < (15 * sundial.MIN_TO_MSEC)) && (event.subType === 'manual') &&
+      if (_.isEqual(event, this.currSMBG)) {
+        // The BloodGlucoseReadingEvent event can be sent twice, if the second event
+        // is a calibration. Since we build calibrations from CalibrationCompleteEvent,
+        // we can delete the exact duplicate.
+        debug('Dropping exact duplicate');
+        return;
+      } else if ((duration < (15 * sundial.MIN_TO_MSEC)) && (event.subType === 'manual') &&
         (this.currSMBG.subType === 'linked')) {
         debug('Dropping duplicate manual value');
         return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.2.5-600series-qa.21",
+  "version": "2.2.5-600series-qa.22",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",

--- a/test/node/medtronic600/testMedtronic600Simulator.js
+++ b/test/node/medtronic600/testMedtronic600Simulator.js
@@ -107,13 +107,11 @@ describe('medtronic600Simulator.js', function() {
       expect(simulator.getEvents()).deep.equals([linked]);
     });
 
-    it('should not drop duplicate linked values', function() {
+    it('should drop exact duplicate linked values', function() {
       simulator.smbg(linked);
       simulator.smbg(linked);
 
-      const expectedSecond = _.cloneDeep(linked);
-
-      expect(simulator.getEvents()).deep.equals([linked, expectedSecond]);
+      expect(simulator.getEvents()).deep.equals([linked]);
     });
   });
 


### PR DESCRIPTION
This can occur for non ClosedLoop SMBGs when a calibration occurs,
causing the Daily view SMBG count to be incorrect.