### PR TITLE
Calculate suspend duration from pump RTC rather than device time

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.5.9-600series-qa.24",
+  "version": "2.5.9-600series-qa.25",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.js",
   "author": {

--- a/lib/drivers/medtronic600/NGPHistoryParser.js
+++ b/lib/drivers/medtronic600/NGPHistoryParser.js
@@ -1493,8 +1493,7 @@ class NGPHistoryParser {
         },
       };
 
-      const duration = resumeEvent == null ? 0 : resumeEvent.timestamp.toDate().valueOf() -
-        event.timestamp.toDate().valueOf();
+      const duration = resumeEvent == null ? 0 : resumeEvent.timestamp.rtc - event.timestamp.rtc;
       if (duration < 0) {
         throw new Error('Suspend event duration cannot be less than zero');
       }

--- a/lib/drivers/medtronic600/NGPHistoryParser.js
+++ b/lib/drivers/medtronic600/NGPHistoryParser.js
@@ -978,10 +978,12 @@ class NGPHistoryParser {
     while (this.events.length > eventIndex &&
       this.events[eventIndex].timestamp.rtc < bgReadingEvent.timestamp.rtc + 900) {
       if (this.events[eventIndex].eventType ===
-        NGPHistoryEvent.EVENT_TYPE.CLOSED_LOOP_BG_READING &&
-        this.events[eventIndex].bgValue === bgReadingEvent.bgValue
-      ) {
-        matchingReadings.push(this.events[eventIndex]);
+        NGPHistoryEvent.EVENT_TYPE.CLOSED_LOOP_BG_READING) {
+        if (this.events[eventIndex].isFirstReading()) {
+          break;
+        } else if (this.events[eventIndex].bgValue === bgReadingEvent.bgValue) {
+          matchingReadings.push(this.events[eventIndex]);
+        }
       }
       eventIndex += 1;
     }

--- a/lib/drivers/medtronic600/medtronic600Driver.js
+++ b/lib/drivers/medtronic600/medtronic600Driver.js
@@ -2028,6 +2028,15 @@ module.exports = (config) => {
 
         events = _.sortBy(events, datum => datum.time);
 
+        // If the delta information hasn't been defined after reading the pump, use the last event
+        // date, if in debug mode. This can happen when using the blob_loader.
+        if (process.env.DEBUG_ERROR === 'true' && _.isUndefined(cfg.delta)) {
+          _.merge(
+            cfg,
+            { delta: { dataEnd: sundial.parseFromFormat(events[events.length - 1].deviceTime) } },
+          ); // Will form part of upload record
+        }
+
         const simulator = new Medtronic600Simulator({
           settings: data.settings,
           tzoUtil: cfg.tzoUtil,

--- a/lib/drivers/medtronic600/medtronic600Simulator.js
+++ b/lib/drivers/medtronic600/medtronic600Simulator.js
@@ -475,9 +475,6 @@ class Medtronic600Simulator {
               break;
             }
           }
-          if (suppressedBasal == null) {
-            throw new Error('Could not find previous suppressed basal');
-          }
         } else {
           suppressedBasal = null;
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.5.9-600series-qa.24",
+  "version": "2.5.9-600series-qa.25",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",


### PR DESCRIPTION
The Real Time Clock (RTC) of the pump is always advancing, making it a
reliable mechanism to determine duration between events, as opposed to
the pump's display time.