### PR TITLE
 Fix suspend duration bug introduced in PR#615

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.5.9-600series-qa.25",
+  "version": "2.5.9-600series-qa.26",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.js",
   "author": {

--- a/lib/drivers/medtronic600/NGPHistoryParser.js
+++ b/lib/drivers/medtronic600/NGPHistoryParser.js
@@ -1520,7 +1520,8 @@ class NGPHistoryParser {
         },
       };
 
-      const duration = resumeEvent == null ? 0 : resumeEvent.timestamp.rtc - event.timestamp.rtc;
+      const duration = resumeEvent == null ? 0 :
+        (resumeEvent.timestamp.rtc - event.timestamp.rtc) * 1000;
       if (duration < 0) {
         throw new Error('Suspend event duration cannot be less than zero');
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.5.9-600series-qa.25",
+  "version": "2.5.9-600series-qa.26",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",

--- a/test/node/medtronic600/testNGPHistoryParser.js
+++ b/test/node/medtronic600/testNGPHistoryParser.js
@@ -103,4 +103,36 @@ describe('NGPHistoryParser.js', () => {
       expect(events[0]).to.deep.equal(expected);
     });
   });
+
+  describe('suspend', () => {
+    it('should calculate the correct suspend duration', () => {
+      const suspendData = '1e000c81ee52f6a092886601';
+      const resumeData = '1f000c81ee56b5a092886602';
+      const historyParser = new NGPHistoryParser(cfg, settings, [suspendData + resumeData]);
+      const events = [];
+
+      const expected = {
+        time: '2018-05-05T21:15:08.000Z',
+        timezoneOffset: 0,
+        clockDriftOffset: 0,
+        conversionOffset: 0,
+        deviceTime: '2018-05-05T21:15:08',
+        type: 'deviceEvent',
+        subType: 'status',
+        status: 'suspended',
+        reason: { suspended: 'automatic', resumed: 'manual' },
+        duration: 959000,
+        payload: {
+          suspended: { cause: 'Alarm suspend' },
+          resumed: { cause: 'User cleared alarm' },
+          logIndices: [2179879670],
+        },
+        index: 2179879670,
+        jsDate: new Date('2018-05-05T21:15:08.000Z'),
+      };
+
+      historyParser.buildSuspendResumeRecords(events);
+      expect(events[0]).to.deep.equal(expected);
+    });
+  });
 });


### PR DESCRIPTION
#615 was made to fix a bug that could happen due to a time change.
However, it introduced a bug where the duration was set in seconds,
rather than in milliseconds.
Fix this introduced bug, as well as making a unit test to protect
against the failure again.