### PR TITLE
Ultra 2 comms fix

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.5.9",
+  "version": "2.5.9-ultra-fix.1",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.js",
   "author": {

--- a/lib/drivers/onetouch/oneTouchUltra2.js
+++ b/lib/drivers/onetouch/oneTouchUltra2.js
@@ -57,6 +57,7 @@ module.exports = function (config) {
   var DMTimeFormat = DM.concat('DMST?'); // hex code '\x44\x4d\x53\x54\x3f'
   var CR = 0x0D;
   var LF = 0x0A;
+  var LISTEN_INTERVAL = 50; // don't set this too low to be kind to the cpu
 
   function buildDateTime(date, time) {
     var fmt = 'MM/DD/YY HH:mm:ss';
@@ -140,8 +141,7 @@ module.exports = function (config) {
 
         callback(null, pkt);
       }
-
-    }, 500);     // spin on this one not so quickly
+    }, LISTEN_INTERVAL);
   };
 
   var otu2CommandResponse = function (command, progress, callback) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.5.9",
+  "version": "2.5.9-ultra-fix.1",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",


### PR DESCRIPTION
A number of Rollbar reports indicate that the device header is sometimes missing when retrieving data from the meter. This PR decreases the listen interval to make sure that we're not missing packets being received. I'm not sure that this will fix it, but it's a start.