### PR TITLE
Handle the last basal event being a temp basal start

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.5.11-600series-qa.29",
+  "version": "2.5.11-600series-qa.30",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.js",
   "author": {

--- a/lib/drivers/medtronic600/NGPHistoryParser.js
+++ b/lib/drivers/medtronic600/NGPHistoryParser.js
@@ -211,6 +211,8 @@ class NGPHistoryEvent {
         return new ClosedLoopTransitionEvent(this.eventData);
       case NGPHistoryEvent.EVENT_TYPE.BASAL_SEGMENT_START:
         return new BasalSegmentStartEvent(this.eventData);
+      case NGPHistoryEvent.EVENT_TYPE.TEMP_BASAL_PROGRAMMED:
+        return new TempBasalProgrammedEvent(this.eventData);
       case NGPHistoryEvent.EVENT_TYPE.TEMP_BASAL_COMPLETE:
         return new TempBasalCompleteEvent(this.eventData);
       case NGPHistoryEvent.EVENT_TYPE.REWIND:
@@ -480,6 +482,34 @@ class BasalSegmentStartEvent extends NGPHistoryEvent {
   }
 }
 
+class TempBasalProgrammedEvent extends NGPHistoryEvent {
+  get rate() {
+    return this.eventData.readUInt32BE(0x0D) / 10000.0;
+  }
+
+  get percentageOfRate() {
+    return this.eventData[0x11];
+  }
+
+  get expectedDuration() {
+    return this.eventData.readUInt16BE(0x12) * sundial.MIN_TO_MSEC;
+  }
+
+  // See NGPUtil.NGPConstants.TEMP_BASAL_TYPE
+  get type() {
+    return this.eventData[0x0C];
+  }
+
+  // See NGPUtil.NGPConstants.TEMP_BASAL_PRESET_NAME
+  get preset() {
+    return this.eventData[0x0B];
+  }
+
+  get presetName() {
+    return NGPUtil.NGPConstants.TEMP_BASAL_PRESET_NAME[this.preset];
+  }
+}
+
 class TempBasalCompleteEvent extends NGPHistoryEvent {
   get rate() {
     return this.eventData.readUInt32BE(0x0D) / 10000.0;
@@ -490,7 +520,10 @@ class TempBasalCompleteEvent extends NGPHistoryEvent {
   }
 
   get duration() {
-    return this.eventData.readUInt16BE(0x12) * 60;
+    if (this.size < 23) {
+      return this.eventData.readUInt16BE(0x12) * sundial.MIN_TO_MSEC;
+    }
+    return this.eventData.readUInt16BE(0x15) * sundial.MIN_TO_MSEC;
   }
 
   get canceled() {
@@ -503,6 +536,7 @@ class TempBasalCompleteEvent extends NGPHistoryEvent {
     return this.eventData[0x0C];
   }
 
+  // See NGPUtil.NGPConstants.TEMP_BASAL_PRESET_NAME
   get preset() {
     return this.eventData[0x0B];
   }
@@ -1481,6 +1515,9 @@ class NGPHistoryParser {
   }
 
   buildTempBasalRecords(events) {
+    // Build temp basal records from the TEMP_BASAL_COMPLETE, since that event type contains
+    // more detail, such as actual duration, and if the event was delivered as scheduled, or
+    // cancelled.
     for (const event of this.eventsOfType(NGPHistoryEvent.EVENT_TYPE.TEMP_BASAL_COMPLETE)) {
       // Since we're using the TEMP_BASAL_COMPLETE event, we need to get the Device timestamp
       // for the *beginning* of the event.
@@ -1492,7 +1529,8 @@ class NGPHistoryParser {
       if (!_.isUndefined(startTempBasal) && !_.isUndefined(suppressedBasal)) {
         const basal = this.cfg.builder.makeTempBasal()
           .with_rate(event.rate)
-          .with_duration(event.duration * sundial.SEC_TO_MSEC)
+          .with_duration(event.duration)
+          .with_expectedDuration(startTempBasal.expectedDuration)
           .set('suppressed', {
             type: 'basal',
             deliveryType: 'scheduled',
@@ -1518,6 +1556,43 @@ class NGPHistoryParser {
 
         events.push(basal);
       }
+    }
+
+    // Check if the last temp basal event is a start event. If we have a TEMP_BASAL_PROGRAMMED
+    // without a TEMP_BASAL_COMPLETE, we should synthesize the temp basal event with what we
+    // know, and it will be overwritten in the next upload that contains the corresponding
+    // TEMP_BASAL_COMPLETE event.
+    const lastTempBasalEvent =
+      this.eventsOfTypeReverse(
+        NGPHistoryEvent.EVENT_TYPE.TEMP_BASAL_PROGRAMMED,
+        NGPHistoryEvent.EVENT_TYPE.TEMP_BASAL_COMPLETE,
+      ).next().value;
+    if (lastTempBasalEvent &&
+      lastTempBasalEvent.eventType === NGPHistoryEvent.EVENT_TYPE.TEMP_BASAL_PROGRAMMED) {
+      const suppressedBasal = this.findSuppressedBasal(lastTempBasalEvent);
+      const basal = this.cfg.builder.makeTempBasal()
+        .with_rate(lastTempBasalEvent.rate)
+        .with_expectedDuration(lastTempBasalEvent.expectedDuration)
+        .with_duration(lastTempBasalEvent.expectedDuration)
+        .set('suppressed', {
+          type: 'basal',
+          deliveryType: 'scheduled',
+          rate: suppressedBasal.rate,
+          scheduleName: suppressedBasal.patternName,
+        });
+
+      // We need to find the normal rate here to calculate event.rate, because
+      // if it's a PERCENT record, event.rate will be 0.
+      if (lastTempBasalEvent.type === NGPUtil.NGPConstants.TEMP_BASAL_TYPE.PERCENT) {
+        basal
+          .with_percent(lastTempBasalEvent.percentageOfRate / 100.0)
+          .with_rate(suppressedBasal.rate * (lastTempBasalEvent.percentageOfRate / 100.0));
+      }
+
+      this.addTimeFields(basal, lastTempBasalEvent.timestamp);
+      annotate.annotateEvent(basal, 'basal/unknown-duration');
+
+      events.push(basal);
     }
 
     return this;
@@ -1594,6 +1669,8 @@ class NGPHistoryParser {
       // when it finished. Even for a normal basal, delivery for 100g of carbs can
       // take a few minutes.
       const beginTimestamp = this.getBeginTimestampForBolusDelivered(event);
+      // If we didn't find a matching start event, don't upload the bolus. Either we've already
+      // uploaded it in the past, or we just don't have enough data to upload it.
       if (!_.isUndefined(beginTimestamp)) {
         const bolus = this.cfg.builder.makeNormalBolus()
           .with_normal(event.deliveredAmount);
@@ -1624,6 +1701,8 @@ class NGPHistoryParser {
     for (const event of this.eventsOfType(NGPHistoryEvent.EVENT_TYPE.SQUARE_BOLUS_DELIVERED)) {
       // We need to get the Device timestamp for the *beginning* of the event.
       const beginTimestamp = this.getBeginTimestampForBolusDelivered(event);
+      // If we didn't find a matching start event, don't upload the bolus. Either we've already
+      // uploaded it in the past, or we just don't have enough data to upload it.
       if (!_.isUndefined(beginTimestamp)) {
         const bolus = this.cfg.builder.makeSquareBolus()
           .with_duration(event.deliveredDuration * sundial.SEC_TO_MSEC)
@@ -1657,6 +1736,8 @@ class NGPHistoryParser {
     for (const event of this.eventsOfType(NGPHistoryEvent.EVENT_TYPE.DUAL_BOLUS_PART_DELIVERED)) {
       // We need to get the Device timestamp for the *beginning* of the event.
       const beginTimestamp = this.getBeginTimestampForBolusDelivered(event);
+      // If we didn't find a matching start event, don't upload the bolus. Either we've already
+      // uploaded it in the past, or we just don't have enough data to upload it.
       if (!_.isUndefined(beginTimestamp)) {
         // There are 2 events for a dual bolus delivery - we only react to the first part,
         // and in processing that, find the second part to build the TP data.

--- a/lib/drivers/medtronic600/NGPUtil.js
+++ b/lib/drivers/medtronic600/NGPUtil.js
@@ -157,7 +157,7 @@ class NGPConstants {
 
   static get TEMP_BASAL_PRESET_NAME() {
     return [
-      'Not Preset',
+      'Manual',
       'Temp 1',
       'Temp 2',
       'Temp 3',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.5.11-600series-qa.29",
+  "version": "2.5.11-600series-qa.30",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",


### PR DESCRIPTION
Previously when the upload happened in the middle of a temp basal
(ie temp basal hadn't completed), the data was uploaded incorrectly
as a regular scheduled basal, meaning that for the next upload, the
basals would be overlayed, rather than replaced.
This commit fixes that bug.
* Fixes https://trello.com/c/fk1vqCBz