### PR TITLE
Remove CCITT checksum from ComD payload

### DIFF
--- a/lib/drivers/medtronic600/medtronic600Driver.js
+++ b/lib/drivers/medtronic600/medtronic600Driver.js
@@ -703,6 +703,8 @@ class TransmitPacketResponse extends NGPResponse {
     super(payload, pumpSession);
 
     // Decrypt response and write it to another member
+    // TODO: These aren't necessarily bad messages. It looks like some of them
+    // could just be pings when the pump is busy processing data.
     const payloadLength =
       MinimedMessage.ENVELOPE_SIZE + this.payload[0x22] + NGPMessage.CHECKSUM_SIZE;
     if (payloadLength < 57) {
@@ -725,15 +727,16 @@ class TransmitPacketResponse extends NGPResponse {
       throw new ChecksumError(expectedChecksum, calculatedChecksum);
     }
 
-    this.decryptedPayload = decryptedPayload;
+    // The CCITT checksum does not form part of the comDPayload
+    this.comDPayload = decryptedPayload.slice(0, -2);
   }
 
   get comDCommand() {
-    return this.decryptedPayload.readUInt16BE(0x01);
+    return this.comDPayload.readUInt16BE(0x01);
   }
 
   get sequenceNumber() {
-    return this.decryptedPayload[0x00];
+    return this.comDPayload[0x00];
   }
 }
 
@@ -1006,7 +1009,7 @@ class TransmitPacketRequest extends NGPRequest {
           case TransmitPacketRequest.COM_D_COMMAND.INITIATE_MULTIPACKET_TRANSFER:
           {
             fetchMoreData = true;
-            this.multipacketSession = new MultipacketSession(response.decryptedPayload);
+            this.multipacketSession = new MultipacketSession(response.comDPayload);
             // Acknowledge that we're ready to start receiving data.
             await Timer.wait(TransmitPacketRequest.SEND_DELAY_MS);
             await new AckCommand(this.pumpSession, response.comDCommand).send(hidDevice);
@@ -1020,7 +1023,7 @@ class TransmitPacketRequest extends NGPRequest {
             if (this.multipacketSession.payloadComplete()) {
               debug('*** Multisession Complete');
               fetchMoreData = false;
-              response.decryptedPayload = this.multipacketSession.sessionPayload;
+              response.comDPayload = this.multipacketSession.sessionPayload;
               await Timer.wait(TransmitPacketRequest.SEND_DELAY_MS);
               await new AckCommand(
                 this.pumpSession,
@@ -1046,10 +1049,9 @@ class TransmitPacketRequest extends NGPRequest {
         if (err instanceof TimeoutError) {
           debug('Got timeout waiting for message.');
         } else if (err instanceof InvalidMessageError) {
-          debug('Invalid Message');
+          debug(`Invalid Message:\n${err}`);
         } else {
-          debug('Unknown error occurred while reading Multipacket message.');
-          debug(err);
+          debug(`Unknown error occurred while reading Multipacket message:\n${err}`);
           throw new InvalidStateError('Software Error. Contact support@tidepool.org.');
         }
 
@@ -1113,11 +1115,11 @@ class AckCommand extends TransmitPacketRequest {
 
 class NakResponse extends TransmitPacketResponse {
   get comDCommand() {
-    return this.decryptedPayload.readUInt16BE(0x03);
+    return this.comDPayload.readUInt16BE(0x03);
   }
 
   get nakCode() {
-    return this.decryptedPayload[0x04];
+    return this.comDPayload[0x04];
   }
 }
 
@@ -1138,11 +1140,11 @@ class MultipacketResendPacketsCommand extends TransmitPacketRequest {
 
 class MultipacketSegmentResponse extends TransmitPacketResponse {
   get packetNumber() {
-    return this.decryptedPayload.readUInt16BE(0x03);
+    return this.comDPayload.readUInt16BE(0x03);
   }
 
   get segmentPayload() {
-    return this.decryptedPayload.slice(0x05, this.decryptedPayload.length - 2);
+    return this.comDPayload.slice(0x05);
   }
 }
 
@@ -1169,11 +1171,11 @@ class HighSpeedModeCommand extends TransmitPacketRequest {
 
 class PumpTimeResponse extends TransmitPacketResponse {
   get time() {
-    if (!this.decryptedPayload[0x03]) {
+    if (!this.comDPayload[0x03]) {
       throw new Error('Device clock not set');
     }
 
-    return NGPUtil.NGPTimestamp.fromBuffer(this.decryptedPayload.slice(0x04, 0x0C));
+    return NGPUtil.NGPTimestamp.fromBuffer(this.comDPayload.slice(0x04, 0x0C));
   }
 }
 
@@ -1189,7 +1191,7 @@ class PumpTimeCommand extends TransmitPacketRequest {
 class TimeSyncDoneCommand extends TransmitPacketRequest {
   constructor(pumpSession, pumpTimeResponse) {
     const params = Buffer.alloc(9);
-    params.write(pumpTimeResponse.decryptedPayload.slice(0x03, 0x0C).toString('hex'), 0x00, 9, 'hex');
+    params.write(pumpTimeResponse.comDPayload.slice(0x03, 0x0C).toString('hex'), 0x00, 9, 'hex');
     super(pumpSession, TransmitPacketRequest.COM_D_COMMAND.TIME_SYNC_DONE_RESPONSE, params);
   }
 }
@@ -1205,11 +1207,11 @@ class EndNodeDeviceInitializationResponse extends TransmitPacketRequest {
 
 class PumpStatusResponse extends TransmitPacketResponse {
   get pumpState() {
-    return this.decryptedPayload[0x03];
+    return this.comDPayload[0x03];
   }
 
   get activeBasalPattern() {
-    return this.decryptedPayload[0x1A];
+    return this.comDPayload[0x1A];
   }
 
   get isPumpActive() {
@@ -1231,16 +1233,16 @@ class BolusWizardBGTargetsResponse extends TransmitPacketResponse {
   get targets() {
     const targets = [];
     // Bytes 0x03 and 0x04 are a CCITT checksum of the target bytes.
-    const numItems = this.decryptedPayload[0x05];
+    const numItems = this.comDPayload[0x05];
 
     for (let i = 0; i < numItems; i++) {
-      const high = this.decryptedPayload.readUInt16BE(0x06 + (i * 9)); // in mg/dL
-      // this.decryptedPayload.readUInt16BE(0x08 + (i * 9)) / 10.0; // in mmol/L
-      const low = this.decryptedPayload.readUInt16BE(0x0A + (i * 9)); // in mg/dL
-      // this.decryptedPayload.readUInt16BE(0x0C + (i * 9)) / 10.0; // in mmol/L
+      const high = this.comDPayload.readUInt16BE(0x06 + (i * 9)); // in mg/dL
+      // this.comDPayload.readUInt16BE(0x08 + (i * 9)) / 10.0; // in mmol/L
+      const low = this.comDPayload.readUInt16BE(0x0A + (i * 9)); // in mg/dL
+      // this.comDPayload.readUInt16BE(0x0C + (i * 9)) / 10.0; // in mmol/L
 
       targets.push({
-        start: this.decryptedPayload[0x0E + (i * 9)] * 30 * sundial.MIN_TO_MSEC,
+        start: this.comDPayload[0x0E + (i * 9)] * 30 * sundial.MIN_TO_MSEC,
         high,
         low,
       });
@@ -1263,14 +1265,14 @@ class BolusWizardCarbRatiosResponse extends TransmitPacketResponse {
   get ratios() {
     const ratios = [];
     // Bytes 0x03 and 0x04 are a CCITT checksum of the ratios bytes.
-    const numItems = this.decryptedPayload[0x05];
+    const numItems = this.comDPayload[0x05];
 
     for (let i = 0; i < numItems; i++) {
-      const amount = (this.decryptedPayload.readUInt32BE(0x06 + (i * 9))) / 10;
+      const amount = (this.comDPayload.readUInt32BE(0x06 + (i * 9))) / 10;
       // There is another UInt32BE after the amount, which is always 0
 
       ratios.push({
-        start: this.decryptedPayload[0x0E + (i * 9)] * 30 * sundial.MIN_TO_MSEC,
+        start: this.comDPayload[0x0E + (i * 9)] * 30 * sundial.MIN_TO_MSEC,
         amount,
       });
     }
@@ -1292,14 +1294,14 @@ class BolusWizardSensitivityFactorsResponse extends TransmitPacketResponse {
   get factors() {
     const factors = [];
     // Bytes 0x03 and 0x04 are a CCITT checksum of the sentivities' bytes.
-    const numItems = this.decryptedPayload[0x05];
+    const numItems = this.comDPayload[0x05];
 
     for (let i = 0; i < numItems; i++) {
-      const amount = this.decryptedPayload.readUInt16BE(0x06 + (i * 5)); // in mg/dL
-      // this.decryptedPayload.readUInt16BE(0x08 + (i * 5)) / 10.0; // in mmol/L
+      const amount = this.comDPayload.readUInt16BE(0x06 + (i * 5)); // in mg/dL
+      // this.comDPayload.readUInt16BE(0x08 + (i * 5)) / 10.0; // in mmol/L
 
       factors.push({
-        start: this.decryptedPayload[0x0A + (i * 5)] * 30 * sundial.MIN_TO_MSEC,
+        start: this.comDPayload[0x0A + (i * 5)] * 30 * sundial.MIN_TO_MSEC,
         amount,
       });
     }
@@ -1341,7 +1343,7 @@ class DeviceCharacteristicsResponse extends TransmitPacketResponse {
   constructor(payload, pumpSession) {
     super(payload, pumpSession);
 
-    if (this.decryptedPayload.length < 13) {
+    if (this.comDPayload.length < 13) {
       throw new InvalidMessageError('Received invalid DeviceCharacteristicsResponse message.');
     }
   }
@@ -1363,67 +1365,67 @@ class DeviceCharacteristicsResponse extends TransmitPacketResponse {
   }
 
   get serial() {
-    return this.decryptedPayload.slice(0x03, 0x0D).toString();
+    return this.comDPayload.slice(0x03, 0x0D).toString();
   }
 
   get MAC() {
-    return this.decryptedPayload.slice(0x0D, 0x15).toString('binary');
+    return this.comDPayload.slice(0x0D, 0x15).toString('binary');
   }
 
   get comDVersion() {
-    const majorNumber = this.decryptedPayload.readUInt8(0x15);
-    const minorNumber = this.decryptedPayload.readUInt8(0x16);
-    const alpha = String.fromCharCode(65 + this.decryptedPayload.readUInt8(0x17));
+    const majorNumber = this.comDPayload.readUInt8(0x15);
+    const minorNumber = this.comDPayload.readUInt8(0x16);
+    const alpha = String.fromCharCode(65 + this.comDPayload.readUInt8(0x17));
     return `${majorNumber}.${minorNumber}${alpha}`;
   }
 
   get telDVersion() {
     /* eslint-disable no-bitwise */
-    const majorNumber = this.decryptedPayload.readUInt8(0x18) >> 3;
-    const minorNumber = (this.decryptedPayload.readUInt8(0x19) >> 5) |
-      ((this.decryptedPayload.readUInt8(0x18) << 29) >> 26);
-    const alpha = String.fromCharCode(64 + ((this.decryptedPayload.readUInt8(0x19) << 3) >> 3));
+    const majorNumber = this.comDPayload.readUInt8(0x18) >> 3;
+    const minorNumber = (this.comDPayload.readUInt8(0x19) >> 5) |
+      ((this.comDPayload.readUInt8(0x18) << 29) >> 26);
+    const alpha = String.fromCharCode(64 + ((this.comDPayload.readUInt8(0x19) << 3) >> 3));
     /* eslint-enable no-bitwise */
     return `${majorNumber}.${minorNumber}${alpha}`;
   }
 
   get model() {
-    const modelMajorNumber = this.decryptedPayload.readUInt16BE(0x1A);
-    const modelMinorNumber = this.decryptedPayload.readUInt16BE(0x1C);
+    const modelMajorNumber = this.comDPayload.readUInt16BE(0x1A);
+    const modelMinorNumber = this.comDPayload.readUInt16BE(0x1C);
     return `${modelMajorNumber}.${modelMinorNumber}`;
   }
 
   get pingInterval() {
-    return this.decryptedPayload.readUInt16BE(0x1E);
+    return this.comDPayload.readUInt16BE(0x1E);
   }
 
   get syncInterval() {
-    return this.decryptedPayload.readUInt16BE(0x20);
+    return this.comDPayload.readUInt16BE(0x20);
   }
 
   get maxMessageSize() {
-    return this.decryptedPayload.readUInt32BE(0x22);
+    return this.comDPayload.readUInt32BE(0x22);
   }
 
   get deviceClassEnum() {
-    return this.decryptedPayload.readUInt8(0x26);
+    return this.comDPayload.readUInt8(0x26);
   }
 
   get deviceClassVersionEnum() {
-    return this.decryptedPayload.readUInt8(0x27);
+    return this.comDPayload.readUInt8(0x27);
   }
 
   get firmwareVersion() {
-    const majorNumber = this.decryptedPayload.readUInt8(0x29);
-    const minorNumber = this.decryptedPayload.readUInt8(0x2A);
-    const alpha = String.fromCharCode(this.decryptedPayload.readUInt8(0x2B));
+    const majorNumber = this.comDPayload.readUInt8(0x29);
+    const minorNumber = this.comDPayload.readUInt8(0x2A);
+    const alpha = String.fromCharCode(this.comDPayload.readUInt8(0x2B));
     return `${majorNumber}.${minorNumber}${alpha}`;
   }
 
   get motorAppVersion() {
-    const majorNumber = this.decryptedPayload.readUInt8(0x2C);
-    const minorNumber = this.decryptedPayload.readUInt8(0x2D);
-    const alpha = String.fromCharCode(this.decryptedPayload.readUInt8(0x2E));
+    const majorNumber = this.comDPayload.readUInt8(0x2C);
+    const minorNumber = this.comDPayload.readUInt8(0x2D);
+    const alpha = String.fromCharCode(this.comDPayload.readUInt8(0x2E));
     return `${majorNumber}.${minorNumber}${alpha}`;
   }
 
@@ -1431,7 +1433,7 @@ class DeviceCharacteristicsResponse extends TransmitPacketResponse {
   // and updating NGPHistoryParser:buildSettingsRecords()
   get units() {
     // See NGPUtil.NGPConstants.BG_UNITS
-    return this.decryptedPayload.readUInt8(0x35);
+    return this.comDPayload.readUInt8(0x35);
   }
 }
 
@@ -1454,7 +1456,7 @@ class DeviceStringResponse extends TransmitPacketResponse {
   constructor(payload, pumpSession) {
     super(payload, pumpSession);
 
-    if (this.decryptedPayload.length < 96) {
+    if (this.comDPayload.length < 94) {
       throw new InvalidMessageError('Received invalid DeviceStringResponse message.');
     }
   }
@@ -1474,19 +1476,19 @@ class DeviceStringResponse extends TransmitPacketResponse {
   }
 
   get MAC() {
-    return this.decryptedPayload.slice(0x03, 0x0B).toString('binary');
+    return this.comDPayload.slice(0x03, 0x0B).toString('binary');
   }
 
   get stringType() {
-    return this.decryptedPayload.readUInt16BE(0x0B);
+    return this.comDPayload.readUInt16BE(0x0B);
   }
 
   get language() {
-    return this.decryptedPayload.readUInt8(0x0D);
+    return this.comDPayload.readUInt8(0x0D);
   }
 
   get string() {
-    const deviceStringUtf16 = this.decryptedPayload.slice(0x0E, 0x5E);
+    const deviceStringUtf16 = this.comDPayload.slice(0x0E, 0x5E);
     // We have to strip the nulls ourselves, because the payload doesn't give us string size.
     return _.replace(iconv.decode(deviceStringUtf16, 'utf16-be'), /\0/g, '');
   }
@@ -1509,12 +1511,12 @@ class ReadBasalPatternResponse extends TransmitPacketResponse {
   get schedule() {
     const schedule = [];
     // Byte 0x03 is the Basal Pattern number
-    const numItems = this.decryptedPayload[0x04];
+    const numItems = this.comDPayload[0x04];
 
     for (let i = 0; i < numItems; i++) {
       schedule.push({
-        start: this.decryptedPayload[0x09 + (i * 5)] * 30 * sundial.MIN_TO_MSEC,
-        rate: (this.decryptedPayload.readUInt32BE(0x05 + (i * 5)) / 10000),
+        start: this.comDPayload[0x09 + (i * 5)] * 30 * sundial.MIN_TO_MSEC,
+        rate: (this.comDPayload.readUInt32BE(0x05 + (i * 5)) / 10000),
       });
     }
 
@@ -1533,15 +1535,15 @@ class ReadBasalPatternCommand extends TransmitPacketRequest {
 
 class ReadHistoryInfoResponse extends TransmitPacketResponse {
   get historySize() {
-    return this.decryptedPayload.readUInt32BE(0x04);
+    return this.comDPayload.readUInt32BE(0x04);
   }
 
   get dataStart() {
-    return NGPUtil.NGPTimestamp.fromBuffer(this.decryptedPayload.slice(0x08, 0x10));
+    return NGPUtil.NGPTimestamp.fromBuffer(this.comDPayload.slice(0x08, 0x10));
   }
 
   get dataEnd() {
-    return NGPUtil.NGPTimestamp.fromBuffer(this.decryptedPayload.slice(0x10, 0x18));
+    return NGPUtil.NGPTimestamp.fromBuffer(this.comDPayload.slice(0x10, 0x18));
   }
 }
 
@@ -1695,12 +1697,12 @@ class ReadHistoryCommand extends TransmitPacketRequest {
         }
         case TransmitPacketRequest.COM_D_COMMAND.UNMERGED_HISTORY_RESPONSE:
         {
-          this.addHistoryBlock(response.decryptedPayload);
+          this.addHistoryBlock(response.comDPayload);
           break;
         }
         case TransmitPacketRequest.COM_D_COMMAND.NAK:
         {
-          const nakResponse = new NakResponse(response.decryptedPayload);
+          const nakResponse = new NakResponse(response.comDPayload);
           throw new InvalidMessageError(`Got NAK from pump for command ${nakResponse.comDCommand}: ${nakResponse.nakCode}`);
         }
         default:
@@ -1800,7 +1802,7 @@ class AdHocPairingCommand extends TransmitPacketRequest {
         }
         case TransmitPacketRequest.COM_D_COMMAND.SET_LINK_KEY:
         {
-          const tempLinkKey = response.decryptedPayload.slice(0x3, 0x13).reverse();
+          const tempLinkKey = response.comDPayload.slice(0x3, 0x13).reverse();
           const tempPackedLinkKey = NGPUtil.NGPLinkCipher
             .packLinkKey(tempLinkKey, this.pumpSession.bcnlSerialNumber, 55);
           await Timer.wait(TransmitPacketRequest.SEND_DELAY_MS);
@@ -2187,7 +2189,7 @@ module.exports = (config) => {
       debug('in getConfigInfo', data);
 
       data.cnlConnection = false;
-      data.pumpConnection = false;
+      data.adHocConnectionActive = false;
       data.pumpHighSpeedMode = false;
 
       const settings = {
@@ -2241,7 +2243,9 @@ module.exports = (config) => {
           }
           throw new Error(errorString);
         }
-        data.pumpConnection = true;
+        if (adHocMode) {
+          data.adHocConnectionActive = true;
+        }
         progress(40);
         if (!driver.isLinked()) {
           const deviceCharacteristics = await driver.temporaryLinkToPump();
@@ -2253,11 +2257,18 @@ module.exports = (config) => {
         data.pumpHighSpeedMode = true;
 
         debug('Get pump date/time');
-        const pumpTime = await driver.getPumpTime();
-        // The sequence number for the first message after the HIGH_SPEED_MODE.ENABLE should
-        // be 1. If it's not, then we have a decryption error, and something is wrong with the
-        // pump link (either paired, or ad hoc)
-        if (pumpTime.sequenceNumber !== 1) {
+        // If we catch a ChecksumError on the first message that is decrypted,
+        // then we probably have a decryption error.
+        let pumpTime = null;
+        try {
+          pumpTime = await driver.getPumpTime();
+          // The sequence number for the first message after the HIGH_SPEED_MODE.ENABLE should
+          // be 1. If it's not, then we have a decryption error, and something is wrong with the
+          // pump link (either paired, or ad hoc)
+          if (pumpTime.sequenceNumber !== 1) {
+            throw new Error('Could not decrypt message from the pump. Please (re-)link your pump and meter.');
+          }
+        } catch (firstDecryptedMessageError) {
           throw new Error('Could not decrypt message from the pump. Please (re-)link your pump and meter.');
         }
         // We store the NGPTimestamp, because we need it for later messages.
@@ -2472,10 +2483,10 @@ module.exports = (config) => {
         // Wrap in async, because this function is not async, and we're dealing with
         // other async functions
         (async () => {
-          if (data.pumpConnection) {
-            debug('Closing connection to pump');
+          if (data.adHocConnectionActive) {
+            debug('Closing ad hoc connection to pump');
             await driver.leaveNetwork();
-            data.pumpConnection = false;
+            data.adHocConnectionActive = false;
           }
 
           if (data.cnlConnection) {


### PR DESCRIPTION
Having the CCITT checksum as part of the ComD payload caused some issues
for messages that were expecting to be able to read the whole payload,
and found an unwanted extra 2 bytes there (the checksum).
Also renamed the member variable to be consistent with its purpose.

* Fixes https://trello.com/c/S11Adtjz

This also includes a change to only leave the 802.15.4 network if we
have an ad hoc connection. Doing so all the time was causing linked
meters and pumps to become unlinked, which was bad.