### PR TITLE
Remove fabricated-from-automode-start annotation

### DIFF
--- a/lib/drivers/medtronic600/NGPHistoryParser.js
+++ b/lib/drivers/medtronic600/NGPHistoryParser.js
@@ -1481,7 +1481,6 @@ class NGPHistoryParser {
           .with_duration(gap)
           .with_scheduleName('Auto-Basal');
 
-        annotate.annotateEvent(basal, 'medtronic600/basal/fabricated-from-automode-start');
         this.addTimeFields(basal, event.timestamp);
 
         events.push(basal);


### PR DESCRIPTION
See https://trello.com/c/sYxXIylr/403-if-auto-mode-starts-with-no-microbolus-delivery-data-is-incorrect#comment-5b4527582ff6ce8edfda6847