### PR TITLE
Throw an error when attempting to use ad hoc pairing with a linked meter

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.6.2-600series-qa.34",
+  "version": "2.6.2-600series-qa.35",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.js",
   "author": {

--- a/lib/drivers/medtronic600/medtronic600Driver.js
+++ b/lib/drivers/medtronic600/medtronic600Driver.js
@@ -2228,12 +2228,20 @@ module.exports = (config) => {
         await driver.readPumpInfo();
         let adHocMode = false;
         if (driver.isLinked()) {
-          debug('Pump is already linked with CNL');
+          debug('Pump is linked with CNL');
+          if (!_.isEmpty(cfg.deviceInfo.serialNumber) &&
+            MM600SeriesDriver.convertSerialToMacID(cfg.deviceInfo.serialNumber) !==
+              driver.pumpSession.pumpMAC) {
+            // TODO: Improved UX flow. Don't make serial number entry available if meter
+            // is already linked.
+            throw new Error('Meter linked to a different pump. Either unlink this meter, or use a different unlinked meter to read from this pump.');
+          }
           await driver.getLinkKey();
         } else {
           debug('Pump is NOT linked with CNL. Start ad hoc pairing');
           adHocMode = true;
           if (_.isEmpty(cfg.deviceInfo.serialNumber)) {
+            // TODO: Improved UX flow. Automatically show serial number box?
             throw new Error('Meter and pump are not linked, and pump serial number was not entered.');
           }
           driver.setPumpMACFromSerial(cfg.deviceInfo.serialNumber);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.6.2-600series-qa.34",
+  "version": "2.6.2-600series-qa.35",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",


### PR DESCRIPTION
Throw an error when the user attempts to use ad hoc pairing to a pump
with a different serial number than the meter is already linked with

* Fixes https://trello.com/c/6ESCkbTM