### PR TITLE
Don't try to upload blob when using blob loader

### DIFF
--- a/lib/driverManager.js
+++ b/lib/driverManager.js
@@ -124,7 +124,7 @@ module.exports = function (driverObjects, configs) {
         }
       }
       function uploadBlob(data, next) {
-        if(_.isArray(data.pages || data.aapPackets)) {
+        if(isBrowser && (_.isArray(data.pages || data.aapPackets))) {
           /*
             we currently support binary blobs for Medtronic (.pages) and
             Libre (.aapPackets)


### PR DESCRIPTION
What it says on the tin. No Trello card is fix is a one-liner and it's not user facing.