### PR TITLE
stop throwing away good errors

### DIFF
--- a/app/actions/async.js
+++ b/app/actions/async.js
@@ -195,7 +195,8 @@ export function doCareLinkUpload(deviceKey, creds, utc) {
           details: err.message,
           utc: actionUtils.getUtc(utc),
           code: 'E_FETCH_CARELINK',
-          version: version
+          version: version,
+          originalError: err
         };
         dispatch(syncActions.fetchCareLinkFailure(errorText.E_FETCH_CARELINK));
         return dispatch(syncActions.uploadFailure(fetchErr, fetchErrProps, targetDevice));
@@ -255,7 +256,8 @@ export function doDeviceUpload(driverId, opts = {}, utc) {
           details: err.message,
           utc: actionUtils.getUtc(utc),
           code: 'E_SERIAL_CONNECTION',
-          version: version
+          version: version,
+          originalError: err
         };
         return dispatch(syncActions.uploadFailure(displayErr, deviceDetectErrProps, targetDevice));
       }

--- a/app/actions/sync.js
+++ b/app/actions/sync.js
@@ -262,10 +262,12 @@ export function initSuccess() {
 }
 
 export function initFailure(err) {
+  const error = new Error(getAppInitErrorMessage(err.status || null));
+  error.originalError = err;
   return {
     type: actionTypes.INIT_APP_FAILURE,
     error: true,
-    payload: new Error(getAppInitErrorMessage(err.status || null)),
+    payload: error,
     meta: {source: actionSources[actionTypes.INIT_APP_FAILURE]}
   };
 }
@@ -604,10 +606,12 @@ export function updateProfileSuccess(profile, userId) {
 }
 
 export function updateProfileFailure(err) {
+  const error = new Error(getUpdateProfileErrorMessage(err.status || null));
+  error.originalError = err;
   return {
     type: actionTypes.UPDATE_PROFILE_FAILURE,
     error: true,
-    payload: new Error(getUpdateProfileErrorMessage(err.status || null)),
+    payload: error,
     meta: {source: actionSources[actionTypes.UPDATE_PROFILE_FAILURE]}
   };
 }
@@ -635,10 +639,12 @@ export function createCustodialAccountSuccess(account) {
 }
 
 export function createCustodialAccountFailure(err) {
+  const error = new Error(getCreateCustodialAccountErrorMessage(err.status || null));
+  error.originalError = err;
   return {
     type: actionTypes.CREATE_CUSTODIAL_ACCOUNT_FAILURE,
     error: true,
-    payload: new Error(getCreateCustodialAccountErrorMessage(err.status || null)),
+    payload: error,
     meta: {source: actionSources[actionTypes.CREATE_CUSTODIAL_ACCOUNT_FAILURE]}
   };
 }

--- a/app/utils/errors.js
+++ b/app/utils/errors.js
@@ -30,7 +30,8 @@ const errorProps = {
   sessionTrace: 'Session Trace',
   stringifiedStack: 'Stack Trace',
   utc: 'UTC Time',
-  version: 'Version'
+  version: 'Version',
+  originalError: 'Original Err'
 };
 
 export function addInfoToError(err, props) {

--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -313,7 +313,9 @@ api.upload.getVersions = function(cb) {
   tidepool.checkUploadVersions(function(err, resp) {
     if (err) {
       if (!navigator.onLine) {
-        return cb(new Error(errorText.E_OFFLINE));
+        var error = new Error(errorText.E_OFFLINE);
+        error.originalError = err;
+        return cb(error);
       }
       return cb(err);
     }
@@ -658,7 +660,9 @@ api.getMostRecentUploadRecord = function(userId, deviceId, cb) {
   tidepool.getUploadRecordsForDevice(userId, deviceId, 1, function(err, resp) {
     if (err) {
       if (!navigator.onLine) {
-        return cb(new Error(errorText.E_OFFLINE));
+        var error = new Error(errorText.E_OFFLINE);
+        error.originalError = err;
+        return cb(error);
       }
       return cb(err);
     }
@@ -701,7 +705,9 @@ api.getTime = function(cb) {
   tidepool.getTime(function(err, resp) {
     if (err) {
       if (!navigator.onLine) {
-        return cb(new Error(errorText.E_OFFLINE));
+        var error = new Error(errorText.E_OFFLINE);
+        error.originalError = err;
+        return cb(error);
       }
       return cb(err);
     }
@@ -727,6 +733,9 @@ api.errors.log = function(error, message, properties) {
       rollbar.error(error, { blobId: error.data.blobId });
     } else {
       rollbar.error(error);
+    }
+    if(error.originalError){
+      rollbar.error(error.originalError);
     }
   }
   return tidepool.logAppError(error.debug, message, properties);

--- a/test/app/actions/async.test.js
+++ b/test/app/actions/async.test.js
@@ -766,7 +766,7 @@ describe('Asynchronous Actions', () => {
       err.code = errProps.code;
       err.utc = errProps.utc;
       err.version = errProps.version;
-      err.debug = `UTC Time: ${time} | Code: ${errProps.code} | Version: ${errProps.version}`;
+      err.debug = `UTC Time: ${time} | Code: ${errProps.code} | Version: ${errProps.version} | Original Err: Error :(`;
       __Rewire__('services', {
         api: {
           upload: {


### PR DESCRIPTION
Took a moment between tasks to try to address our tendency to create a new `Error` object and selectively copy over properties from a caught `Error` in order to have something friendly to display to the user. 

I saw two mechanisms that would probably work - (1) just attach the caught error to the new error and then have the error logging look for this property and log to Rollbar if it exists or (2) modify most of the functions to accept a new parameter which would potentially be an `originalError`. (1) seemed like a less intrusive approach.

Submitting for thoughts/review.