### PR TITLE
Release 2.10.0 merging back into develop

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.js",


### PR DESCRIPTION
Due to branch protection, we also need a PR to get the version bump merged back into develop.