### PR TITLE
Error handling update

### DIFF
--- a/app/actions/async.js
+++ b/app/actions/async.js
@@ -255,9 +255,9 @@ export function doDeviceUpload(driverId, opts = {}, utc) {
           details: err.message,
           utc: actionUtils.getUtc(utc),
           code: 'E_SERIAL_CONNECTION',
-          version: version,
-          originalError: err
+          version: version
         };
+        displayErr.originalError = err;
         return dispatch(syncActions.uploadFailure(displayErr, deviceDetectErrProps, targetDevice));
       }
 

--- a/app/actions/utils.js
+++ b/app/actions/utils.js
@@ -87,9 +87,9 @@ export function makeUploadCb(dispatch, getState, errCode, utc) {
         sessionToken: err.sessionToken || null,
         code: err.code || errCode,
         version: version,
-        data: recs,
-        originalError: err
+        data: recs
       };
+      displayErr.originalError = err;
 
       if (!(process.env.NODE_ENV === 'test')) {
         uploadErrProps.stringifiedStack = _.map(

--- a/app/utils/errors.js
+++ b/app/utils/errors.js
@@ -30,8 +30,7 @@ const errorProps = {
   sessionTrace: 'Session Trace',
   stringifiedStack: 'Stack Trace',
   utc: 'UTC Time',
-  version: 'Version',
-  originalError: 'Original Error'
+  version: 'Version'
 };
 
 export function addInfoToError(err, props) {

--- a/test/app/actions/async.test.js
+++ b/test/app/actions/async.test.js
@@ -766,7 +766,7 @@ describe('Asynchronous Actions', () => {
       err.code = errProps.code;
       err.utc = errProps.utc;
       err.version = errProps.version;
-      err.debug = `UTC Time: ${time} | Code: ${errProps.code} | Version: ${errProps.version} | Original Error: Error :(`;
+      err.debug = `UTC Time: ${time} | Code: ${errProps.code} | Version: ${errProps.version}`;
       __Rewire__('services', {
         api: {
           upload: {


### PR DESCRIPTION
Since the `addInfoToError` function will check all values against `!_.isEmpty` and `Error`s have no owned enumerable properties and will fail that check, they get omitted when trying to use that function to extend our displayErrors. This will simply add them as a property to the displayError directly instead.