### PR TITLE
600-series: Allow extended boluses with 0 normal (UPLOAD-8)

### DIFF
--- a/lib/drivers/medtronic600/medtronic600Simulator.js
+++ b/lib/drivers/medtronic600/medtronic600Simulator.js
@@ -399,7 +399,7 @@ class Medtronic600Simulator {
     return _.filter(this.events, (event) => {
       // filter out zero boluses
       if (event.type === 'bolus') {
-        if (event.normal === 0 && !event.expectedNormal) {
+        if (event.subType === 'normal' && event.normal === 0 && !event.expectedNormal) {
           return false;
         }
       } else if (event.type === 'wizard') {


### PR DESCRIPTION

The Medtronic 600-series driver simulator previously discarded
*any* bolus events with a normal value of 0.
However, this meant that extended boluses with a zero component
were also discarded. This fixes that bug.

* Fixes https://trello.com/c/s67Yc2qP (for 600-series driver)