### PR TITLE
Use new metadata API to get user list (UPLOAD-57)

### DIFF
--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -247,49 +247,40 @@ api.user.logout = function(cb) {
 api.user.getUploadGroups = function(cb) {
   var userId = tidepool.getUserId();
 
-  api.log('GET /access/groups/' + userId);
+  api.log('GET /metadata/users/' + userId);
 
-  tidepool.getUploadGroups(userId, function(err, groups) {
-    if (err) {
-      return cb(err);
+  async.parallel([
+    (callback) => tidepool.getAssociatedUsersDetails(userId, callback),
+    (callback) => tidepool.findProfile(userId, callback),
+  ], function(err, results){
+    if(err){
+      cb(err);
     }
+    var [ users, profile ] = results;
+    
+    var uploadUsers = _.filter(users, function(user) {
+      return _.has(user.trustorPermissions, 'upload');
+    });
 
-    var asyncProfileSearchTasks = [];
-    var uploadGroups = [];
+    uploadUsers = _.map(uploadUsers, function(user) {
+      user.permissions = user.trustorPermissions;
+      delete user.trustorPermissions;
+      return user;
+    });
 
-    for(var id in groups) {
-      var group = groups[id];
-
-      var find = (function(_id, group) {
-        return function(callback) {
-          tidepool.findProfile(_id, function(err, profile) {
-            if (err) {
-              return callback(err);
-            }
-
-            uploadGroups.push({
-              userid: _id,
-              profile: profile,
-              permissions: group,
-            });
-
-            return callback();
-          });
-        };
-      })(id, group);
-
-      asyncProfileSearchTasks.push(find);
-    }
-
-    if(!asyncProfileSearchTasks.length) {
+    if (_.isEmpty(uploadUsers)) {
       return cb(null, []);
     }
 
-    async.parallel(asyncProfileSearchTasks, function(){
-      var sortedGroups = _.sortBy(uploadGroups, function(group) { return group.userid === userId; });
-
-      return cb(null, sortedGroups);
+    // getAssociatedUsersDetails doesn't include the current user
+    uploadUsers.push({
+      userid: userId,
+      profile: profile,
+      permissions: {root: {}},
     });
+
+    var sortedUsers = _.sortBy(uploadUsers, function(group) { return group.userid === userId; });
+    return cb(null, sortedUsers);
   });
 };
 
@@ -580,7 +571,7 @@ api.upload.toPlatform = function(data, sessionInfo, progress, groupId, cb, uploa
       if(sessionInfo.blobId != null) {
         _.set(uploadItem, 'client.private.blobId', sessionInfo.blobId);
       }
-
+      
       _.set(uploadItem, 'client.private.os', os.platform() + '-' + os.arch() + '-' + os.release());
 
       if(uploadType === 'jellyfish') {

--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -571,7 +571,7 @@ api.upload.toPlatform = function(data, sessionInfo, progress, groupId, cb, uploa
       if(sessionInfo.blobId != null) {
         _.set(uploadItem, 'client.private.blobId', sessionInfo.blobId);
       }
-      
+
       _.set(uploadItem, 'client.private.os', os.platform() + '-' + os.arch() + '-' + os.release());
 
       if(uploadType === 'jellyfish') {


### PR DESCRIPTION
Updates `getUploadGroups` API call to use the updated `getAssociatedUsersDetails` call instead of iterating through `findProfile` fetches for all available upload users.

Addresses [UPLOAD-57]

[UPLOAD-57]: https://tidepool.atlassian.net/browse/UPLOAD-57