### PR TITLE
Don't throw error when bolus termination is first event (UPLOAD-114)

### DIFF
--- a/lib/drivers/insulet/insuletSimulator.js
+++ b/lib/drivers/insulet/insuletSimulator.js
@@ -23,6 +23,9 @@ var annotate = require('../../eventAnnotations');
 var common = require('./common');
 var simulations = require('../../commonFunctions');
 
+var isBrowser = typeof window !== 'undefined';
+var debug = isBrowser ? require('bows')('InsuletDriver') : console.log;
+
 var twentyFourHours = 24 * 60 * 60 * 1000;
 
 /**
@@ -216,9 +219,7 @@ exports.make = function(config){
         }
       }
       else {
-        throw new Error(
-          util.format('Cannot find bolus to modify given bolus termination[%j]', event)
-        );
+        debug('Cannot find bolus to modify given bolus termination: [%j]. PDM was likely reset.', event);
       }
     },
     changeDeviceTime: function(event) {


### PR DESCRIPTION
Fixes [UPLOAD-114].

When a bolus termination record is the first bolus record on the pump, we throw an error. But when a PDM reset happens, it’s entirely plausible for a bolus termination record to be the first bolus record in the PDM history.

[UPLOAD-114]: https://tidepool.atlassian.net/browse/UPLOAD-114